### PR TITLE
ci(release): add Intel (x86_64) macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,21 @@ jobs:
           fi
 
   macos:
-    name: Build macOS .dmg
+    name: Build macOS .dmg (${{ matrix.arch }})
     needs: guard
-    runs-on: macos-14
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Build both Mac architectures as separate native bundles. PyInstaller and
+      # the ML wheels (torch, onnxruntime) are arch-specific, so there is no
+      # single universal2 build — Apple Silicon and Intel each get their own dmg.
+      # fail-fast: false so an Intel-only hiccup can't sink the arm64 build.
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14   # Apple Silicon (arm64)
+            arch: arm64
+          - runner: macos-13   # Intel (x86_64)
+            arch: x86_64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -56,7 +68,7 @@ jobs:
         run: bash packaging/build_macos.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-${{ matrix.arch }}
           path: dist/*.dmg
           if-no-files-found: error
 

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# build_macos.sh — build AutoPTZ.app on macOS (Apple Silicon).
+# build_macos.sh — build AutoPTZ.app for the host macOS architecture
+# (Apple Silicon arm64 or Intel x86_64; PyInstaller freezes host-native).
 #
 # Produces dist/AutoPTZ.app, an unsigned bundle whose Info.plist declares
 # CFBundleName=AutoPTZ — that is what makes the macOS app menu read "AutoPTZ"
@@ -75,7 +76,11 @@ plutil -lint "${APP}/Contents/Info.plist"
 # sets MAKE_DMG=1; local builds skip it by default.
 if [[ "${MAKE_DMG:-0}" == "1" ]]; then
     VER="$("${PY}" -c 'import autoptz; print(autoptz.__version__)')"
-    DMG="dist/AutoPTZ-${VER}-macos-arm64.dmg"
+    # Native host architecture: "arm64" on Apple Silicon, "x86_64" on Intel.
+    # PyInstaller (target_arch=None) freezes for the host, so the dmg name must
+    # follow suit instead of always claiming arm64.
+    ARCH="$(uname -m)"
+    DMG="dist/AutoPTZ-${VER}-macos-${ARCH}.dmg"
     echo "==> Building ${DMG}"
     STAGE="$(mktemp -d)"
     cp -R "${APP}" "${STAGE}/"


### PR DESCRIPTION
## What

Builds a native **Intel (x86_64)** macOS dmg in addition to the existing Apple Silicon one. The `macos` job becomes a 2-leg matrix:

| runner | arch | artifact |
|---|---|---|
| `macos-14` | arm64 | `macos-arm64` |
| `macos-13` | x86_64 | `macos-x86_64` |

Also de-hardcodes the dmg arch suffix in `build_macos.sh` (was always `macos-arm64`) to use `uname -m`, so the Intel dmg is labelled correctly.

## Why

The release only produced an Apple Silicon build, leaving Intel Mac users with no native installer.

## Notes / risk

- No single universal2 build is possible: `torch` and `onnxruntime` ship arch-specific wheels, so each arch gets its own bundle. `target_arch=None` in the spec already freezes host-native.
- `torch` is unpinned (transitive via `ultralytics`), so pip resolves the newest wheel each arch actually has. CI is the real test that x86_64 deps resolve — `fail-fast: false` keeps an Intel hiccup from sinking the arm64 build.

> **Stacked on #49** (the version-guard PR) because both touch the `macos:` job. Base will be retargeted to `main` once #49 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)