### PR TITLE
fix(macos): best-effort signing so a cert problem can't brick the release

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -40,6 +40,18 @@ MAKE_DMG=1 bash packaging/build_macos.sh                 # signed + notarized + 
 `security find-identity -v -p codesigning` lists your identity + Team ID. Entitlements
 come from `packaging/entitlements.plist` (hardened runtime, required for notarization).
 
+> **You need a "Developer ID Application" certificate.** An **"Apple Development"**
+> cert (the default Xcode one) signs locally but **cannot be notarized** — Apple
+> returns `status: Invalid`. Create a Developer ID cert (needs the paid Apple
+> Developer Program): Xcode → Settings → Accounts → your team → Manage Certificates →
+> **+** → *Developer ID Application* (or via developer.apple.com → Certificates).
+> Then export it from Keychain Access as a `.p12`.
+
+If signing succeeds but notarization can't (e.g. wrong cert type), the script ships a
+**signed-but-not-notarized** build by default rather than failing — so a signing
+problem never blocks the Windows/Linux release. Set **`MACOS_SIGN_REQUIRED=1`** to make
+a non-notarized result a hard error once your Developer ID cert is in place.
+
 ### Signed releases in CI
 
 The [release workflow](../.github/workflows/release.yml) signs + notarizes the published

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -36,9 +36,11 @@ echo "    venv:  ${VENV}"
 SIGN_IDENTITY="${MACOS_SIGN_IDENTITY:-}"
 
 # Notarize + staple a signed artifact (.app or .dmg) with whichever credentials
-# are available; a no-op (with a note) when none are set. Fails the build (and
-# prints Apple's detailed log) if the submission is not Accepted, instead of
-# blindly stapling a rejected artifact.
+# are available; a no-op (with a note) when none are set. On a non-Accepted
+# submission it prints Apple's detailed log, then by default warns and continues
+# (the build ships signed-but-not-notarized) so a signing problem can't brick the
+# whole cross-platform release. Set MACOS_SIGN_REQUIRED=1 to make it fatal once a
+# valid Developer ID Application cert is in place.
 notarize_and_staple() {
     local target="$1"
     local creds=()
@@ -66,7 +68,15 @@ notarize_and_staple() {
             echo "==> Apple notary log for ${submission_id}:"
             xcrun notarytool log "${submission_id}" "${creds[@]}" || true
         fi
-        return 1
+        echo "   Notarization requires a 'Developer ID Application' certificate; an"
+        echo "   'Apple Development' cert cannot notarize. See docs/building.md."
+        if [[ "${MACOS_SIGN_REQUIRED:-0}" == "1" ]]; then
+            echo "!! MACOS_SIGN_REQUIRED=1 — failing the build."
+            return 1
+        fi
+        echo "==> Continuing with a signed-but-NOT-notarized ${target}. Users will"
+        echo "    see a Gatekeeper warning until a Developer ID cert is configured."
+        return 0
     fi
     echo "==> Stapling ${target}"
     xcrun stapler staple "${target}"


### PR DESCRIPTION
rc1's macOS build failed because the configured cert is an **Apple Development** cert, which can't be notarized (`status: Invalid`) — and that sank the entire cross-platform release.

- Notarization now degrades gracefully: prints Apple's log + a cert hint, then (by default) warns and continues with a signed-but-not-notarized build instead of failing.
- `MACOS_SIGN_REQUIRED=1` makes a non-notarized result fatal — flip it on once a real **Developer ID Application** cert is configured.
- docs/building.md documents the cert requirement and the flag.

Real notarized signing still needs a Developer ID Application cert (paid Apple Developer Program); this just stops a cert problem from blocking releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)