### PR TITLE
Fix Windows model delete/download, EP reporting, persist+skip-load services, perf Phase A

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -662,6 +662,21 @@ class CameraWorker:
         with self._cmd_lock:
             self._cmd_queue.append(("reload_models", None))
 
+    def release_inference_models(self, *, wait: float = 0.0) -> None:
+        """Drop the worker's detector/pose refs so their ORT sessions can be freed.
+
+        Unlike :meth:`reload_inference_models` this does *not* rebuild — it only
+        releases, so the OS file handles are gone before the on-disk model cache
+        is mutated (delete/replace fails on Windows while a handle is open).  Pass
+        ``wait > 0`` to block until the inference thread confirms the release (or
+        the timeout elapses); the caller then GCs and mutates the files.
+        """
+        done = threading.Event() if wait > 0 else None
+        with self._cmd_lock:
+            self._cmd_queue.append(("release_models", done))
+        if done is not None:
+            done.wait(timeout=wait)
+
     def set_inference_start_paused(self, paused: bool) -> None:
         """Pause/release heavy inference startup while preview/capture opens."""
         if paused:
@@ -797,6 +812,10 @@ class CameraWorker:
             self._refresh_detector_from_pool()
         elif kind == "reload_models":
             self._reload_inference_models()
+        elif kind == "release_models":
+            self._release_inference_models()
+            if isinstance(payload, threading.Event):
+                payload.set()
         elif kind == "save_ptz_preset":
             self._save_ptz_preset(int(payload))
         elif kind == "recall_ptz_preset":
@@ -830,6 +849,21 @@ class CameraWorker:
             self._last_applied_fps = float(fps)
         except Exception:  # noqa: BLE001
             log.debug("camera_id=%s set_target_fps failed", self.camera_id, exc_info=True)
+
+    def _release_inference_models(self) -> None:
+        """Drop detector/pose refs *without* rebuilding so their ORT sessions free.
+
+        Called before the on-disk model cache is mutated: once these refs and the
+        shared pool's are gone (and GC runs), Windows can delete/replace the files
+        that onnxruntime had open.  The subsequent ``reload_models`` rebuilds.
+        """
+        self._detect = None
+        self._unified_pose_active = False
+        self._last_detections = []
+        self._pose = None
+        self._pose_probed = False
+        self._pose_keypoints = None
+        self._pose_kp_track_id = None
 
     def _reload_inference_models(self) -> None:
         """Force-drop + rebuild detector/pose to match the current model cache."""
@@ -3758,19 +3792,7 @@ class CameraWorker:
                 ),
                 detail="recognition and identity reacquire",
             ),
-            RuntimeServiceInfo(
-                key="pose",
-                name="Pose",
-                configured="on",
-                enabled=self._feature("pose"),
-                active=bool(self._feature("pose") and self._pose is not None),
-                state=self._stage_status(
-                    "pose",
-                    enabled=self._feature("pose"),
-                    available=self._pose is not None or not self._pose_probed,
-                ),
-                detail="PTZ aim point" if self._feature("pose") else "disabled",
-            ),
+            self._pose_service_row(pool),
             RuntimeServiceInfo(
                 key="framing",
                 name="Framing",
@@ -3793,6 +3815,38 @@ class CameraWorker:
                 confidence="trusted" if cap else "unknown",
             ),
         ]
