### PR TITLE
perf(ptz): low-latency manual PTZ path (Phase B)

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -415,6 +415,13 @@ class CameraWorker:
         self._inference_thread: threading.Thread | None = None
         self._cmd_lock = threading.Lock()
         self._cmd_queue: deque[tuple[str, Any]] = deque()
+        # Manual PTZ commands (nudge/home/menu) ride a SEPARATE queue drained on
+        # the capture thread, not the inference thread — a detect+track pass can
+        # be tens of ms, so routing the joystick/D-pad through it added that lag
+        # to every move.  The capture loop ticks at the full source rate, so this
+        # makes manual PTZ feel immediate (the NDI-Studio-like responsiveness).
+        self._ptz_cmd_lock = threading.Lock()
+        self._ptz_cmd_queue: deque[tuple[str, Any]] = deque()
 
         # ── async pipeline handoff ───────────────────────────────────────────────
         # The capture thread reads frames, pushes the live preview, and emits
@@ -706,18 +713,20 @@ class CameraWorker:
             return bool(self._features.get(name, True))
 
     def ptz_home(self) -> None:
-        """Drive the PTZ backend to its optical home position (queued command)."""
-        with self._cmd_lock:
-            self._cmd_queue.append(("ptz_home", None))
+        """Drive the PTZ backend to its optical home position (low-latency path)."""
+        with self._ptz_cmd_lock:
+            self._ptz_cmd_queue.append(("ptz_home", None))
 
     def ptz_menu(self) -> None:
-        """Toggle the camera's on-screen-display (OSD) menu (queued command)."""
-        with self._cmd_lock:
-            self._cmd_queue.append(("ptz_menu", None))
+        """Toggle the camera's on-screen-display (OSD) menu (low-latency path)."""
+        with self._ptz_cmd_lock:
+            self._ptz_cmd_queue.append(("ptz_menu", None))
 
     def ptz_nudge(self, pan: float, tilt: float, zoom: float) -> None:
-        with self._cmd_lock:
-            self._cmd_queue.append(("ptz_nudge", (float(pan), float(tilt), float(zoom))))
+        # Fast path: drained on the capture thread so the move isn't delayed by an
+        # in-flight inference pass (see _drain_ptz_commands / _ptz_cmd_queue).
+        with self._ptz_cmd_lock:
+            self._ptz_cmd_queue.append(("ptz_nudge", (float(pan), float(tilt), float(zoom))))
 
     def set_target_fps(self, fps: float) -> None:
         """Change capture/detection pacing **live** (no engine restart)."""
@@ -747,6 +756,31 @@ class CameraWorker:
                 self._apply_command(kind, payload)
             except Exception:  # noqa: BLE001
                 log.warning("camera_id=%s command %s failed", self.camera_id, kind, exc_info=True)
+
+    def _drain_ptz_commands(self) -> None:
+        """Apply manual PTZ commands on the CAPTURE thread for minimal latency.
+
+        Drives the backend under ``_ptz_lock`` (serialised with the auto loop and
+        the telemetry position read), at the full capture tick — so the joystick/
+        D-pad moves the camera without waiting on the inference thread.  Safe
+        no-op until the backend is built (``_drive_ptz_nudge`` guards ``None``).
+        """
+        with self._ptz_cmd_lock:
+            if not self._ptz_cmd_queue:
+                return
+            pending = list(self._ptz_cmd_queue)
+            self._ptz_cmd_queue.clear()
+        for kind, payload in pending:
+            try:
+                with self._ptz_lock:
+                    if kind == "ptz_nudge":
+                        self._drive_ptz_nudge(*payload)
+                    elif kind == "ptz_home":
+                        self._ptz_home()
+                    elif kind == "ptz_menu":
+                        self._ptz_menu()
+            except Exception:  # noqa: BLE001
+                log.warning("camera_id=%s ptz cmd %s failed", self.camera_id, kind, exc_info=True)
 
     def _apply_command(self, kind: str, payload: Any) -> None:
         if kind == "enable_tracking":
@@ -2120,6 +2154,10 @@ class CameraWorker:
             self._emit_telemetry(tracks=[], health=last_health, last_error=last_error)
 
         while not self._stop_event.is_set():
+            # Apply any pending manual PTZ first thing each tick (low-latency path,
+            # independent of inference) so the joystick/D-pad feels immediate.
+            self._drain_ptz_commands()
+
             tick_t0 = time.perf_counter()
             frame: NDArray[np.uint8] | None = None
             if self._source is not None:

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -704,6 +704,23 @@ class TestCameraWorker:
             worker.stop()
         assert backend.stopped is True
 
+    def test_ptz_nudge_uses_low_latency_queue(self, qapp) -> None:
+        # Manual nudges must ride the dedicated PTZ queue (drained on the capture
+        # thread), NOT the inference command queue — otherwise a heavy detect+track
+        # pass adds tens of ms of lag to every joystick move.
+        from autoptz.engine.camera_worker import CameraWorker
+
+        worker = CameraWorker(
+            "ptzcam01abcd",
+            _camera_config("ptzcam01abcd"),
+            lambda m: None,
+            frame_source=FakeFrameSource(),
+        )
+        worker.ptz_nudge(0.5, 0.0, 0.0)
+        assert len(worker._ptz_cmd_queue) == 1
+        assert worker._ptz_cmd_queue[0][0] == "ptz_nudge"
+        assert len(worker._cmd_queue) == 0
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CameraWorker._track_error — region-aware aim point


### PR DESCRIPTION
## Summary
Phase B of the performance roadmap. Manual PTZ commands (nudge / home / menu) previously rode the **inference** command queue, so a detect+track pass (tens of ms) added latency to every joystick/D-pad move. They now ride a dedicated `_ptz_cmd_queue` drained on the **capture thread** at the full source tick (under `_ptz_lock`, serialised with the auto loop and the telemetry position read) — making manual PTZ feel immediate, the NDI-Studio-like responsiveness requested.

- Auto-tracking still suspends during the manual-override window (unchanged).
- Backend access stays serialised via `_ptz_lock`.

## Deferred (need hardware/visual validation)
The remaining Phase B ingest/render items — NDI BGR-direct (skip per-frame `cvtColor`), zero-copy preview, dynamic shm dims — change pixel paths and need NDI cameras + a visual quality check, so they're not merged blind here.

## Tests
- `+test_ptz_nudge_uses_low_latency_queue` (verifies routing to the fast-path queue, not the inference queue).
- `test_ptz_nudge_drives_injected_backend` still green (nudge reaches the backend via the capture thread).
- 197 worker/PTZ/pacing tests pass; mypy (CI scope) + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)