### PR TITLE
ci(release): make the Intel macOS build best-effort (can't block releases)

### DIFF
--- a/.github/actions/macos-signed-build/action.yml
+++ b/.github/actions/macos-signed-build/action.yml
@@ -1,0 +1,79 @@
+name: Build signed macOS dmg
+description: >
+  Build AutoPTZ.app + .dmg for the host arch, importing a Developer ID cert and
+  signing/notarizing when the signing inputs are provided (unsigned otherwise),
+  then upload the dmg as the macos-<arch> artifact.
+
+inputs:
+  arch:
+    description: Host arch label for the artifact name (arm64 / x86_64).
+    required: true
+  cert-b64:
+    description: Developer ID Application cert as a base64-encoded .p12.
+    required: false
+    default: ""
+  cert-password:
+    description: Password for the .p12.
+    required: false
+    default: ""
+  sign-identity:
+    description: '"Developer ID Application: Name (TEAMID)" codesign identity.'
+    required: false
+    default: ""
+  notary-apple-id:
+    required: false
+    default: ""
+  notary-team-id:
+    required: false
+    default: ""
+  notary-password:
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+    # Import the Developer ID cert into a temporary keychain so build_macos.sh can
+    # codesign. No-op (unsigned build) when the secret is absent, so forks /
+    # unconfigured repos still produce a working .dmg.
+    - name: Import Developer ID certificate
+      shell: bash
+      env:
+        CERT_B64: ${{ inputs.cert-b64 }}
+        CERT_PASSWORD: ${{ inputs.cert-password }}
+      run: |
+        if [ -z "${CERT_B64}" ]; then
+          echo "No signing cert provided — building unsigned."
+          exit 0
+        fi
+        KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+        KEYCHAIN_PW="$(uuidgen)"
+        printf '%s' "${CERT_B64}" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+        security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN"
+        security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+        security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "${CERT_PASSWORD}" \
+          -T /usr/bin/codesign -T /usr/bin/security
+        security set-key-partition-list -S apple-tool:,apple:,codesign: \
+          -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+        security list-keychains -d user -s "$KEYCHAIN" \
+          $(security list-keychains -d user | sed 's/["[:space:]]//g')
+        rm -f "$RUNNER_TEMP/cert.p12"
+    - name: Build .app + .dmg
+      shell: bash
+      env:
+        MAKE_DMG: "1"
+        MACOS_SIGN_IDENTITY: ${{ inputs.sign-identity }}
+        MACOS_NOTARY_APPLE_ID: ${{ inputs.notary-apple-id }}
+        MACOS_NOTARY_TEAM_ID: ${{ inputs.notary-team-id }}
+        MACOS_NOTARY_PASSWORD: ${{ inputs.notary-password }}
+      run: bash packaging/build_macos.sh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: macos-${{ inputs.arch }}
+        path: dist/*.dmg
+        if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,66 +40,44 @@ jobs:
             echo "Manual dispatch (ref_type=$GITHUB_REF_TYPE); __version__=$ver — skipping tag match."
           fi
 
+  # Apple Silicon (arm64) — the required macOS build; gates the release.
   macos:
-    name: Build macOS .dmg (${{ matrix.arch }})
+    name: Build macOS .dmg (arm64)
     needs: guard
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      # Build both Mac architectures as separate native bundles. PyInstaller and
-      # the ML wheels (torch, onnxruntime) are arch-specific, so there is no single
-      # universal2 build — Apple Silicon and Intel each get their own signed dmg.
-      # fail-fast: false so an Intel-only hiccup can't sink the arm64 build.
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-14   # Apple Silicon (arm64)
-            arch: arm64
-          - runner: macos-13   # Intel (x86_64)
-            arch: x86_64
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/macos-signed-build
         with:
-          python-version: "3.12"
-          cache: pip
-      # Import the Developer ID Application cert into a temporary keychain so
-      # build_macos.sh can codesign. No-op (unsigned build) when the secret is
-      # absent, so forks / unconfigured repos still produce a working .dmg.
-      - name: Import Developer ID certificate
-        env:
-          CERT_B64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
-          CERT_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-        run: |
-          if [ -z "${CERT_B64}" ]; then
-            echo "MACOS_CERTIFICATE_P12_BASE64 not set — building unsigned."
-            exit 0
-          fi
-          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
-          KEYCHAIN_PW="$(uuidgen)"
-          printf '%s' "${CERT_B64}" | base64 --decode > "$RUNNER_TEMP/cert.p12"
-          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
-          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "${CERT_PASSWORD}" \
-            -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
-          security list-keychains -d user -s "$KEYCHAIN" \
-            $(security list-keychains -d user | sed 's/["[:space:]]//g')
-          rm -f "$RUNNER_TEMP/cert.p12"
-      - name: Build .app + .dmg
-        env:
-          MAKE_DMG: "1"
-          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
-          MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
-          MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-          MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
-        run: bash packaging/build_macos.sh
-      - uses: actions/upload-artifact@v4
+          arch: arm64
+          cert-b64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          cert-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          sign-identity: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          notary-apple-id: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          notary-team-id: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          notary-password: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+
+  # Intel (x86_64) — best-effort. GitHub's macos-13 runners are scarce, so this is
+  # deliberately NOT a dependency of `release`: a missing/slow Intel runner can
+  # never hold up the arm64 + Windows + Linux release. continue-on-error keeps the
+  # run green if it fails; the x86_64 dmg ships whenever it finishes in time.
+  macos-intel:
+    name: Build macOS .dmg (x86_64, best-effort)
+    needs: guard
+    runs-on: macos-13
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/macos-signed-build
         with:
-          name: macos-${{ matrix.arch }}
-          path: dist/*.dmg
-          if-no-files-found: error
+          arch: x86_64
+          cert-b64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          cert-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          sign-identity: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          notary-apple-id: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          notary-team-id: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          notary-password: ${{ secrets.MACOS_NOTARY_PASSWORD }}
 
   windows:
     name: Build Windows installer


### PR DESCRIPTION
GitHub's `macos-13` Intel runners are scarce — one sat ~36 min unassigned and hung a whole release. Split macOS into two jobs:

- **`macos`** (arm64, macos-14) — required; gates the release.
- **`macos-intel`** (x86_64, macos-13) — `continue-on-error` + timeout, and **not** a dependency of `release`, so a missing/slow Intel runner never blocks the arm64 + Windows + Linux release. The Intel dmg ships when it finishes in time.

Shared cert-import + signed-build logic factored into a composite action (`.github/actions/macos-signed-build`) to avoid duplicating the keychain steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)