### PR TITLE
perf(ptz): opt-in acceleration-aware predictive lead (Phase C)

### DIFF
--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -194,6 +194,12 @@ class PTZConfig(BaseModel, frozen=True):
     # the target's measured velocity, so the camera anticipates motion instead of
     # always chasing where the subject *was* (which reads as laggy following).
     lead_time_s: float = Field(default=0.15, ge=0.0, le=1.0)
+    # Second-order (acceleration) prediction gain, 0..1.  When > 0 the lead also
+    # extrapolates the change in the subject's velocity (½·a·lead²·gain), so the
+    # camera anticipates a subject *starting* or *stopping* — sharper "leading"
+    # feel — instead of only constant-velocity motion.  Opt-in (default 0 = off):
+    # acceleration is noisier than velocity, so it wants per-rig tuning before use.
+    predict_accel_gain: float = Field(default=0.0, ge=0.0, le=1.0)
     # Aim smoothing 0..1 (0 = most responsive, 1 = smoothest).  Maps to the
     # one-euro filter's minimum cutoff inside the controller; 0.5 ≈ the original.
     aim_smoothing: float = Field(default=0.5, ge=0.0, le=1.0)

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -59,6 +59,7 @@ _OSC_DECAY = 0.6  # per-tick score decay (lower = forgets flips faster)
 _OSC_GAIN = 0.6  # how hard the score damps the command
 _OSC_MAX = 4.0  # score ceiling (caps the strongest damping)
 _LEAD_MAX_S = 0.8  # hard cap on total lead time (avoid runaway extrapolation)
+_ACCEL_LEAD_MAX = 0.3  # hard cap on the acceleration-term contribution to the aim
 # Framing-box hold hysteresis: once parked inside the box, the subject must move
 # this fraction *beyond* the box edge before following resumes — kills the
 # start/stop chatter when they hover right on the boundary.
@@ -219,6 +220,11 @@ class PTZController:
         self._prev_ex_f: float = 0.0
         self._prev_ey_f: float = 0.0
         self._last_t: float = -1.0
+
+        # Previous (ego-corrected) target velocity, for the opt-in acceleration
+        # term of the predictive lead (predict_accel_gain > 0).
+        self._prev_vx: float = 0.0
+        self._prev_vy: float = 0.0
 
         # PID integral accumulators (anti-windup clamped in _pd_step)
         self._int_ex: float = 0.0
@@ -447,6 +453,8 @@ class PTZController:
                 self._apply_smoothing()
                 self._prev_ex_f = 0.0
                 self._prev_ey_f = 0.0
+                self._prev_vx = 0.0
+                self._prev_vy = 0.0
                 self._last_t = -1.0
                 # Fresh acquire: drop accumulated integral + hunting history so a
                 # stale wind-up or flip score can't kick the new target.
@@ -531,6 +539,17 @@ class PTZController:
             if lead > 0.0:
                 ex += vx * lead
                 ey += vy * lead
+                # Opt-in 2nd-order term: anticipate a subject starting/stopping by
+                # projecting the *change* in velocity (½·a·lead²·gain), clamped so a
+                # noisy acceleration spike can't fling the aim off the subject.
+                g = float(getattr(cfg, "predict_accel_gain", 0.0))
+                if g > 0.0 and self._last_t >= 0.0:
+                    dt_v = max(t - self._last_t, 1e-3)
+                    half_l2 = 0.5 * lead * lead * g
+                    ax = (vx - self._prev_vx) / dt_v
+                    ay = (vy - self._prev_vy) / dt_v
+                    ex += _clamp(ax * half_l2, -_ACCEL_LEAD_MAX, _ACCEL_LEAD_MAX)
+                    ey += _clamp(ay * half_l2, -_ACCEL_LEAD_MAX, _ACCEL_LEAD_MAX)
 
         # 2. one-euro filter
         ex_f = self._filt_ex(ex, t)
@@ -614,6 +633,9 @@ class PTZController:
 
         self._prev_ex_f = ex_f
         self._prev_ey_f = ey_f
+        # Store the raw measured velocity (not the hold-zeroed locals) so the next
+        # tick's acceleration term reflects real subject dynamics.
+        self._prev_vx, self._prev_vy = p.velocity
         self._last_t = t
 
         return pan_cmd, tilt_cmd

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -281,6 +281,25 @@ class TestControllerMath:
         pan_ff, _, _ = ctrl_ff.step((0.2, 0.0), (0.5, 0.0), 0.45, True, t=0.0)
         assert pan_ff > pan_noff
 
+    def test_predict_accel_gain_off_by_default(self) -> None:
+        # Phase C predictive lead must be opt-in: default config keeps it disabled.
+        assert _cfg().predict_accel_gain == 0.0
+
+    def test_acceleration_prediction_anticipates_when_enabled(self) -> None:
+        # An accelerating subject (velocity rising tick-to-tick): with
+        # predict_accel_gain the controller projects the change in velocity and
+        # commands a larger move than the velocity-only (gain=0) controller.  The
+        # first tick only seeds the previous velocity (accel term skipped).
+        c0 = PTZController(MockBackend(), _cfg(kv=0.0, safe_zone_enabled=False))
+        c1 = PTZController(
+            MockBackend(), _cfg(kv=0.0, safe_zone_enabled=False, predict_accel_gain=1.0)
+        )
+        c0.step((0.4, 0.0), (0.3, 0.0), 0.45, True, t=0.0)
+        c1.step((0.4, 0.0), (0.3, 0.0), 0.45, True, t=0.0)
+        pan0, _, _ = c0.step((0.4, 0.0), (0.8, 0.0), 0.45, True, t=0.1)
+        pan1, _, _ = c1.step((0.4, 0.0), (0.8, 0.0), 0.45, True, t=0.1)
+        assert pan1 > pan0
+
     def test_deadzone_suppresses_small_error(self) -> None:
         ctrl = PTZController(MockBackend(), _cfg(kp=0.6, deadzone_x=0.1, deadzone_y=0.1))
         pan, tilt, _ = ctrl.step((0.05, 0.08), (0.0, 0.0), 0.45, True, t=0.0)


### PR DESCRIPTION
## Summary
Phase C, contained slice. The controller already leads the aim by `velocity × lead_time`; this adds an **optional** second-order term that projects the *change* in the subject's velocity (`½·a·lead²·gain`), so the camera anticipates a subject **starting or stopping** — a sharper "leading" feel toward the requested real-time tracking.

- **Opt-in** via `PTZConfig.predict_accel_gain` (default `0.0` = off, behaviour unchanged).
- Hard-clamped (`_ACCEL_LEAD_MAX`) so a noisy acceleration spike can't fling the aim off the subject.
- Uses the existing **ego-corrected** velocity, so it leads world motion, not the camera's own pan.

## Deferred (need hardware validation)
The heavier Phase C items — **GPU render path**, **hardware-accelerated decode**, **process-per-camera isolation** — change platform/runtime architecture and require live multi-camera + visual validation. Per the project's own "validate on hardware" guidance, they are **not merged blind**; they remain the documented roadmap for a hands-on session.

## Tests
- `+test_predict_accel_gain_off_by_default` (opt-in contract).
- `+test_acceleration_prediction_anticipates_when_enabled` (accelerating subject → larger command when enabled).
- 85 PTZ controller tests pass; mypy (CI scope) + ruff clean; full suite 793 pass (only the 4 environmental `offscreen` UI tests fail locally — they pass on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)