### PR TITLE
ci(release): build Intel (x86_64) macOS dmg alongside arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,21 @@ jobs:
           fi
 
   macos:
-    name: Build macOS .dmg
+    name: Build macOS .dmg (${{ matrix.arch }})
     needs: guard
-    runs-on: macos-14
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Build both Mac architectures as separate native bundles. PyInstaller and
+      # the ML wheels (torch, onnxruntime) are arch-specific, so there is no single
+      # universal2 build — Apple Silicon and Intel each get their own signed dmg.
+      # fail-fast: false so an Intel-only hiccup can't sink the arm64 build.
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14   # Apple Silicon (arm64)
+            arch: arm64
+          - runner: macos-13   # Intel (x86_64)
+            arch: x86_64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -85,7 +97,7 @@ jobs:
         run: bash packaging/build_macos.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-${{ matrix.arch }}
           path: dist/*.dmg
           if-no-files-found: error
 

--- a/autoptz/update/checker.py
+++ b/autoptz/update/checker.py
@@ -39,11 +39,20 @@ class UpdateInfo:
     assets: tuple[tuple[str, str], ...] = ()  # (filename, browser_download_url)
 
     def asset_for_platform(self) -> tuple[str, str] | None:
-        """Return ``(filename, url)`` for this OS, or None if absent."""
+        """Return ``(filename, url)`` for this OS (and arch on macOS), or None."""
         if sys.platform == "darwin":
-            exts = (".dmg",)
-        elif sys.platform == "win32":
-            exts = ("setup.exe", ".msi", ".exe")
+            # Releases ship separate arm64 and x86_64 dmgs; prefer the one matching
+            # this Mac, falling back to any .dmg (e.g. an older single-arch release).
+            import platform
+
+            arch = platform.machine().lower()  # "arm64" or "x86_64"
+            dmgs = [(n, u) for n, u in self.assets if n.lower().endswith(".dmg")]
+            for name, url in dmgs:
+                if arch in name.lower():
+                    return name, url
+            return dmgs[0] if dmgs else None
+        if sys.platform == "win32":
+            exts: tuple[str, ...] = ("setup.exe", ".msi", ".exe")
         else:
             exts = (".appimage", ".deb", ".tar.gz")
         for name, url in self.assets:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,10 +5,11 @@
 Download the latest build for your OS from the
 [Releases page](https://github.com/AutoPTZ/autoptz/releases):
 
-- **macOS** — `AutoPTZ-<version>-macos-arm64.dmg`. Open it and drag **AutoPTZ**
-  to Applications. Signed + notarized releases open normally. If you build it
-  yourself unsigned, the first launch needs: right-click the app → **Open** →
-  **Open** (or System Settings → Privacy & Security → *Open Anyway*).
+- **macOS** — `AutoPTZ-<version>-macos-arm64.dmg` (Apple Silicon) or
+  `…-macos-x86_64.dmg` (Intel). Open it and drag **AutoPTZ** to Applications.
+  Signed + notarized releases open normally. If you build it yourself unsigned,
+  the first launch needs: right-click the app → **Open** → **Open** (or System
+  Settings → Privacy & Security → *Open Anyway*).
 - **Windows** — `AutoPTZ-<version>-windows-x64-setup.exe`. Run it; it installs
   Start-menu/desktop shortcuts and an uninstaller. SmartScreen may warn on the
   unsigned installer — **More info → Run anyway**.

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# build_macos.sh — build AutoPTZ.app on macOS (Apple Silicon).
+# build_macos.sh — build AutoPTZ.app for the host macOS architecture
+# (Apple Silicon arm64 or Intel x86_64; PyInstaller freezes host-native).
 #
 # Produces dist/AutoPTZ.app, an unsigned bundle whose Info.plist declares
 # CFBundleName=AutoPTZ — that is what makes the macOS app menu read "AutoPTZ"
@@ -119,7 +120,11 @@ fi
 # sets MAKE_DMG=1; local builds skip it by default.
 if [[ "${MAKE_DMG:-0}" == "1" ]]; then
     VER="$("${PY}" -c 'import autoptz; print(autoptz.__version__)')"
-    DMG="dist/AutoPTZ-${VER}-macos-arm64.dmg"
+    # Native host architecture: "arm64" on Apple Silicon, "x86_64" on Intel.
+    # PyInstaller (target_arch=None) freezes for the host, so the dmg name must
+    # follow suit instead of always claiming arm64.
+    ARCH="$(uname -m)"
+    DMG="dist/AutoPTZ-${VER}-macos-${ARCH}.dmg"
     echo "==> Building ${DMG}"
     STAGE="$(mktemp -d)"
     cp -R "${APP}" "${STAGE}/"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -99,6 +99,40 @@ def test_asset_url_for_platform(monkeypatch) -> None:
     assert asset[1] == url
 
 
+def test_asset_for_platform_macos_prefers_matching_arch(monkeypatch) -> None:
+    import platform as _platform
+
+    monkeypatch.setattr(checker.sys, "platform", "darwin")
+    info = UpdateInfo(
+        version="2.1.0",
+        tag="v2.1.0",
+        name="x",
+        body="",
+        html_url="https://example/rel",
+        is_prerelease=False,
+        assets=(
+            ("AutoPTZ-2.1.0-macos-x86_64.dmg", "https://example/intel"),
+            ("AutoPTZ-2.1.0-macos-arm64.dmg", "https://example/arm"),
+        ),
+    )
+    monkeypatch.setattr(_platform, "machine", lambda: "arm64")
+    assert info.asset_for_platform() == ("AutoPTZ-2.1.0-macos-arm64.dmg", "https://example/arm")
+    monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+    assert info.asset_for_platform()[1] == "https://example/intel"
+
+    # An older single, unlabeled dmg still resolves via the fallback.
+    one = UpdateInfo(
+        version="2.0.0",
+        tag="v2.0.0",
+        name="x",
+        body="",
+        html_url="https://example/rel",
+        is_prerelease=False,
+        assets=(("AutoPTZ-2.0.0.dmg", "https://example/any"),),
+    )
+    assert one.asset_for_platform() == ("AutoPTZ-2.0.0.dmg", "https://example/any")
+
+
 def test_update_manager_prerelease_opt_in() -> None:
     """include_prereleases defaults to opt-out (False) and the setter persists.
 


### PR DESCRIPTION
Re-applies the Intel macOS build (PR #50 merged into the version-guard branch, never reached main), integrated with the new code-signing so **both** arches are signed + notarized.

- release.yml: macOS job → arm64 (macos-14) + x86_64 (macos-13) matrix; both keep the cert import + sign/notarize steps; artifacts `macos-<arch>`.
- build_macos.sh: dmg name follows `uname -m`.
- update/checker.py: `asset_for_platform` prefers the dmg matching the running Mac's arch (fallback to any .dmg) — so the updater never hands an Apple Silicon user the Intel dmg. New test added.
- installation.md: documents both dmgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)