### PR TITLE
release: 2.1.0-rc1

### DIFF
--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.0.0"
+__version__ = "2.1.0-rc1"
 
 
 def version() -> str:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -188,7 +188,12 @@ class TestUSBAdapterReconnect:
         ):
             adapter.start()
             opened.wait(timeout=2.0)
-            time.sleep(0.1)
+            # Poll until a frame has actually been read (which implies RUNNING)
+            # rather than sleeping a fixed window, which flakes when a loaded CI
+            # runner stalls the adapter thread.
+            deadline = time.monotonic() + 2.0
+            while adapter.status.frames_total <= 0 and time.monotonic() < deadline:
+                time.sleep(0.01)
             status = adapter.status
             adapter.stop()
 

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -565,7 +565,12 @@ class TestControllerThread:
         ctrl = PTZController(backend, _cfg(kp=0.6), rate_hz=50.0)
         ctrl.start()
         ctrl.update((0.5, 0.0), (0.0, 0.0), 0.45, True)
-        time.sleep(0.1)
+        # Poll until the worker thread delivers rather than sleeping a fixed window:
+        # at 50 Hz a tick is ~20 ms, but a loaded CI runner can stall the thread, so
+        # a fixed 0.1 s sleep flakes. Allow a generous ceiling; return as soon as ready.
+        deadline = time.monotonic() + 2.0
+        while not backend.velocity_calls and time.monotonic() < deadline:
+            time.sleep(0.01)
         ctrl.stop()
         assert len(backend.velocity_calls) >= 1
 


### PR DESCRIPTION
Bumps `__version__` to **2.1.0-rc1** (the release guard requires the tag to match).

Minor bump — new backward-compatible features since 2.0.0: quick-collapse side panels, signed + notarized macOS builds, Intel macOS dmg, plus dependency bumps and the Linux CI fix (see CHANGELOG `[Unreleased]`).

RC first so the new release pipeline (signing, notarization, arm64/x86_64 matrix) runs as a GitHub **pre-release** before the final 2.1.0.

After merge: tag `v2.1.0-rc1` to trigger the signed release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)