### PR TITLE
Fix constants path resolution

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -1,14 +1,20 @@
-import cv2
 import os
 
-ROOT_DIR = os.path.abspath(os.curdir)
-TRAINER_PATH = ROOT_DIR + "/logic/image_processing/models/"
-ENCODINGS_PATH = ROOT_DIR + '/logic/image_processing/models/encodings.pickle'
-CAFFEMODEL_PATH = ROOT_DIR + \
-    '/logic/image_processing/models/MobileNetSSD_deploy.caffemodel'
-PROTOTXT_PATH = ROOT_DIR + \
-    '/logic/image_processing/models/MobileNetSSD_deploy.prototxt'
-FONT = cv2.FONT_HERSHEY_SIMPLEX
+try:
+    import cv2
+    FONT = cv2.FONT_HERSHEY_SIMPLEX
+except Exception:  # pragma: no cover - optional dependency
+    FONT = None
+
+# Determine the project root based on this file's location rather than the
+# current working directory.  This allows the code to be executed from any
+# path without breaking the relative resource references.
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+TRAINER_PATH = os.path.join(ROOT_DIR, "logic", "image_processing", "models")
+ENCODINGS_PATH = os.path.join(TRAINER_PATH, "encodings.pickle")
+CAFFEMODEL_PATH = os.path.join(TRAINER_PATH, "MobileNetSSD_deploy.caffemodel")
+PROTOTXT_PATH = os.path.join(TRAINER_PATH, "MobileNetSSD_deploy.prototxt")
 CAMERA_STYLESHEET = """
                     QLabel[active="false"]{
                         border: 2.5px solid slategray;
@@ -27,5 +33,5 @@ CURRENT_ACTIVE_PTZ_DEVICE = None
 IN_USE_USB_PTZ_DEVICES = []
 ASSIGNED_USB_PTZ_CAMERA_WIDGETS = []
 RUNNING_HARDWARE_CAMERA_WIDGETS = []
-ICON_PNG = ROOT_DIR + '/shared/AutoPTZLogo.png'
+ICON_PNG = os.path.join(ROOT_DIR, 'shared', 'AutoPTZLogo.png')
 NDI_SOURCE_LIST = []


### PR DESCRIPTION
## Summary
- compute project root relative to constants file location
- fall back gracefully if OpenCV is unavailable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854cc1617888325a693eb82fcdb5bf0