### PR TITLE
release: 2.1.0-rc2

### DIFF
--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.1.0-rc1"
+__version__ = "2.1.0-rc2"
 
 
 def version() -> str:


### PR DESCRIPTION
Second RC for 2.1.0. rc1 failed at macOS notarization (Apple Development cert can't notarize); the cert is now a Developer ID Application cert and signing is best-effort (#60), so this validates the full pipeline — macOS should come back notarized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)