### PR TITLE
release: 2.1.0-rc3

### DIFF
--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.1.0-rc2"
+__version__ = "2.1.0-rc3"
 
 
 def version() -> str:


### PR DESCRIPTION
Third RC for 2.1.0 — validates macOS notarization with the now-correct Developer ID Application cert, plus the decoupled best-effort Intel build (#62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)