+
+    def _pose_service_row(self, pool: Any) -> RuntimeServiceInfo:
+        """Pose status, surfacing a 'present but failed to load' reason.
+
+        Mirrors the detector row: when pose is on and the model was probed but the
+        estimator is unavailable with a known reason (e.g. the ORT session failed
+        on this platform), report ``failed`` + that reason instead of a silent
+        idle — so "downloaded but not working" explains itself.
+        """
+        enabled = self._feature("pose")
+        pose_obj = self._pose
+        loaded = pose_obj is not None and bool(getattr(pose_obj, "available", True))
+        error = str(getattr(pool, "pose_error", "") or "") if pool is not None else ""
+        if not error:
+            error = str(getattr(pose_obj, "error", "") or "")
+        failed = enabled and self._pose_probed and not loaded and bool(error)
+        if failed:
+            state, detail = "failed", error
+        else:
+            state = self._stage_status(
+                "pose", enabled=enabled, available=loaded or not self._pose_probed
+            )
+            detail = "PTZ aim point" if enabled else "disabled"
+        return RuntimeServiceInfo(
+            key="pose",
+            name="Pose",
+            configured="on",
+            enabled=enabled,
+            active=bool(enabled and loaded),
+            state=state,
+            detail=detail,
+        )
 
     def _reid_service_row(self, tracking: Any) -> RuntimeServiceInfo:
         """ReID status with the resolved on/off state and a plain reason.

--- a/autoptz/engine/pipeline/pool.py
+++ b/autoptz/engine/pipeline/pool.py
@@ -116,6 +116,10 @@ class _LockedPose:
     def ep(self) -> str:
         return str(getattr(self._estimator, "ep", ""))
 
+    @property
+    def error(self) -> str:
+        return str(getattr(self._estimator, "error", ""))
+
     def estimate(
         self,
         frame: NDArray[np.uint8],
@@ -174,6 +178,9 @@ class InferencePool:
         self._pose: _LockedPose | None = None
         self._pose_built = False
         self._pose_call_lock = threading.Lock()
+        # Reason the shared pose estimator is unavailable ("" = fine / not tried),
+        # surfaced so a "downloaded but not working" pose model explains itself.
+        self._pose_error = ""
 
     # ── detector ────────────────────────────────────────────────────────────────
 
@@ -201,6 +208,17 @@ class InferencePool:
     def detector_error(self) -> str:
         """Why the shared detector failed to build ("" = built or not tried)."""
         return self._detector_error
+
+    @property
+    def pose_error(self) -> str:
+        """Why the shared pose estimator is unavailable ("" = ok / not tried).
+
+        Prefers the live estimator's own reason (e.g. ORT session load failure)
+        and falls back to the build-time reason when the estimator couldn't even
+        be constructed.
+        """
+        live = str(getattr(self._pose, "error", "") or "") if self._pose is not None else ""
+        return live or self._pose_error
 
     @property
     def detector_tier(self) -> str:
@@ -357,12 +375,27 @@ class InferencePool:
             log.warning("inference pool: detector model resolution failed.", exc_info=True)
             return None
         if model_path is None:
-            self._detector_error = (
-                manager.last_error
-                or f"Model '{self._detector_tier}' unavailable (live-preview-only)."
+            # Never go silent: if the selected tier can't be resolved, fall back to
+            # the always-present bundled default (Auto/Fast) so detection keeps
+            # running.  Only the explicitly-chosen heavier tiers can hit this.
+            fallback = None
+            if self._detector_tier not in ("auto", "fast"):
+                try:
+                    fallback = manager.ensure_detector(tier="auto", allow_download=False)
+                except Exception:  # noqa: BLE001
+                    fallback = None
+            if fallback is None:
+                self._detector_error = (
+                    manager.last_error
+                    or f"Model '{self._detector_tier}' unavailable (live-preview-only)."
+                )
+                log.debug("inference pool: no detector model; live-preview-only.")
+                return None
+            log.warning(
+                "inference pool: tier %s unavailable; using bundled default detector.",
+                self._detector_tier,
             )
-            log.debug("inference pool: no detector model; live-preview-only.")
-            return None
+            model_path = fallback
 
         # Unified path: one YOLO11-pose backbone emitting boxes + keypoints.  If
         # its model can't be resolved/built we fall through to the plain detector
@@ -458,17 +491,22 @@ class InferencePool:
         """Build the shared PoseEstimator wrapped in a serialising proxy."""
         try:
             from autoptz.engine.camera_worker import detection_runtime_available
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            self._pose_error = f"pose runtime import failed: {exc}"
             return None
         if not detection_runtime_available():
+            self._pose_error = "detection runtime (onnxruntime/opencv) unavailable"
             return None
         try:
             from autoptz.engine.pipeline.pose import PoseEstimator
 
             estimator = PoseEstimator(allow_download=self._allow_model_download)
+            # Carry the estimator's own load reason ("" when it loaded fine).
+            self._pose_error = str(getattr(estimator, "error", "") or "")
             return _LockedPose(estimator, self._pose_call_lock)
-        except Exception:  # noqa: BLE001 — pose must never break startup
+        except Exception as exc:  # noqa: BLE001 — pose must never break startup
             log.debug("inference pool: pose estimator init failed; bbox aim only.", exc_info=True)
+            self._pose_error = f"pose estimator init failed: {exc}"
             return None
 
     # ── release (free a model so memory is reclaimed) ──────────────────────────────
@@ -499,6 +537,7 @@ class InferencePool:
         with self._build_lock:
             self._pose = None
             self._pose_built = False
+            self._pose_error = ""
 
     # ── warm-up ───────────────────────────────────────────────────────────────────
     #

--- a/autoptz/engine/pipeline/pose.py
+++ b/autoptz/engine/pipeline/pose.py
@@ -172,6 +172,10 @@ class PoseEstimator:
         self._session: Any | None = None
         self._input_name: str = ""
         self._output_name: str = ""
+        #: Human-readable reason the estimator is unavailable, surfaced to the UI
+        #: so a "downloaded but not working" pose model explains *why* (e.g. the
+        #: ORT/EP session failed to build) instead of silently disappearing.
+        self._error: str = ""
 
         if _session is not None:
             self._session = _session
@@ -197,8 +201,9 @@ class PoseEstimator:
                     out.name,
                     self._input_size,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 log.debug("pose session introspection failed", exc_info=True)
+                self._error = f"pose session introspection failed: {exc}"
                 self._session = None
 
     # ── public API ──────────────────────────────────────────────────────────────
@@ -207,6 +212,11 @@ class PoseEstimator:
     def available(self) -> bool:
         """True iff a pose session loaded and is ready to infer."""
         return self._session is not None
+
+    @property
+    def error(self) -> str:
+        """Reason the estimator is unavailable ("" when it loaded or never tried)."""
+        return self._error if self._session is None else ""
 
     @property
     def ep(self) -> str:
@@ -298,14 +308,16 @@ class PoseEstimator:
         )
         if not path or not Path(path).is_file():
             _log_no_pose_once("no model file")
+            self._error = "no pose model file found (download or bundle it)"
             return
         try:
             from autoptz.engine.runtime.inference import make_session
 
             self._session = make_session(Path(path), prefs)
-        except Exception:  # noqa: BLE001 — load failure → estimator stays disabled
+        except Exception as exc:  # noqa: BLE001 — load failure → estimator stays disabled
             _log_no_pose_once("session load failed")
             log.debug("pose session load failed for %s", path, exc_info=True)
+            self._error = f"pose model present but the ORT session failed to load: {exc}"
             self._session = None
 
     def _letterbox(

--- a/autoptz/engine/runtime/diagnostics.py
+++ b/autoptz/engine/runtime/diagnostics.py
@@ -120,19 +120,29 @@ def face_status() -> dict[str, str]:
 def pose_status() -> dict[str, str]:
     """Pose model/dependency availability for skeleton + torso-stable aim."""
     try:
-        from autoptz.engine.runtime.models import default_manager  # noqa: PLC0415
+        from autoptz.engine.runtime.models import (  # noqa: PLC0415
+            bundled_models_dir,
+            default_manager,
+        )
 
-        onnx = default_manager().cache_dir / "yolo11n-pose.onnx"
-        if onnx.is_file():
-            size_mb = onnx.stat().st_size / (1 << 20)
-            return _entry("pose", "Pose model", "ok", f"{onnx.name} · {size_mb:.1f} MB")
+        name = "yolo11n-pose.onnx"
+        cached = default_manager().cache_dir / name
+        bundled = bundled_models_dir() / name
+        # The pose model can ship *inside* the app (bundled) as well as be
+        # downloaded into the user cache.  Only checking the cache made a bundled
+        # model read as "not cached" even though pose loads fine from the bundle.
+        present = cached if cached.is_file() else (bundled if bundled.is_file() else None)
+        if present is not None:
+            size_mb = present.stat().st_size / (1 << 20)
+            where = "cached" if present == cached else "bundled"
+            return _entry("pose", "Pose model", "ok", f"{name} · {size_mb:.1f} MB · {where}")
         if _module_present("ultralytics"):
-            return _entry("pose", "Pose model", "warn", f"not cached · can export to {onnx}")
+            return _entry("pose", "Pose model", "warn", f"not cached · can export to {cached}")
         return _entry(
             "pose",
             "Pose model",
             "off",
-            f"not cached · needs bundled model or ultralytics export to {onnx}",
+            f"not cached · needs bundled model or ultralytics export to {cached}",
         )
     except Exception:  # noqa: BLE001
         return _entry("pose", "Pose model", "off", "lookup failed")

--- a/autoptz/engine/runtime/models.py
+++ b/autoptz/engine/runtime/models.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+import time
 import urllib.request
 from collections.abc import Callable
 from pathlib import Path
@@ -169,6 +170,46 @@ def _format_bytes(value: int) -> str:
 def _model_export_disabled() -> bool:
     """Return True when runtime model export is explicitly disabled."""
     return os.environ.get(_DISABLE_EXPORT_ENV, "").strip().lower() in _TRUE_ENV_VALUES
+
+
+# Windows refuses to delete/replace a file while another handle is open and,
+# unlike POSIX, can briefly lock a freshly-written file behind antivirus scanning.
+# The engine releases its ORT sessions before mutating the cache, but the OS
+# handle can linger a beat after GC — so retry the mutation through these helpers
+# instead of failing the whole operation on the first transient lock.
+_FILE_OP_ATTEMPTS = 10
+_FILE_OP_DELAY_S = 0.2
+
+
+def _retry_file_op(op: Callable[[], None], *, attempts: int = _FILE_OP_ATTEMPTS) -> None:
+    """Run a file mutation, retrying transient Windows locks; re-raise the last error.
+
+    Only sharing-violation-style errors are retried — a missing file (or other
+    permanent error) is re-raised immediately rather than waited on.
+    """
+    last: Exception | None = None
+    for attempt in range(max(1, attempts)):
+        try:
+            op()
+            return
+        except FileNotFoundError:  # permanent — nothing to wait for
+            raise
+        except (PermissionError, OSError) as exc:  # locked by ORT handle / antivirus
+            last = exc
+            if attempt + 1 < attempts:
+                time.sleep(_FILE_OP_DELAY_S)
+    if last is not None:
+        raise last
+
+
+def _replace_with_retry(src: Path, dst: Path) -> None:
+    """``src.replace(dst)`` with Windows lock retries (see :func:`_retry_file_op`)."""
+    _retry_file_op(lambda: src.replace(dst))
+
+
+def _unlink_with_retry(path: Path) -> None:
+    """``path.unlink()`` with Windows lock retries (see :func:`_retry_file_op`)."""
+    _retry_file_op(path.unlink)
 
 
 def _models_cache_dir() -> Path:
@@ -317,7 +358,7 @@ class ModelManager:
                 if not tmp.is_file() or tmp.stat().st_size < _MIN_ONNX_BYTES:
                     log.warning("INT8 quantization of %s produced no/!tiny file", src.name)
                     return None
-                tmp.replace(dst)
+                _replace_with_retry(tmp, dst)
                 log.info("INT8 detector ready at %s (%.1f MB)", dst, dst.stat().st_size / (1 << 20))
                 return str(dst)
             except Exception:  # noqa: BLE001 — quantization is best-effort
@@ -532,7 +573,7 @@ class ModelManager:
             for path in self.managed_model_files(keys=keys):
                 try:
                     size = path.stat().st_size
-                    path.unlink()
+                    _unlink_with_retry(path)
                     removed.append(
                         {
                             "name": path.name,
@@ -630,7 +671,7 @@ class ModelManager:
                 )
                 return None
 
-            tmp_path.replace(onnx_path)
+            _replace_with_retry(tmp_path, onnx_path)
             log.info(
                 "Model ONNX ready at %s (%.1f MB, prebuilt, torch-free)",
                 onnx_path,
@@ -710,7 +751,7 @@ class ModelManager:
             exported_path = Path(exported) if exported else (self._cache_dir / onnx_path.name)
             if exported_path.is_file() and exported_path != onnx_path:
                 try:
-                    exported_path.replace(onnx_path)
+                    _replace_with_retry(exported_path, onnx_path)
                 except Exception:  # noqa: BLE001
                     # If the rename fails, fall back to whatever path exists.
                     if exported_path.is_file():

--- a/autoptz/engine/runtime/models.py
+++ b/autoptz/engine/runtime/models.py
@@ -181,7 +181,7 @@ _FILE_OP_ATTEMPTS = 10
 _FILE_OP_DELAY_S = 0.2
 
 
-def _retry_file_op(op: Callable[[], None], *, attempts: int = _FILE_OP_ATTEMPTS) -> None:
+def _retry_file_op(op: Callable[[], Any], *, attempts: int = _FILE_OP_ATTEMPTS) -> None:
     """Run a file mutation, retrying transient Windows locks; re-raise the last error.
 
     Only sharing-violation-style errors are retried — a missing file (or other

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -143,6 +143,16 @@ class Supervisor:
 
     # ── lifecycle ───────────────────────────────────────────────────────────────
 
+    def prime_features(self, features: dict[str, bool] | None) -> None:
+        """Seed the global feature switches *before* :meth:`start` spawns workers.
+
+        ``_spawn_worker`` applies ``self._features`` to each new worker, so seeding
+        them here means a disabled service is never built at spin-up (the worker
+        gates model construction on these flags).  Must be called before ``start``;
+        a no-op mid-run since workers already exist.
+        """
+        self._features = {str(k): bool(v) for k, v in (features or {}).items()}
+
     def start(
         self,
         *,
@@ -573,13 +583,15 @@ class Supervisor:
                 except Exception:  # noqa: BLE001
                     log.debug("pool %s failed", method, exc_info=True)
 
-    def apply_model_cache_changed(self) -> None:
-        """Drop + rebuild detector/pose after the on-disk model cache changed.
+    def release_model_sessions(self) -> None:
+        """Free every detector/pose ORT session (pool + workers) before a cache mutation.
 
-        Called when models are downloaded/removed while the engine is running so
-        live ORT sessions for now-stale files are freed: the pool drops its
-        cached models and each worker force-reloads, rebuilding from the fresh
-        cache (the new model, or live-preview-only when files were removed).
+        Windows refuses to delete/replace a model file while onnxruntime still has
+        it open, so the UI calls this *before* downloading/removing files: the pool
+        drops its shared models and each worker synchronously releases its refs,
+        then a ``gc.collect()`` finalises the sessions so the OS handles are gone.
+        POSIX tolerates unlink-while-open, which is why the old (release-after)
+        order only failed on Windows.
         """
         if not self._running:
             return
@@ -595,12 +607,47 @@ class Supervisor:
         with self._lock:
             workers = list(self._workers.values())
         for worker in workers:
+            release = getattr(worker, "release_inference_models", None)
+            if callable(release):
+                try:
+                    # Block briefly so the inference thread actually drops its refs
+                    # before we GC + mutate; the file-op retry covers any residual.
+                    release(wait=1.0)
+                except Exception:  # noqa: BLE001
+                    log.debug("worker model release failed", exc_info=True)
+        import gc
+
+        gc.collect()
+
+    def rebuild_model_sessions(self) -> None:
+        """Rebuild detector/pose from the (now-refreshed) cache after a mutation.
+
+        Each worker force-reloads from the shared pool — yielding the new model, or
+        live-preview-only when the files were removed.  Pairs with
+        :meth:`release_model_sessions`.
+        """
+        if not self._running:
+            return
+        with self._lock:
+            workers = list(self._workers.values())
+        for worker in workers:
             reload = getattr(worker, "reload_inference_models", None)
             if callable(reload):
                 try:
                     reload()
                 except Exception:  # noqa: BLE001
                     log.debug("worker model reload failed", exc_info=True)
+
+    def apply_model_cache_changed(self) -> None:
+        """Release then rebuild model sessions in one call (release-before-rebuild).
+
+        Retained for callers that mutate the cache and only signal afterward; the
+        Model Manager now calls :meth:`release_model_sessions` *before* the mutation
+        and :meth:`rebuild_model_sessions` after, which is what makes delete/replace
+        work on Windows.
+        """
+        self.release_model_sessions()
+        self.rebuild_model_sessions()
 
     def _on_update_config(self, cmd: UpdateCameraConfigCmd) -> None:
         worker = self._get(cmd.camera_id)
@@ -688,9 +735,12 @@ class Supervisor:
         if hw.intra_op_threads:
             threads = int(hw.intra_op_threads)
         else:
-            # Spread cores across cameras so several workers don't oversubscribe.
+            # Spread cores across cameras so several workers don't oversubscribe,
+            # and reserve one core for the capture/UI/paint threads so inference
+            # can't starve the very pipeline that feeds it (keeps preview smooth).
             cores = os.cpu_count() or 4
-            threads = max(1, cores // max(1, camera_count))
+            usable = max(1, cores - 1)
+            threads = max(1, usable // max(1, camera_count))
         os.environ["AUTOPTZ_ORT_INTRA_THREADS"] = str(threads)
 
         log.info(

--- a/autoptz/ui/engine_client.py
+++ b/autoptz/ui/engine_client.py
@@ -194,13 +194,11 @@ class EngineClient(QObject):
         self._startup_started_cameras: int = 0
         self._startup_total_cameras: int = 0
         self._startup_missing_components: list[str] = []
-        self._features: dict[str, bool] = {
-            "detection": True,
-            "tracking": True,
-            "face_recognition": True,
-            "pose": True,
-            "reid": True,
-        }
+        # Persisted ML-subsystem switches.  A service the operator turns off stays
+        # off across launches AND is never built at spin-up (see startEngine →
+        # prime_features), so disabling e.g. detection genuinely reclaims the
+        # CPU/RAM that model would cost — not just hides its output.
+        self._features: dict[str, bool] = self._load_persisted_features()
         self._detector_model_tier: str = "auto"
         self._model_download_lock = threading.Lock()
         self._model_download_running = False
@@ -393,7 +391,17 @@ class EngineClient(QObject):
             total=len(self._model.camera_ids()),
             missing=self._missing_optional_components(promptable_only=True),
         )
-        self.resetFeatureOverrides()
+        # Seed the supervisor with the persisted feature switches BEFORE it spawns
+        # workers, so a disabled service is never built at spin-up (the worker
+        # gates model construction on these flags).  Without priming, workers
+        # would spawn all-on and only release disabled models afterward — paying
+        # the build cost we are trying to avoid.
+        prime = getattr(self._supervisor, "prime_features", None)
+        if callable(prime):
+            try:
+                prime(self.features())
+            except Exception:  # noqa: BLE001
+                log.debug("prime_features failed", exc_info=True)
         try:
             try:
                 self._supervisor.start(
@@ -416,15 +424,19 @@ class EngineClient(QObject):
             return
 
         self._engine_running = True
-        self._engine_ep = ""
+        # Seed the EP label from a cheap probe so the status bar shows something
+        # immediately (and even when detection is disabled and no detector session
+        # is ever built).  Telemetry later corrects this to the session's real EP.
+        self._engine_ep = self._probe_best_ep()
         if self.autoDownloadModels() and not self._detector_tier_cached(self._detector_model_tier):
             switch = getattr(self._supervisor, "switch_detector_model_tier", None)
             self._download_detector_tier_async(
                 self._detector_model_tier,
                 switch if callable(switch) else None,
             )
-        # Push the session-only global feature switches. They intentionally reset
-        # to all-on at launch; Services-panel disables are testing overrides only.
+        # Re-assert the persisted feature switches to every worker (belt-and-
+        # suspenders alongside prime_features, and the source of truth for any
+        # worker that spawned before priming).
         try:
             self._enqueue(SetFeaturesCmd(camera_id=None, features=self.features()))
         except Exception:  # noqa: BLE001
@@ -970,42 +982,65 @@ class EngineClient(QObject):
         """Toggle the camera's on-screen (OSD) menu (safe no-op when unsupported)."""
         self._enqueue(PtzMenuCmd(camera_id=camera_id))
 
-    # ── session-only feature switches + detector model tier ────────────────────
+    # ── persisted feature switches + detector model tier ───────────────────────
 
     _FEATURE_KEYS = ("detection", "tracking", "face_recognition", "pose", "reid")
+    _FEATURE_SETTING_KEY = "feature_overrides"
+
+    def _load_persisted_features(self) -> dict[str, bool]:
+        """Load the saved feature switches (all default True) from the store."""
+        raw: Any = {}
+        try:
+            if self._store is not None:
+                raw = self._store.get_setting(self._FEATURE_SETTING_KEY, {}) or {}
+        except Exception:  # noqa: BLE001
+            raw = {}
+        if not isinstance(raw, dict):
+            raw = {}
+        return {k: bool(raw.get(k, True)) for k in self._FEATURE_KEYS}
+
+    def _persist_features(self) -> None:
+        try:
+            if self._store is not None:
+                self._store.set_setting(self._FEATURE_SETTING_KEY, dict(self._features))
+        except Exception:  # noqa: BLE001
+            log.debug("persist feature overrides failed", exc_info=True)
 
     @Slot(result="QVariant")
     def features(self) -> dict[str, bool]:
-        """Return the session-only ML-subsystem switches (all default True).
+        """Return the persisted ML-subsystem switches (all default True).
 
         Keys: ``detection``, ``tracking``, ``face_recognition``, ``pose``,
-        ``reid``.  These do not persist; they are testing/runtime overrides that
-        reset each launch.
+        ``reid``.  These persist across launches; a disabled service is also
+        skipped at spin-up so it costs no CPU/RAM (see :meth:`startEngine`).
         """
         return {k: bool(self._features.get(k, True)) for k in self._FEATURE_KEYS}
 
     @Slot(str, bool)
     def setFeatureEnabled(self, name: str, enabled: bool) -> None:
-        """Enable/disable a global subsystem for this session.
+        """Enable/disable a global subsystem and persist the choice.
 
         ``name`` is one of ``detection``/``tracking``/``face_recognition``/``pose``/
         ``reid``.  Broadcasts a :class:`SetFeaturesCmd` so every worker turns the
-        subsystem on/off without a restart, but does not persist across launches.
+        subsystem on/off without a restart, and saves it so it sticks next launch
+        (and the model isn't rebuilt at spin-up).
         """
         if name not in self._FEATURE_KEYS:
             return
         feats = self.features()
         feats[name] = bool(enabled)
         self._features = feats
+        self._persist_features()
         self._enqueue(SetFeaturesCmd(camera_id=None, features=feats))
         self.featuresChanged.emit()
 
     @Slot()
     def resetFeatureOverrides(self) -> None:
-        """Reset all session-only module testing overrides to enabled."""
+        """Re-enable every subsystem and persist the reset."""
         feats = {k: True for k in self._FEATURE_KEYS}
         changed = feats != self._features
         self._features = feats
+        self._persist_features()
         if self._engine_running:
             self._enqueue(SetFeaturesCmd(camera_id=None, features=feats))
         if changed:
@@ -1065,22 +1100,47 @@ class EngineClient(QObject):
         self.optionalComponentsChanged.emit()
 
     @Slot()
-    def applyModelCacheChanged(self) -> None:
-        """Unload + rebuild live models after the on-disk model cache changed.
+    def releaseModelSessions(self) -> None:
+        """Free the engine's ORT sessions *before* the model cache is mutated.
 
-        Called by the Model Manager after a download/removal so a running engine
-        frees the ORT sessions for now-stale files and rebuilds from the fresh
-        cache — no manual restart needed.  Safe no-op when the engine is stopped.
+        The Model Manager calls this prior to a download/removal so onnxruntime
+        no longer holds the files open — without it, delete/replace fails on
+        Windows (POSIX tolerates unlink-while-open, which is why it only broke
+        there).  Safe no-op when the engine is stopped.
         """
         sup = self._supervisor
         if self._engine_running and sup is not None:
-            fn = getattr(sup, "apply_model_cache_changed", None)
+            fn = getattr(sup, "release_model_sessions", None)
             if callable(fn):
                 try:
                     fn()
                 except Exception:  # noqa: BLE001
-                    log.debug("apply_model_cache_changed failed", exc_info=True)
+                    log.debug("release_model_sessions failed", exc_info=True)
+
+    @Slot()
+    def rebuildModelSessions(self) -> None:
+        """Rebuild live models from the fresh cache after a download/removal."""
+        sup = self._supervisor
+        if self._engine_running and sup is not None:
+            fn = getattr(sup, "rebuild_model_sessions", None)
+            if callable(fn):
+                try:
+                    fn()
+                except Exception:  # noqa: BLE001
+                    log.debug("rebuild_model_sessions failed", exc_info=True)
         self.optionalComponentsChanged.emit()
+
+    @Slot()
+    def applyModelCacheChanged(self) -> None:
+        """Unload + rebuild live models after the on-disk model cache changed.
+
+        Release-then-rebuild in one call, retained for any caller that mutates the
+        cache and only signals afterward.  The Model Manager instead brackets the
+        mutation with :meth:`releaseModelSessions` / :meth:`rebuildModelSessions`.
+        Safe no-op when the engine is stopped.
+        """
+        self.releaseModelSessions()
+        self.rebuildModelSessions()
 
     def _detector_tier_cached(self, tier: str) -> bool:
         try:
@@ -1093,6 +1153,24 @@ class EngineClient(QObject):
         except Exception:  # noqa: BLE001
             log.debug("detector tier cache check failed", exc_info=True)
         return False
+
+    @staticmethod
+    def _probe_best_ep() -> str:
+        """Best available EP label (e.g. ``CoreMLExecutionProvider``) without a session.
+
+        A cheap probe so the UI can show an EP before any model loads; returns ""
+        if onnxruntime can't be queried.  Telemetry overrides this with the EP the
+        live session actually used.
+        """
+        try:
+            from autoptz.engine.runtime.inference import get_best_ep
+
+            # Store the short label (UI strips this too, defensively) so the
+            # property is "CoreML"/"CPU"/"Dml", never the raw provider id.
+            return str(get_best_ep().value).replace("ExecutionProvider", "")
+        except Exception:  # noqa: BLE001 — never block engine start on a probe
+            log.debug("EP probe failed", exc_info=True)
+            return ""
 
     @staticmethod
     def _detector_tier_label(tier: str) -> str:
@@ -1885,6 +1963,17 @@ class EngineClient(QObject):
                     row["state"] = "ok" if state == "active" else "warn"
                     row["detail"] = detail
                     break
+        pose = _find_runtime_row(getattr(live, "runtime_services", []), "pose")
+        if pose is not None and str(_obj_field(pose, "state", "")) == "failed":
+            # The model is on disk but the live session failed to load (common on
+            # Windows when the EP/onnx can't initialise).  Surface it as a warning
+            # with the reason so it stops reading as a healthy "ok" pose row.
+            reason = str(_obj_field(pose, "detail", "")) or "pose model present but failed to load"
+            for row in rows:
+                if row.get("key") == "pose":
+                    row["state"] = "warn"
+                    row["detail"] = reason
+                    break
         switch = getattr(live, "model_switch", None)
         if switch is not None:
             state = str(_obj_field(switch, "state", "idle"))
@@ -2029,6 +2118,14 @@ class EngineClient(QObject):
     def _on_telemetry_main(self, msg: TelemetryMsg) -> None:
         """Apply telemetry on the owning (GUI) thread."""
         self._model.update_telemetry(msg)
+        # Surface the actually-active inference EP reported by the worker.  Without
+        # this the status bar / camera-info panel showed a blank EP on every
+        # platform (the value was only ever seeded empty); the user noticed it on
+        # Windows.  Telemetry carries the real provider (CoreML / Dml / CPU / …).
+        ep = (getattr(msg, "ep", "") or "").replace("ExecutionProvider", "")
+        if ep and ep != self._engine_ep:
+            self._engine_ep = ep
+            self.engineStateChanged.emit()
         self.telemetryUpdated.emit(msg.camera_id)
 
     # ── identity ingest (called from engine/worker thread) ─────────────────────

--- a/autoptz/ui/widgets/camera_tile.py
+++ b/autoptz/ui/widgets/camera_tile.py
@@ -546,9 +546,12 @@ class CameraTile(QWidget):
     # ── painting ───────────────────────────────────────────────────────────────
 
     def paintEvent(self, _event: Any) -> None:  # noqa: N802
+        # Render hints are scoped, not global: the live video is drawn with the
+        # cheap (nearest) transform — bilinear SmoothPixmapTransform on every
+        # repaint of every tile was a real GUI-thread cost and motion hides the
+        # difference — while Antialiasing + smoothing are turned on only for the
+        # HUD shapes/text below, where crispness actually matters.
         p = QPainter(self)
-        p.setRenderHint(QPainter.RenderHint.Antialiasing)
-        p.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
         w, h = self.width(), self.height()
 
         # backing: real frames cover this, while no-signal/letterbox areas still
@@ -571,6 +574,11 @@ class CameraTile(QWidget):
             p.drawImage(self._painted_rect, img, QRectF(img.rect()))
         else:
             self._painted_rect = QRectF(0, 0, w, h)
+
+        # From here on we draw vector shapes + text (no-signal label, HUD) — enable
+        # smoothing only for those, not the per-frame video blit above.
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        p.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
 
         if not streaming:
             self._paint_no_signal(p, health)

--- a/autoptz/ui/widgets/dialogs/model_manager.py
+++ b/autoptz/ui/widgets/dialogs/model_manager.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 MODEL_SETUP_REMINDER_KEY = "model_setup_dont_remind"
 _DETECTOR_TIERS = (
-    ("auto", "Auto"),
+    ("auto", "Auto (recommended)"),
     ("fast", "Fast"),
     ("balanced", "Balanced"),
     ("medium", "Accurate"),
@@ -68,12 +68,22 @@ class _ModelTask(QObject):
     progress = Signal(str, int, int)
     done = Signal(object)
 
-    def __init__(self, action: str, keys: list[str]) -> None:
+    def __init__(self, action: str, keys: list[str], client: Any | None = None) -> None:
         super().__init__()
         self._action = action
         self._keys = list(keys)
+        self._client = client
 
     def run(self) -> None:
+        # Free the engine's ORT sessions BEFORE touching the files: Windows refuses
+        # to delete/replace a model onnxruntime still has open (POSIX tolerates it,
+        # which is why this only failed on Windows).  Rebuild from the fresh cache
+        # afterwards so a removed model stops drawing and a new one is picked up.
+        if self._client is not None:
+            try:
+                self._client.releaseModelSessions()
+            except Exception:  # noqa: BLE001
+                log.debug("releaseModelSessions before model op failed", exc_info=True)
         try:
             from autoptz.engine.runtime.models import default_manager
 
@@ -100,6 +110,12 @@ class _ModelTask(QObject):
                     "error": str(exc),
                 }
             ]
+        finally:
+            if self._client is not None:
+                try:
+                    self._client.rebuildModelSessions()
+                except Exception:  # noqa: BLE001
+                    log.debug("rebuildModelSessions after model op failed", exc_info=True)
         self.done.emit({"action": self._action, "results": results})
 
 
@@ -275,12 +291,23 @@ class ModelManagerDialog(QDialog):
         for value, label in _DETECTOR_TIERS:
             self._tier.addItem(label, value)
         self._tier.setToolTip(
-            "The detector model tier the engine uses (Auto maps to Fast). Tiers "
-            "that aren't downloaded are greyed out unless automatic download is on."
+            "Which detector the engine runs. Auto always works — it uses the Fast "
+            "model that ships with AutoPTZ and automatically upgrades to a heavier "
+            "tier once you download one. Fast/Balanced/Accurate trade speed for "
+            "accuracy; a tier you haven't downloaded is greyed out unless automatic "
+            "download is on."
         )
         self._tier.currentIndexChanged.connect(self._on_tier_changed)
         tier_row.addWidget(self._tier, 1)
         root.addLayout(tier_row)
+
+        tier_help = QLabel(
+            "Auto is recommended and always available — no download required. "
+            "Pick a specific tier only if you want to pin speed vs. accuracy."
+        )
+        tier_help.setWordWrap(True)
+        tier_help.setStyleSheet(f"color: {T.CURRENT.subtext};")
+        root.addWidget(tier_help)
 
         self._auto_download = QCheckBox(
             "Automatically download a missing detector tier when I select it"
@@ -412,16 +439,20 @@ class ModelManagerDialog(QDialog):
                 value = str(combo.itemData(i) or "auto")
                 key = _detector_key_for_tier(value)
                 cached = bool(self._status_by_key.get(key, {}).get("cached"))
-                if cached:
-                    suffix = ""
+                # Auto always works: it falls back to the bundled Fast model and
+                # upgrades automatically, so it is never greyed or flagged missing.
+                if value == "auto":
+                    suffix, enabled = "", True
+                elif cached:
+                    suffix, enabled = "", True
                 elif auto_dl:
-                    suffix = "  (will download)"
+                    suffix, enabled = "  (will download)", True
                 else:
-                    suffix = "  (not downloaded)"
+                    suffix, enabled = "  (not downloaded)", False
                 combo.setItemText(i, labels.get(value, value) + suffix)
                 item = model.item(i) if hasattr(model, "item") else None
                 if item is not None:
-                    item.setEnabled(cached or auto_dl)
+                    item.setEnabled(enabled)
         finally:
             combo.blockSignals(False)
 
@@ -596,7 +627,7 @@ class ModelManagerDialog(QDialog):
         if not keys:
             QMessageBox.information(self, "No Models Selected", "Select at least one model first.")
             return
-        task = _ModelTask(action, keys)
+        task = _ModelTask(action, keys, client=self._client)
         self._task = task
         task.progress.connect(self._on_progress)
         task.done.connect(self._on_done)
@@ -641,13 +672,9 @@ class ModelManagerDialog(QDialog):
             for row in results
             if isinstance(row, dict) and row.get("state") not in {"ok", "removed"}
         ]
-        # Tell a running engine to unload + rebuild from the new cache state so a
-        # removed model stops drawing boxes (and a freshly downloaded one is
-        # picked up) without a manual restart.
-        try:
-            self._client.applyModelCacheChanged()
-        except Exception:  # noqa: BLE001
-            log.debug("applyModelCacheChanged failed", exc_info=True)
+        # Model sessions were released before the mutation and rebuilt after (see
+        # _ModelTask.run), so a removed model has already stopped drawing boxes and
+        # a freshly downloaded one is live — no manual restart, no extra reload here.
         self._refresh_rows()
         if failed:
             detail = "\n".join(

--- a/autoptz/ui/widgets/services_panel.py
+++ b/autoptz/ui/widgets/services_panel.py
@@ -41,31 +41,36 @@ _STATE_LABEL = {
     "off": "OFF",
 }
 
-# Session-only ML-subsystem testing overrides: (feature key, label, help text). The keys match
+# Persisted ML-subsystem switches: (feature key, label, help text). The keys match
 # ``EngineClient.features()`` / ``setFeatureEnabled`` exactly.
 _FEATURE_TOGGLES = (
     (
         "detection",
         "Person detection",
-        "Testing override: disable person detection for this session. It resets on launch.",
+        "Disable person detection. Your choice persists and the detector model is "
+        "skipped at startup (no CPU/RAM) until you re-enable it.",
     ),
     (
         "tracking",
         "Tracking",
-        "Testing override: disable track association/PTZ follow for this session.",
+        "Disable track association / PTZ follow. Persists across launches.",
     ),
     (
         "face_recognition",
         "Face recognition",
-        "Testing override: disable face matching for this session.",
+        "Disable face matching. Persists; the face model is skipped at startup while off.",
     ),
-    ("pose", "Pose", "Testing override: disable pose keypoints for this session."),
+    (
+        "pose",
+        "Pose",
+        "Disable pose keypoints. Persists; the pose model is skipped at startup while off.",
+    ),
     (
         "reid",
         "ReID (stable tracking)",
         "Master switch for appearance ReID. A camera only uses it when this is on "
         "AND its tracking Mode is “Stable”. Turn it off to disable Stable mode "
-        "everywhere. Resets to on each launch.",
+        "everywhere. Persists across launches.",
     ),
 )
 
@@ -155,15 +160,26 @@ class ServicesPanel(QWidget):
             head.addWidget(b)
         root.addLayout(head)
 
-        # ── testing controls ──────────────────────────────────────────────────
+        # ── module switches ─────────────────────────────────────────────────────
         root.addWidget(hline())
-        root.addWidget(section_label("Testing Overrides"))
+        mod_head = QHBoxLayout()
+        mod_head.setSpacing(6)
+        mod_head.addWidget(section_label("Modules"))
+        mod_head.addStretch(1)
+        self._enable_all = QPushButton("Enable all")
+        self._enable_all.setToolTip("Re-enable every module (clears your disabled choices).")
+        self._enable_all.setMinimumHeight(22)
+        self._enable_all.clicked.connect(lambda: _safe(self._client.resetFeatureOverrides, None))
+        mod_head.addWidget(self._enable_all)
+        root.addLayout(mod_head)
         self._hint = QLabel(
-            "Services start enabled every launch. Disable modules here only for testing."
+            "Your choices persist across launches. A disabled module is skipped at "
+            "startup, so it uses no CPU or memory until you turn it back on."
         )
         self._hint.setWordWrap(True)
         root.addWidget(self._hint)
 
+        self._feature_pills: dict[str, QLabel] = {}
         for key, label, tip in _FEATURE_TOGGLES:
             row = QHBoxLayout()
             row.setSpacing(6)
@@ -175,6 +191,10 @@ class ServicesPanel(QWidget):
             row.addWidget(box)
             row.addWidget(HelpBadge(tip))
             row.addStretch(1)
+            pill = QLabel()
+            pill.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._feature_pills[key] = pill
+            row.addWidget(pill, 0, Qt.AlignmentFlag.AlignVCenter)
             root.addLayout(row)
         _connect(client, "featuresChanged", self._refresh_features)
 
@@ -281,7 +301,7 @@ class ServicesPanel(QWidget):
     # ── testing overrides ────────────────────────────────────────────────────
 
     def _on_feature_toggled(self, key: str, checked: bool) -> None:
-        """Apply a session-only subsystem switch live via the client."""
+        """Apply + persist a subsystem switch live via the client."""
         _safe(lambda: self._client.setFeatureEnabled(key, checked), None)
 
     def _refresh_features(self) -> None:
@@ -304,7 +324,9 @@ class ServicesPanel(QWidget):
         if label is None:
             return
         tier = str(_safe(lambda: self._client.getDetectorModelTier(), "auto") or "auto")
-        label.setText(f"Active detector model: {_DETECTOR_TIER_LABELS.get(tier, tier.title())}")
+        name = _DETECTOR_TIER_LABELS.get(tier, tier.title())
+        suffix = " — always available, no download needed" if tier == "auto" else ""
+        label.setText(f"Active detector model: {name}{suffix}")
 
     def _refresh_optional_components(self) -> None:
         summary = getattr(self, "_model_summary", None)
@@ -342,20 +364,27 @@ class ServicesPanel(QWidget):
             )
         summary.setText(line)
 
-    def _apply_component_gating(self) -> None:
-        """Grey out toggles whose required model/component is missing.
+    def _set_feature_pill(self, pill: QLabel, text: str, color: str) -> None:
+        """Render a small state badge (ON / OFF / UNAVAILABLE) next to a toggle."""
+        pill.setText(text)
+        pill.setStyleSheet(
+            f"color: {color}; border: 1px solid {color}; border-radius: 8px;"
+            f" padding: 1px 8px; font-size: {T.fs(9)}px; font-weight: 700;"
+        )
 
-        Purely **visual** — the engine's feature flags are left untouched.  The
-        detector is pool-authoritative now: a missing model means nothing runs
-        and nothing is drawn regardless of the flag, so there is no UI/engine
-        desync to "enforce".  Just as importantly, NOT forcing the flag off means
-        detection (and the downstream features) resume automatically once the
-        model is downloaded again, instead of sticking off — which previously
-        left the engine quiet after a delete→re-download.  The checked state
-        mirrors the engine via :meth:`_refresh_features`.
+    def _apply_component_gating(self) -> None:
+        """Show each module's state clearly and grey what its model can't back.
+
+        A status pill makes off-vs-on unmistakable at a glance (the bare checkbox
+        was too subtle): ``ON`` (green) when enabled and backed, ``OFF`` (muted)
+        when the operator disabled it, ``UNAVAILABLE`` (amber) when the required
+        model/component is missing.  Gating stays **visual** — the engine's flags
+        are untouched, so a module resumes automatically once its model is back;
+        the checked state mirrors the engine via :meth:`_refresh_features`.
         """
         states = self._component_states
         detector_ok = states.get("detector", "ok") == "ok"
+        pills = getattr(self, "_feature_pills", {})
         # Everything visible flows from the body detector: face/pose/ReID only
         # label or stabilise *already-detected* bodies, and tracking follows them —
         # so without the detector model nothing is drawn no matter the individual
@@ -371,16 +400,24 @@ class ServicesPanel(QWidget):
             needs_detector = feature != "detection"
             available = own_ok and (detector_ok or not needs_detector)
             box.setEnabled(available)
-            if available:
-                box.setToolTip(self._feature_tips.get(feature, ""))
+            pill = pills.get(feature)
+            if not available:
+                if needs_detector and not detector_ok:
+                    reason = "Requires the detector model — open Manage Models to download it."
+                elif component is not None:
+                    reason = f"Disabled until the {component} component is available."
+                else:
+                    reason = "Unavailable."
+                box.setToolTip(f"{self._feature_tips.get(feature, '')}\n\n{reason}")
+                if pill is not None:
+                    self._set_feature_pill(pill, "UNAVAILABLE", T.WARNING)
                 continue
-            if needs_detector and not detector_ok:
-                reason = "Requires the detector model — open Manage Models to download it."
-            elif component is not None:
-                reason = f"Disabled until the {component} component is available."
-            else:
-                reason = "Unavailable."
-            box.setToolTip(f"{self._feature_tips.get(feature, '')}\n\n{reason}")
+            box.setToolTip(self._feature_tips.get(feature, ""))
+            if pill is not None:
+                if box.isChecked():
+                    self._set_feature_pill(pill, "ON", T.TRACKING)
+                else:
+                    self._set_feature_pill(pill, "OFF", T.CURRENT.muted)
 
     def _open_model_manager(self) -> None:
         from autoptz.ui.widgets.dialogs.model_manager import ModelManagerDialog

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1284,6 +1284,46 @@ class TestEngineLifecycleApi:
             c.stopEngine()
         assert c.engineEp == ""
 
+    def test_engine_ep_updates_from_telemetry(self, qapp) -> None:
+        # Regression: engineEp must reflect the worker-reported EP, not stay blank.
+        from autoptz.engine.runtime.messages import TelemetryMsg
+
+        c = _make_client(qapp)
+        cid = c.addCamera("usb://0", "X")
+        c.drain_commands()
+        c.set_supervisor(_make_supervisor(c, factory=FakeWorker))
+        c.startEngine()
+        try:
+            c.push_telemetry(TelemetryMsg(camera_id=cid, seq=1, ep="CoreMLExecutionProvider"))
+            assert c.engineEp == "CoreML"
+        finally:
+            c.stopEngine()
+
+    def test_model_task_releases_sessions_before_mutating(self, qapp, monkeypatch) -> None:
+        # Regression: on Windows the model file can't be deleted/replaced while
+        # onnxruntime holds it open, so sessions must be released BEFORE the
+        # on-disk mutation and rebuilt after.
+        import autoptz.engine.runtime.models as models_mod
+        from autoptz.ui.widgets.dialogs.model_manager import _ModelTask
+
+        order: list[str] = []
+
+        class _SpyClient:
+            def releaseModelSessions(self):
+                order.append("release")
+
+            def rebuildModelSessions(self):
+                order.append("rebuild")
+
+        class _FakeManager:
+            def remove_app_models(self, *, keys=None):
+                order.append("remove")
+                return [{"name": "m", "state": "removed", "path": "", "size": "0", "error": ""}]
+
+        monkeypatch.setattr(models_mod, "default_manager", lambda: _FakeManager())
+        _ModelTask("remove", ["detector_fast"], client=_SpyClient()).run()
+        assert order == ["release", "remove", "rebuild"]
+
     def test_engine_state_changed_emitted(self, qapp) -> None:
         c = _make_client(qapp)
         c.set_supervisor(_make_supervisor(c, factory=FakeWorker))


### PR DESCRIPTION
## Summary
Addresses the Windows model bugs, the blank inference-EP, pose "downloaded but not working", service-state clarity, Auto-tier guarantees, and the first round of per-camera performance work.

### Windows model delete/download
- Release in-process ORT sessions **before** mutating the model cache (release→gc→mutate→rebuild). POSIX tolerates unlink-while-open; Windows refused while onnxruntime held the file → "file in use". Engine is in-process, so releasing first fixes it.
- Split `Supervisor.apply_model_cache_changed` into `release_model_sessions()` / `rebuild_model_sessions()`; new worker `release_inference_models(wait=)`; `_ModelTask` does release→mutate→rebuild.
- Retry-on-lock helpers (`_replace_with_retry`/`_unlink_with_retry`) for residual antivirus/handle locks.

### Inference EP reporting
- `engineEp` was a dead value (only ever `""`). Now seeded from `get_best_ep()` at start and updated from `TelemetryMsg.ep` in `_on_telemetry_main` (stored as the short label).

### Pose "downloaded but not working"
- `PoseEstimator.error` → `InferencePool.pose_error` → worker `failed`+reason row, overlaid as a warn in `serviceStatus`; `pose_status()` now recognises the bundled model.

### Service state: persist + skip-load
- Feature switches **persist** (`ConfigStore` key `feature_overrides`) and a disabled service is **never built at spin-up** (`Supervisor.prime_features` before workers spawn) — the real CPU/RAM win. Clear **ON / OFF / UNAVAILABLE** pills + "Enable all" reset.

### Auto detector tier
- Never greyed / "NOT DOWNLOADED" (self-heals to bundled); the pool falls back to the bundled default if a selected heavier tier goes missing so the engine never goes silent.

### Performance — Phase A
- `camera_tile` paints live video with the cheap transform (smoothing/AA only for HUD/text); supervisor ORT thread split reserves a core for capture/UI.

## Phased perf roadmap (follow-up PRs)
- **Phase B:** NDI BGR-direct, zero-copy/throttled preview, PTZ fast-path (manual nudge bypasses the inference tick), decoupled capture/inference/display fps.
- **Phase C:** GPU render path, hardware decode, process-per-camera isolation, predictive PTZ.

## Tests
- 790 pass. The only failures are `test_ui.py`'s `offscreen` Qt-plugin tests — environmental (a bare `QApplication` with `QT_QPA_PLATFORM=offscreen` fails identically with none of this code involved).
- +2 regression tests: `engineEp` populates from telemetry; `_ModelTask` releases sessions before mutating files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)