### PR TITLE
ci(macos): print signing identity + authority for notarization diagnosis

### DIFF
--- a/.github/actions/macos-signed-build/action.yml
+++ b/.github/actions/macos-signed-build/action.yml
@@ -63,6 +63,11 @@ runs:
         security list-keychains -d user -s "$KEYCHAIN" \
           $(security list-keychains -d user | sed 's/["[:space:]]//g')
         rm -f "$RUNNER_TEMP/cert.p12"
+        # Diagnostic (identity names are not secret): show what the .p12 actually
+        # contains. Notarization needs a "Developer ID Application: …" identity here;
+        # an "Apple Development: …" identity will be rejected by Apple.
+        echo "==> Code-signing identities in the import keychain:"
+        security find-identity -v -p codesigning "$KEYCHAIN" || true
     - name: Build .app + .dmg
       shell: bash
       env:

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -143,6 +143,10 @@ if [[ -n "${SIGN_IDENTITY}" ]]; then
         --entitlements packaging/entitlements.plist \
         --sign "${SIGN_IDENTITY}" "${APP}"
     codesign --verify --deep --strict --verbose=2 "${APP}"
+    # Diagnostic: which certificate actually signed the bundle? Notarization needs
+    # "Authority=Developer ID Application: …"; "Apple Development: …" is rejected.
+    echo "==> Signing authority on ${APP}:"
+    codesign -dvv "${APP}" 2>&1 | grep -i "^Authority=" || true
     echo "==> ${APP} signed"
 fi
 


### PR DESCRIPTION
Three RCs failed notarization with the same error ("not signed with a valid Developer ID certificate"). Add two non-secret diagnostics so we can see exactly which cert is being used: `security find-identity` on the import keychain, and `codesign -dvv | grep Authority=` after signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)