### PR TITLE
feat(update): opt out of pre-release updates (default to opt-out)

### DIFF
--- a/autoptz/ui/update_manager.py
+++ b/autoptz/ui/update_manager.py
@@ -109,7 +109,13 @@ class UpdateManager(QObject):
 
     @property
     def include_prereleases(self) -> bool:
-        return bool(self._get("update_include_prereleases", True))
+        # Opt-in: stable users are only offered stable releases. Matches the
+        # checker's own default (check_for_update(..., include_prereleases=False))
+        # and the release workflow's "opted into pre-releases" intent.
+        return bool(self._get("update_include_prereleases", False))
+
+    def set_include_prereleases(self, on: bool) -> None:
+        self._set("update_include_prereleases", bool(on))
 
     def skip_version(self, version: str) -> None:
         self._set("update_skip_version", version)

--- a/autoptz/ui/widgets/main_window.py
+++ b/autoptz/ui/widgets/main_window.py
@@ -365,6 +365,14 @@ class MainWindow(QMainWindow):
                 tip="Check GitHub for a newer AutoPTZ release.",
             )
         )
+        self._act_prereleases = QAction("Include Pre-release (Beta) Updates", self, checkable=True)
+        self._act_prereleases.setChecked(self._updates.include_prereleases)
+        self._act_prereleases.setToolTip(
+            "Also offer beta / release-candidate builds when checking for updates."
+        )
+        self._act_prereleases.setStatusTip(self._act_prereleases.toolTip())
+        self._act_prereleases.toggled.connect(self._updates.set_include_prereleases)
+        helpm.addAction(self._act_prereleases)
         helpm.addSeparator()
         helpm.addAction(_action(self, "About AutoPTZ", self._show_about))
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -99,6 +99,37 @@ def test_asset_url_for_platform(monkeypatch) -> None:
     assert asset[1] == url
 
 
+def test_update_manager_prerelease_opt_in() -> None:
+    """include_prereleases defaults to opt-out (False) and the setter persists.
+
+    Stable users must not be offered pre-releases unless they explicitly opt in,
+    matching check_for_update()'s own default.
+    """
+    from PySide6.QtCore import QCoreApplication
+
+    from autoptz.ui.update_manager import UpdateManager
+
+    if QCoreApplication.instance() is None:
+        QCoreApplication([])
+
+    store: dict[str, object] = {}
+
+    class _Client:
+        def getSetting(self, key: str, default: object) -> object:
+            return store.get(key, default)
+
+        def setSetting(self, key: str, value: object) -> None:
+            store[key] = value
+
+    mgr = UpdateManager(_Client(), "2.0.0")
+    assert mgr.include_prereleases is False  # opt-out by default
+    mgr.set_include_prereleases(True)
+    assert mgr.include_prereleases is True
+    assert store["update_include_prereleases"] is True
+    mgr.set_include_prereleases(False)
+    assert mgr.include_prereleases is False
+
+
 def test_download_update_writes_platform_asset(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(checker.sys, "platform", "linux")
     info = UpdateInfo(


### PR DESCRIPTION
## What

Gives users an in-app way to control whether the updater offers GitHub pre-releases (RC/beta), and makes the default **opt-out**.

- `UpdateManager.set_include_prereleases()` added (mirrors the existing `set_auto_check` setter).
- Default flipped `True` → `False` in `include_prereleases`.
- New checkable **Help → "Include Pre-release (Beta) Updates"** menu item, initialised from and bound to the setting.

## Why

`include_prereleases` was read-only and defaulted to `True` with no UI, so **every user was offered beta builds by default** and couldn't opt out without hand-editing the persisted QSetting. That contradicted:
- the checker's own default — `check_for_update(..., include_prereleases=False)` (`autoptz/update/checker.py`), and
- the release workflow's documented intent — pre-releases are "surfaced to users who **opted into** pre-releases" (`.github/workflows/release.yml`).

So this aligns the manager with the rest of the system rather than changing the intended behavior.

## Test

- `test_update_manager_prerelease_opt_in` — asserts the default is `False` and the setter round-trips/persists.
- Full suite green locally: `pytest tests/test_update.py tests/test_ui.py` → 104 passed (incl. the MainWindow smoke test that builds the new menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)