### PR TITLE
Fix Ubuntu CI teardown abort, simplify naming + menus, refresh docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["dev/v2-architecture-rework", "phase-*/**", "main"]
+    branches: ["main"]
   pull_request:
-    branches: ["dev/v2-architecture-rework", "main"]
+    branches: ["main"]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ follow [Semantic Versioning](https://semver.org/).
 ## [2.0.0] — 2026-06-21
 
 First stable release of the v2 architecture: a native Qt Widgets app with a
-multi-process, multi-camera real-time tracking engine.
+multi-threaded, multi-camera real-time tracking engine.
 
 ### Added
 
-- **Multi-camera engine** — one worker per camera (capture + inference threads),
-  supervised, with shared-memory preview and typed command/telemetry.
+- **Multi-camera engine** — one threaded worker per camera (capture + inference
+  threads), supervised, with shared-memory preview and typed command/telemetry.
 - **Vision pipeline** — YOLO11 person detection (ONNX Runtime), BoT-SORT/ByteTrack
   tracking with an IoU fallback, OSNet appearance ReID re-acquisition, YOLO11
   pose, and face-recognition identity binding.
@@ -25,8 +25,10 @@ multi-process, multi-camera real-time tracking engine.
   graph optimization and CPU-oversubscription-aware thread capping. Optional
   `gpu-nvidia` / `gpu-directml` / `openvino` requirement sets. Opt-in INT8
   detector quantization and drop-in RT-DETR support.
-- **In-app updates** — notify-only GitHub Releases check on startup and via
-  **Help → Check for Updates…**, with skip-version + prerelease support.
+- **In-app updates** — checks GitHub Releases on startup and via
+  **Help → Updates**; when a newer build exists it can download the matching OS
+  asset and launch the installer. Stable releases by default, with an opt-in for
+  pre-releases (beta/RC) and a skip-this-version option.
 - **Installers** — macOS `.dmg`, Windows Inno Setup `.exe`, Linux AppImage, built
   and published by a tag-triggered release workflow.
 - **Tooling** — `tools/bench/ep_compare.py` (per-EP latency) and `track_clip.py`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ to strict annotations (see the `tests.*` mypy override).
 
 ## Branching
 
-Active development happens on `dev/v2-architecture-rework`. Branch from it, keep
-the suite green, and open a PR back into it. See [docs/architecture.md](docs/architecture.md)
-for the layout and [docs/building.md](docs/building.md) for release/installer builds.
+`main` is the trunk. Branch from `main`, keep the suite green, and open a PR back
+into `main`. Releases are cut by pushing a `vX.Y.Z` tag, which must match
+`autoptz.__version__` (CI enforces this). See
+[docs/architecture.md](docs/architecture.md) for the layout and
+[docs/building.md](docs/building.md) for release/installer builds.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ device is missing (it always keeps live preview).
   with per-EP tuning (FP16, persistent TensorRT engine cache, full graph
   optimization). See [Performance](docs/performance.md).
 - **PTZ backends** — VISCA over USB, VISCA over IP, ONVIF, and NDI.
-- **In-app updates** — downloads the matching GitHub Release asset for your OS
-  and starts the installer/new AppImage.
+- **In-app updates** — checks GitHub Releases and downloads the matching asset for
+  your OS to launch the installer/new AppImage. Stable builds by default; opt into
+  pre-releases under **Help → Updates**.
 
 ## Quick start (from source)
 
@@ -80,7 +81,7 @@ Pre-built installers are published on the
 Windows installer (`.exe`), and a Linux `AppImage`. To build them yourself see
 [docs/building.md](docs/building.md).
 
-After install, **Help -> Check for Updates...** downloads the matching OS asset,
+After install, **Help → Updates → Check Now…** downloads the matching OS asset,
 starts it, and closes AutoPTZ so the update can finish. If a release is missing
 your OS asset, AutoPTZ opens the release page instead.
 
@@ -89,7 +90,7 @@ your OS asset, AutoPTZ opens the release page instead.
 | Doc | What's in it |
 | --- | --- |
 | [Installation](docs/installation.md)   | From source + pre-built installers, per platform. |
-| [Configuration](docs/configuration.md) | Every tuning knob: model tier, detect interval, framing, smoothing, PTZ gains. |
+| [Configuration](docs/configuration.md) | Every tuning knob: detector tier, detect interval, framing, smoothing, PTZ gains. |
 | [Performance](docs/performance.md)     | Cross-platform device/precision matrix + the `ep_compare` benchmark. |
 | [Building](docs/building.md)           | PyInstaller bundles → DMG / Windows installer / AppImage. |
 | [Architecture](docs/architecture.md)   | Module map and the per-frame data flow. |

--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -31,7 +31,6 @@ def _now() -> datetime:
 
 class HardwarePrefs(BaseModel, frozen=True):
     force_ep: str | None = None  # "CoreMLExecutionProvider", etc.; None = auto
-    model_tier: Literal["nano", "small", "medium", "large"] = "nano"
     max_workers: int = Field(default=4, ge=1, le=32)
     # Inference precision. "auto" lets each accelerator pick (GPU EPs use FP16);
     # "fp32"/"fp16" force it; "int8" runs a dynamically-quantized detector (CPU win,
@@ -95,18 +94,13 @@ class TrackingConfig(BaseModel, frozen=True):
     coast_window_ms: int = Field(default=300, ge=0)
     face_confirm: bool = False
     quality_floor: Literal["auto", "high", "balanced", "low"] = "auto"
-    # Which part of the detected person box the PTZ aims at (vertically). The
-    # horizontal aim is always the box centre; this picks how high up the box the
-    # vertical aim point sits, so the camera frames the face / upper body / whole
-    # person.  See ``AIM_REGION_FRACTION`` for the actual fractions used by the
-    # controller.  (True arm/leg exclusion would need pose keypoints; this is the
+    # "Framing" preset — the single user-facing control for how the shot is composed.
+    # It sets the vertical aim point (how high up the person box the camera centres:
+    # face / head & shoulders / upper body / whole person) and is mirrored into
+    # ``ptz.zoom_framing`` to set how tightly auto-zoom frames the subject. The
+    # horizontal aim is always the box centre. See ``AIM_REGION_FRACTION`` for the aim
+    # fractions. (True arm/leg exclusion would need pose keypoints; this is the
     # pragmatic bbox-fraction approximation.)
-    aim_region: Literal["face", "head_shoulders", "upper_body", "full_body"] = "upper_body"
-    # Unified "Framing" preset — the single user-facing control that drives BOTH
-    # where the camera aims (``aim_region``) and how tightly it zooms
-    # (``ptz.zoom_framing``).  The 4 names line up 1:1 with both legacy controls,
-    # so consumers read ``framing`` directly and map through the matching constant
-    # (``AIM_REGION_FRACTION`` for aim, the controller's zoom targets for zoom).
     framing: Literal["face", "head_shoulders", "upper_body", "full_body"] = "upper_body"
     # Whether pose-aware aiming ignores arms/limbs and tracks the torso, or uses
     # the whole detection silhouette. Torso is the default because it prevents an

--- a/autoptz/engine/pipeline/framing.py
+++ b/autoptz/engine/pipeline/framing.py
@@ -115,7 +115,7 @@ def torso_aim_point(
 
     The point is derived from the shoulders/hips only, so raising or extending
     an arm — which would grow the YOLO person bbox and shift its centre — does
-    not move the aim.  *bias* maps the configured ``tracking.aim_region`` onto a
+    not move the aim.  *bias* maps the configured ``tracking.framing`` onto a
     sensible torso anchor:
 
     - ``face`` / ``head_shoulders`` → just above the shoulder line (head sits a

--- a/autoptz/engine/worker/frame_source.py
+++ b/autoptz/engine/worker/frame_source.py
@@ -25,18 +25,11 @@ log = logging.getLogger(__name__)
 
 
 def _resolve_framing(tracking: TrackingConfig) -> str:
-    """Return the effective framing preset for aim/pose.
+    """Return the framing preset for aim/pose.
 
-    ``tracking.framing`` is the unified user-facing control; when it has been
-    moved off its default it wins. ``tracking.aim_region`` is honoured as a
-    fallback when ``framing`` is still at its default (the Properties panel still
-    writes ``aim_region``), so both controls keep working without disagreeing.
+    ``tracking.framing`` is the single user-facing control for shot composition.
     """
-    default = TrackingConfig.model_fields["framing"].default
-    framing = getattr(tracking, "framing", default)
-    if framing != default:
-        return framing
-    return getattr(tracking, "aim_region", default)
+    return getattr(tracking, "framing", TrackingConfig.model_fields["framing"].default)
 
 
 # ── frame source abstraction ───────────────────────────────────────────────────

--- a/autoptz/ui/widgets/main_window.py
+++ b/autoptz/ui/widgets/main_window.py
@@ -348,23 +348,37 @@ class MainWindow(QMainWindow):
             act.toggled.connect(lambda on, k=key: self._client.setOverlay(k, on))
             overlays.addAction(act)
 
-        panels = bar.addMenu("&Panels")
+        # Panels (dock toggles) and Layouts are view concerns, so they live under
+        # View rather than as separate top-level menus.
+        view.addSeparator()
+        panels = view.addMenu("Panels")
         for key in ("properties", "camera_info", "people", "services", "logs"):
             panels.addAction(self._docks[key].toggleViewAction())
 
-        self._layouts_menu = bar.addMenu("&Layouts")
+        self._layouts_menu = view.addMenu("Layouts")
         self._layouts_menu.setToolTipsVisible(True)
         self._layouts_menu.aboutToShow.connect(self._populate_layouts_menu)
 
         helpm = bar.addMenu("&Help")
-        helpm.addAction(
+        updates = helpm.addMenu("Updates")
+        updates.setToolTipsVisible(True)
+        updates.addAction(
             _action(
                 self,
-                "Check for Updates…",
+                "Check Now…",
                 self._updates.check_now,
                 tip="Check GitHub for a newer AutoPTZ release.",
             )
         )
+        updates.addSeparator()
+        self._act_auto_check = QAction("Check Automatically on Startup", self, checkable=True)
+        self._act_auto_check.setChecked(self._updates.auto_check_enabled)
+        self._act_auto_check.setToolTip(
+            "Check GitHub for a newer release once a day when AutoPTZ starts."
+        )
+        self._act_auto_check.setStatusTip(self._act_auto_check.toolTip())
+        self._act_auto_check.toggled.connect(self._updates.set_auto_check)
+        updates.addAction(self._act_auto_check)
         self._act_prereleases = QAction("Include Pre-release (Beta) Updates", self, checkable=True)
         self._act_prereleases.setChecked(self._updates.include_prereleases)
         self._act_prereleases.setToolTip(
@@ -372,7 +386,7 @@ class MainWindow(QMainWindow):
         )
         self._act_prereleases.setStatusTip(self._act_prereleases.toolTip())
         self._act_prereleases.toggled.connect(self._updates.set_include_prereleases)
-        helpm.addAction(self._act_prereleases)
+        updates.addAction(self._act_prereleases)
         helpm.addSeparator()
         helpm.addAction(_action(self, "About AutoPTZ", self._show_about))
 

--- a/autoptz/ui/widgets/properties_panel.py
+++ b/autoptz/ui/widgets/properties_panel.py
@@ -1318,8 +1318,8 @@ class PropertiesPanel(QWidget):
             self._detect_interval.setValue(int(tr.get("detect_interval", 1) or 1))
             _set_combo_data(self._tracking_mode, tr.get("tracking_mode", "stable"))
             _set_combo(self._tracker, tr.get("tracker", "botsort"))
-            # Unified Framing: prefer ``tracking.framing``; fall back to the legacy
-            # ``aim_region`` so an un-migrated config still selects sensibly.
+            # Framing: read ``tracking.framing``; fall back to a legacy ``aim_region``
+            # key from older configs so the selection migrates instead of resetting.
             _set_combo_data(
                 self._framing,
                 tr.get("framing") or tr.get("aim_region") or "upper_body",
@@ -1499,13 +1499,12 @@ class PropertiesPanel(QWidget):
         cfg["tracking"]["detect_interval"] = self._detect_interval.value()
         cfg["tracking"]["tracking_mode"] = self._tracking_mode.currentData() or "stable"
         cfg["tracking"]["tracker"] = self._tracker.currentText()
-        # The single Framing control drives both aim and zoom: store it as the new
-        # unified ``tracking.framing`` and ALSO mirror it into the existing
-        # consumers — ``tracking.aim_region`` (worker aim) and ``ptz.zoom_framing``
-        # (controller zoom) — so both honor it without a separate worker bridge.
+        # The single Framing control drives both aim and zoom. The worker reads
+        # ``tracking.framing`` for aim; the PTZ controller reads ``ptz.zoom_framing``
+        # for zoom, so mirror the value there too (zoom_framing also offers a "wide"
+        # option that the controller can use).
         framing = self._framing.currentData() or "upper_body"
         cfg["tracking"]["framing"] = framing
-        cfg["tracking"]["aim_region"] = framing
         cfg["tracking"]["aim_body_mode"] = (
             "torso" if self._ignore_arms.isChecked() else "full_silhouette"
         )

--- a/autoptz/ui/widgets/services_panel.py
+++ b/autoptz/ui/widgets/services_panel.py
@@ -70,11 +70,13 @@ _FEATURE_TOGGLES = (
     ),
 )
 
+# (stored value, display label). Values are stable for back-compat with saved
+# settings and the fetch_models / weight-map vocabulary; only labels are cosmetic.
 _DETECTOR_TIERS = (
     ("auto", "Auto"),
-    ("fast", "Fast / Nano"),
-    ("balanced", "Balanced / Small"),
-    ("medium", "Medium"),
+    ("fast", "Fast"),
+    ("balanced", "Balanced"),
+    ("medium", "Accurate"),
 )
 
 
@@ -159,9 +161,11 @@ class ServicesPanel(QWidget):
         for value, label in _DETECTOR_TIERS:
             self._detector_tier.addItem(label, value)
         self._detector_tier.setToolTip(
-            "Choose the shared detector model tier. When the engine is running, "
-            "AutoPTZ builds the new detector in the background and swaps it in "
-            "when ready; the active state is shown in diagnostics."
+            "Detector model, shared by all cameras. Auto picks Fast. Fast (YOLO11n) "
+            "is lightest; Balanced (YOLO11s) and Accurate (YOLO11m) trade speed for "
+            "detection quality. When the engine is running, AutoPTZ builds the new "
+            "model in the background and swaps it in when ready; the active state is "
+            "shown in diagnostics."
         )
         self._detector_tier.currentIndexChanged.connect(self._on_detector_tier_changed)
         tier_row.addWidget(tier_label)

--- a/docs/building.md
+++ b/docs/building.md
@@ -70,6 +70,7 @@ choose the right download for the current OS, launch it, and close AutoPTZ.
 
 `packaging/autoptz.spec` is the shared PyInstaller spec: it bundles the package,
 assets (logo), optional pre-fetched models, and PySide6 plugins; sets the
-app/exe/bundle icon; and runs `multiprocessing.freeze_support()` for spawned
-workers. Set `ONEFILE=1` for a single-file Windows exe (not used by the
-installer, which packages the onedir tree).
+app/exe/bundle icon; and runs `multiprocessing.freeze_support()` so the
+spawn-based multiprocessing the app uses (e.g. the selftest's shared-memory probe)
+works under a frozen build. Set `ONEFILE=1` for a single-file Windows exe (not used
+by the installer, which packages the onedir tree).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,10 @@
 
 Settings live in a per-user SQLite database in the platform app-data dir
 (`~/Library/Application Support/AutoPTZ` on macOS, `%APPDATA%\AutoPTZ` on Windows,
-`~/.config/AutoPTZ` on Linux) and are edited from the app's **Properties** panel.
-This page documents what each knob does. Defaults are the validated, broadcast-sane
-starting point; one concept = one control.
+`~/.config/AutoPTZ` on Linux). Per-camera settings (source, tracking, PTZ) are edited
+in the **Properties** panel; app-wide settings (hardware/EP and the shared detector
+model) are in the **Services** panel. This page documents what each knob does.
+Defaults are the validated, broadcast-sane starting point; one concept = one control.
 
 ## Source
 
@@ -24,7 +25,7 @@ starting point; one concept = one control.
 | `quality_floor` | `auto` | `auto` adapts the detect interval to the frame budget; `high`/`balanced`/`low` pin it. |
 | `reid_threshold_hi` / `lo` | `0.60` / `0.35` | Hysteresis for appearance re-acquisition (enter / maintain lock). |
 | `coast_window_ms` | `300` | How long a lost track is coasted before it's dropped. |
-| `framing` | `upper_body` | Unified preset driving aim height + zoom tightness: `face`, `head_shoulders`, `upper_body`, `full_body`. |
+| `framing` | `upper_body` | The single "shot composition" control. Sets the vertical aim point and (mirrored into `zoom_framing`) the auto-zoom tightness: `face`, `head_shoulders`, `upper_body`, `full_body`. |
 | `aim_body_mode` | `torso` | `torso` ignores arms/limbs (steadier aim); `full_silhouette` uses the whole box. |
 | `min_detection_size_frac` | `0.05` | Drop people smaller than this fraction of frame height (ignore distant specks). |
 | `face_confirm` | `false` | Require a face match before binding a target. |
@@ -42,7 +43,7 @@ starting point; one concept = one control.
 | `safe_zone_roundness` | `1.0` | 0 = rectangle … 1 = full oval. |
 | `deadzone_x` / `deadzone_y` | `0.05` | Per-axis circular deadzone (used when the safe zone is off). |
 | `auto_zoom` | `true` | Drive zoom to keep the subject at the framing target height. |
-| `zoom_framing` | `upper_body` | Target subject height for auto-zoom. |
+| `zoom_framing` | `upper_body` | Auto-zoom target height: `face`, `head_shoulders`, `upper_body`, `full_body`, or `wide`. Mirrors `framing`; `wide` is the one extra (looser) option. |
 | `loss_zoom_out` / `reacquire_window_s` | `0.25` / `4.0` | On loss, gently zoom out to widen the view and re-find the subject. |
 | `soft_limits` | none | Optional pan/tilt/zoom travel clamps. |
 
@@ -51,8 +52,8 @@ starting point; one concept = one control.
 | Setting | Default | Notes |
 | --- | --- | --- |
 | `force_ep` | auto | Pin an execution provider (e.g. `CoreMLExecutionProvider`); falls back to auto if unavailable. |
-| `precision` | `auto` | `auto`/`fp32`/`fp16`. Accelerator EPs use FP16 unless forced to fp32; CPU is always fp32. |
-| `model_tier` | `nano` | `nano` (fastest) → `small` → `medium`. |
+| `precision` | `auto` | `auto`/`fp32`/`fp16`/`int8`. Accelerator EPs use FP16 unless forced to fp32; CPU is always fp32; `int8` runs a quantized detector (see [Performance](performance.md)). |
+| `detector_model_tier` | `auto` | Detector model shared by all cameras (Services panel). `auto` picks Fast (YOLO11n); `fast`/`balanced`/`medium` map to YOLO11n/s/m — bigger detects better but costs more. Shown in the UI as Auto / Fast / Balanced / Accurate. |
 | `max_workers` | `4` | Parallel camera workers (also informs the per-worker thread cap). |
 | `intra_op_threads` | auto | Override ORT intra-op threads per worker (auto = cores ÷ cameras). |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ Download the latest build for your OS from the
   unsigned installer — **More info → Run anyway**.
 - **Linux** — `AutoPTZ-<version>-linux-x86_64.AppImage`. `chmod +x` it and run.
 
-The app checks GitHub Releases on startup and from **Help -> Check for Updates...**.
+The app checks GitHub Releases on startup and from **Help → Updates → Check Now…**.
 When a newer version exists, AutoPTZ downloads the matching asset for your OS,
 starts it, and closes so the installer/new AppImage can finish. If that release
 does not include your OS asset, AutoPTZ opens the release page instead.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -54,16 +54,18 @@ back to FP32 automatically if quantization fails.
 ### RT-DETR (drop-in)
 
 The detector's pre-NMS parser already understands RT-DETR's (NMS-free) COCO
-output. To try it, export an RT-DETR ONNX (`rtdetr-l`/`rtdetr-x` are in the tier
-map for `tools.fetch_models`) and point `AUTOPTZ_MODEL_PATH` at it. Benchmark vs
-YOLO11 with `ep_compare`/`track_clip` on your hardware before switching.
+output. The in-app detector tier only offers the YOLO11 sizes, so to try RT-DETR
+export an `rtdetr-l`/`rtdetr-x` ONNX yourself (e.g. via Ultralytics) and point
+`AUTOPTZ_MODEL_PATH` at it. Benchmark vs YOLO11 with `ep_compare`/`track_clip` on
+your hardware before switching.
 
 ## Tuning for stability
 
 For the smoothest tracking on constrained machines (see
 [Configuration](configuration.md) for all knobs):
 
-- Lower the **model tier** (`nano` is default and fastest) and/or input size.
+- Lower the **detector tier** (Fast/YOLO11n is the lightest; Auto picks it) and/or
+  input size.
 - Raise **detect interval** (run detection every N frames; the Kalman tracker
   interpolates between) or let **quality floor = auto** adapt it to the frame
   budget.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,7 +50,7 @@ See [Configuration](configuration.md). Quick levers:
 
 - **Laggy follow** — lower `aim_smoothing`, raise `lead_time_s` or `kp`.
 - **Jittery** — raise `aim_smoothing`, enlarge the framing safe zone.
-- **CPU-bound** — drop the model tier, raise `detect_interval` (or leave
+- **CPU-bound** — drop the detector tier, raise `detect_interval` (or leave
   `quality_floor=auto`), cap source `fps`.
 
 ## App menu shows "Python" (macOS, source run)

--- a/packaging/autoptz.spec
+++ b/packaging/autoptz.spec
@@ -10,8 +10,11 @@ Outputs:
     Windows  -> dist/AutoPTZ/AutoPTZ.exe  (onedir; flip ONEFILE=1 for onefile)
 
 The entry point is autoptz/__main__.py so the frozen app behaves exactly like
-`python -m autoptz` (it calls multiprocessing.freeze_support() — REQUIRED for
-the spawn-based engine workers to start under a frozen build).
+`python -m autoptz` (it calls multiprocessing.freeze_support() — REQUIRED so the
+spawn-based multiprocessing the app uses, e.g. the selftest's shared-memory probe,
+starts correctly under a frozen build). The camera engine itself runs threads in
+this process today; the transport is process-safe for a future process-per-camera
+build.
 
 What gets bundled
 -----------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared test fixtures and a Linux-safe shutdown guard.
+
+Two things live here so every test file can rely on them:
+
+``qapp``
+    One process-wide Qt application object. These tests are headless — no widgets
+    are created in-process (the widget smoke tests in ``test_ui.py`` spawn their own
+    offscreen subprocess), so a ``QCoreApplication`` is enough. Qt allows only one
+    application per process, so the fixture is session-scoped and reuses any existing
+    instance.
+
+``pytest_sessionfinish`` guard
+    On Linux, native extensions (PySide6/Qt, OpenCV, ONNX Runtime, torch) can corrupt
+    the heap while their global destructors run at interpreter shutdown — the process
+    aborts ("corrupted double-linked list", exit code 134) *after* every test has
+    already passed, turning a green run red on CI. A conftest hook wrapper runs outside
+    pytest's own, i.e. after the terminal summary is printed, so we flush output and
+    hard-exit with pytest's own status. The result stays authoritative and the flaky
+    native teardown never runs. Scoped to Linux so other platforms keep their normal
+    shutdown (coverage/JUnit writers and the like).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest import ExitCode, Session
+
+
+@pytest.fixture(scope="session")
+def qapp() -> Generator[object]:
+    """One process-wide Qt application object for headless tests."""
+    from PySide6.QtCore import QCoreApplication
+
+    app = QCoreApplication.instance() or QCoreApplication(sys.argv[:1])
+    yield app
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_sessionfinish(
+    session: Session, exitstatus: int | ExitCode
+) -> Generator[None, None, None]:
+    """Hard-exit on Linux before native teardown can abort the process."""
+    result = yield
+    if sys.platform.startswith("linux"):
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(int(exitstatus))
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,8 +79,8 @@ class TestModels:
         with pytest.raises(ValidationError):
             TrackingConfig(detect_interval=0)
 
-    def test_tracking_aim_region_defaults_to_upper_body(self) -> None:
-        assert TrackingConfig().aim_region == "upper_body"
+    def test_tracking_framing_defaults_to_upper_body(self) -> None:
+        assert TrackingConfig().framing == "upper_body"
 
     def test_tracking_coast_window_defaults_short(self) -> None:
         assert TrackingConfig().coast_window_ms == 300
@@ -99,27 +99,29 @@ class TestModels:
         with pytest.raises(ValidationError):
             TrackingConfig(aim_body_mode="arms_only")
 
-    def test_tracking_aim_region_rejects_unknown(self) -> None:
+    def test_tracking_framing_rejects_unknown(self) -> None:
         with pytest.raises(ValidationError):
-            TrackingConfig(aim_region="elbow")
+            TrackingConfig(framing="elbow")
 
-    def test_aim_region_fraction_table_covers_all_choices(self) -> None:
+    def test_aim_region_fraction_table_covers_all_framing_choices(self) -> None:
         from autoptz.config.models import AIM_REGION_FRACTION
 
         for region in ("face", "head_shoulders", "upper_body", "full_body"):
             assert region in AIM_REGION_FRACTION
             assert 0.0 <= AIM_REGION_FRACTION[region] <= 1.0
-        # Aim point must rise (smaller fraction) as the region tightens toward the
+        # Aim point must rise (smaller fraction) as the framing tightens toward the
         # face, and full_body must be the geometric centre.
         f = AIM_REGION_FRACTION
         assert f["face"] < f["head_shoulders"] < f["upper_body"] < f["full_body"]
         assert f["full_body"] == 0.5
 
-    def test_legacy_config_without_aim_region_loads_as_default(self) -> None:
-        """A config persisted before aim_region existed must still validate."""
+    def test_legacy_aim_region_key_is_ignored(self) -> None:
+        """A config persisted with the old ``aim_region`` key (folded into
+        ``framing``) must still validate; the extra key is simply ignored."""
         data = CameraConfig(name="Legacy").model_dump()
-        del data["tracking"]["aim_region"]
-        assert CameraConfig.model_validate(data).tracking.aim_region == "upper_body"
+        data["tracking"]["aim_region"] = "face"
+        cam = CameraConfig.model_validate(data)
+        assert cam.tracking.framing == "upper_body"
 
     def test_ptz_preset_name_blank_raises(self) -> None:
         with pytest.raises(Exception, match="name"):
@@ -225,14 +227,14 @@ class TestCameraStore:
         assert reloaded.name == cam.name
         assert reloaded.source.address == cam.source.address
         assert reloaded.tracking.detect_interval == cam.tracking.detect_interval
-        assert reloaded.tracking.aim_region == cam.tracking.aim_region
+        assert reloaded.tracking.framing == cam.tracking.framing
         assert reloaded.ptz.backend == cam.ptz.backend
 
-    def test_aim_region_survives_store_round_trip(self, store: ConfigStore) -> None:
-        c = CameraConfig(name="Framed", tracking=TrackingConfig(aim_region="face"))
+    def test_framing_survives_store_round_trip(self, store: ConfigStore) -> None:
+        c = CameraConfig(name="Framed", tracking=TrackingConfig(framing="face"))
         store.save_camera(c)
         reloaded = store.load_cameras()[0]
-        assert reloaded.tracking.aim_region == "face"
+        assert reloaded.tracking.framing == "face"
 
     def test_simulated_restart(self, tmp_path: Path, cam: CameraConfig) -> None:
         """CameraConfig must survive a store close-and-reopen (simulated restart)."""
@@ -427,13 +429,13 @@ class TestAppConfig:
     def test_save_and_reload_app_config(self, store: ConfigStore, cam: CameraConfig) -> None:
         cfg = AppConfig(
             theme=ThemeConfig(name="light"),
-            hardware=HardwarePrefs(model_tier="small"),
+            hardware=HardwarePrefs(precision="fp16"),
             cameras=[cam],
         )
         store.save_app_config(cfg)
         reloaded = store.load_app_config()
         assert reloaded.theme.name == "light"
-        assert reloaded.hardware.model_tier == "small"
+        assert reloaded.hardware.precision == "fp16"
         assert len(reloaded.cameras) == 1
         assert reloaded.cameras[0].id == cam.id
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -14,27 +14,12 @@ All tests use QCoreApplication (no display) so they run cleanly in CI.
 from __future__ import annotations
 
 import logging
-import sys
 import threading
 import time
 
 import numpy as np
 import PySide6  # noqa: F401
 import pytest
-
-# ── one QCoreApplication for the whole module ─────────────────────────────────
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    from PySide6.QtCore import QCoreApplication
-
-    existing = QCoreApplication.instance()
-    if existing is not None:
-        yield existing
-        return
-    app = QCoreApplication(sys.argv[:1])
-    yield app
 
 
 def _telemetry(camera_id: str, **kw):

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -537,16 +537,6 @@ def _make_client(tmp_path=None):
     return EngineClient(), None
 
 
-@pytest.fixture(scope="module")
-def qapp():
-    import sys
-
-    from PySide6.QtCore import QCoreApplication
-
-    app = QCoreApplication.instance() or QCoreApplication(sys.argv[:1])
-    yield app
-
-
 class TestEngineClientIdentityAPI:
     def test_has_frozen_slots(self, qapp):
         client, _ = _make_client()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -636,11 +636,11 @@ class TestCameraWorker:
 
 
 class TestTrackErrorAimRegion:
-    """The vertical aim point must follow ``tracking.aim_region`` while the
+    """The vertical aim point must follow ``tracking.framing`` while the
     horizontal aim stays on the box centre."""
 
     @staticmethod
-    def _worker(aim_region: str, aim_body_mode: str = "torso"):
+    def _worker(framing: str, aim_body_mode: str = "torso"):
         from autoptz.config.models import (
             CameraConfig,
             SourceConfig,
@@ -652,7 +652,7 @@ class TestTrackErrorAimRegion:
             id="aimcam012345",
             name="Aim",
             source=SourceConfig(type="usb", address="usb://0"),
-            tracking=TrackingConfig(aim_region=aim_region, aim_body_mode=aim_body_mode),
+            tracking=TrackingConfig(framing=framing, aim_body_mode=aim_body_mode),
         )
         # No frame source / shm needed — we never start(); we call the pure method.
         return CameraWorker("aimcam012345", cfg, lambda _m: None)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -7,28 +7,12 @@ camera hardware, ML model, or GUI is required.
 
 from __future__ import annotations
 
-import sys
 import threading
 import time
 
 import numpy as np
 import PySide6  # noqa: F401
 import pytest
-
-# ── one QCoreApplication for the whole module ─────────────────────────────────
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    from PySide6.QtCore import QCoreApplication
-
-    existing = QCoreApplication.instance()
-    if existing is not None:
-        yield existing
-        return
-    app = QCoreApplication(sys.argv[:1])
-    yield app
-
 
 # ── helpers / fakes ───────────────────────────────────────────────────────────
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,22 +16,6 @@ from pathlib import Path
 import PySide6  # noqa: F401
 import pytest
 
-# ── one QCoreApplication for the whole module ─────────────────────────────────
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    from PySide6.QtCore import QCoreApplication
-
-    existing = QCoreApplication.instance()
-    if existing is not None:
-        yield existing
-        return
-    app = QCoreApplication(sys.argv[:1])
-    yield app
-    # deliberately do not call app.quit() — other module fixtures still need it
-
-
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_w1_appwiring.py
+++ b/tests/test_w1_appwiring.py
@@ -1,6 +1,6 @@
 """W1 (app-wiring slice) tests.
 
-Covers the Python app-wiring contracts exposed to QML:
+Covers the Python app-wiring contracts the UI relies on:
 - EngineClient.restartEngine() — stop then start.
 - EngineClient.getSetting/setSetting round-trip through ConfigStore.
 - EngineClient.scanUSBCameras() shape + Continuity label + in_use de-dup.
@@ -12,24 +12,8 @@ All tests use QCoreApplication (no display) so they run in CI.
 
 from __future__ import annotations
 
-import sys
-
 import PySide6  # noqa: F401
 import pytest
-
-# ── one QCoreApplication for the whole module ─────────────────────────────────
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    from PySide6.QtCore import QCoreApplication
-
-    existing = QCoreApplication.instance()
-    if existing is not None:
-        yield existing
-        return
-    app = QCoreApplication(sys.argv[:1])
-    yield app
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Why

Two things prompted this:
1. The CI **test** job started failing on **ubuntu-latest only** (exit 134) after #51 merged.
2. A docs/naming audit found several claims that no longer matched the code.

Fix the build first, then the safe cleanups, then make the docs honest. Five focused commits.

## 1 — Ubuntu CI fix (`fix(ci): …`)

Not a real test failure: **all 770 tests pass**, then the process aborts with `corrupted double-linked list` while native extensions (PySide6/Qt, OpenCV, ONNX Runtime, torch) run their global destructors at interpreter shutdown. pytest returns 0, but the process exit code (134) turns the run red. Teardown-order dependent (intermittent), so earlier commits passed.

- `tests/conftest.py`: a `pytest_sessionfinish` wrapper that, **on Linux only**, flushes stdio and `os._exit()`s with pytest's own status *after* the terminal summary prints. Result stays authoritative; the flaky native teardown is skipped. macOS/Windows unchanged.
- Consolidate five duplicated module-scoped `qapp` fixtures into one session-scoped `QCoreApplication` fixture.

✅ ubuntu-latest now passes (and macOS/Windows stay green).

## 2 — Naming / dead-field cleanup (`refactor(config): …`)

- Remove `HardwarePrefs.model_tier` — no readers; the real control is the global `detector_model_tier` (Services panel). `large` had silently resolved to nano.
- Fold `tracking.aim_region` into `tracking.framing` (a pure 4-value mirror). Worker reads `framing` directly; a legacy `aim_region` key is ignored/migrated. `ptz.zoom_framing` stays (separate model, read by the controller, has an extra `wide` option).
- Detector-tier dropdown: drop the dual "Fast / Nano" labels for one set (Auto / Fast / Balanced / Accurate). Stored values unchanged.

## 3 — Honesty fixes (`chore: …`)

- `packaging/autoptz.spec`: `freeze_support()` is for the spawn-based multiprocessing the app uses (the selftest), not "spawn-based engine workers" — the engine runs threads.
- `.github/workflows/ci.yml`: drop retired `dev/v2-architecture-rework` / `phase-*/**` triggers; `main` is the trunk.

## 4 — Menu simplification (`feat(ui): …`)

Six top-level menus → four (Engine · Cameras · View · Help): `Panels` + `Layouts` move under View; Help's update items become an `Updates` submenu, which also exposes the existing auto-check setting as "Check Automatically on Startup".

## 5 — Docs (`docs: …`)

README / `docs/` / CHANGELOG / CONTRIBUTING updated to match: real `detector_model_tier`, `framing`/`zoom_framing` relationship, `int8` precision, RT-DETR via `AUTOPTZ_MODEL_PATH`, multi-threaded (not multi-process) engine, `main`-trunk branching, `Help → Updates` menu path. All documented CLI flags verified to exist; all relative doc links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)