### PR TITLE
perf(ui): halve preview-frame copies with Format_BGR888

### DIFF
--- a/autoptz/ui/frames.py
+++ b/autoptz/ui/frames.py
@@ -28,10 +28,17 @@ log = logging.getLogger(__name__)
 
 
 def bgr_to_qimage(bgr: np.ndarray) -> QImage:  # type: ignore[type-arg]
-    """Convert a BGR numpy frame to an owned RGB :class:`QImage`."""
-    rgb = bgr[..., ::-1].copy()  # BGR→RGB; copy gives data ownership
-    h, w = rgb.shape[:2]
-    img = QImage(rgb.data, w, h, w * 3, QImage.Format.Format_RGB888)
+    """Convert a BGR numpy frame to an owned :class:`QImage` that renders correctly.
+
+    Wraps the BGR bytes directly with ``Format_BGR888`` (no channel-reversal copy)
+    and ``.copy()`` to detach from the numpy buffer — halving the per-frame
+    GUI-thread copy work versus reversing BGR→RGB first.  The rendered pixels are
+    identical; only the redundant copy is gone.
+    """
+    if not bgr.flags["C_CONTIGUOUS"]:
+        bgr = np.ascontiguousarray(bgr)  # no-op for the normal (already-packed) path
+    h, w = bgr.shape[:2]
+    img = QImage(bgr.data, w, h, w * 3, QImage.Format.Format_BGR888)
     return img.copy()  # detach from the numpy buffer
 
 

--- a/tests/test_preview_fix.py
+++ b/tests/test_preview_fix.py
@@ -33,6 +33,42 @@ def _cleanup_shm(name: str) -> None:
             pass
 
 
+# ── bgr_to_qimage: color correctness (Format_BGR888, no reversal copy) ─────────
+
+
+class TestBgrToQImage:
+    """The preview converter must render BGR frames with correct colors — the
+    Format_BGR888 fast path must not swap the red/blue channels."""
+
+    def test_red_and_blue_channels_not_swapped(self) -> None:
+        from autoptz.ui.frames import bgr_to_qimage
+
+        # Pure red in BGR is (B=0, G=0, R=255) in the third channel.
+        red_bgr = np.zeros((4, 6, 3), dtype=np.uint8)
+        red_bgr[:, :, 2] = 255
+        red_img = bgr_to_qimage(red_bgr)
+        assert (red_img.width(), red_img.height()) == (6, 4)
+        rc = red_img.pixelColor(0, 0)
+        assert (rc.red(), rc.green(), rc.blue()) == (255, 0, 0)
+
+        # Pure blue in BGR is the first channel.
+        blue_bgr = np.zeros((4, 6, 3), dtype=np.uint8)
+        blue_bgr[:, :, 0] = 255
+        bc = bgr_to_qimage(blue_bgr).pixelColor(3, 2)
+        assert (bc.red(), bc.green(), bc.blue()) == (0, 0, 255)
+
+    def test_non_contiguous_input_is_handled(self) -> None:
+        from autoptz.ui.frames import bgr_to_qimage
+
+        # A non-contiguous (sliced) view must still render correctly.
+        base = np.zeros((4, 12, 3), dtype=np.uint8)
+        base[:, :, 1] = 255  # green
+        view = base[:, ::2, :]  # non-contiguous
+        assert not view.flags["C_CONTIGUOUS"]
+        gc = bgr_to_qimage(view).pixelColor(0, 0)
+        assert (gc.red(), gc.green(), gc.blue()) == (0, 255, 0)
+
+
 # ── The self-healing provider regression ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Continues the deferred "zero-copy/throttled preview" perf work. `bgr_to_qimage` did **two** full-frame copies per preview frame on the GUI thread — a BGR→RGB channel-reversal copy, then a `.copy()` detach. Qt6 has `Format_BGR888`, so the reversal copy is unnecessary: wrap the BGR bytes directly and only `.copy()` to detach. **One fewer full-frame copy per preview frame, per camera**, with identical rendered pixels.

The expensive conversion only runs on a *new* frame (idle ticks already reuse the cached `QImage`), so this directly trims the per-frame GUI-thread cost in the services-disabled baseline.

## Tests
- `+TestBgrToQImage`: red/blue channels are **not** swapped (the key correctness property of `Format_BGR888` vs RGB reversal), and non-contiguous input is handled.
- Full suite 795 pass; ruff clean. (The 4 `test_ui.py` `offscreen` failures are environmental on the dev mac and pass on Linux CI.)

## Still deferred (need live-hardware/visual validation)
Process-per-camera isolation, GPU/QRhi render path, hardware-accelerated decode, NDI receiver-format changes — these alter runtime/platform/pixel paths and shouldn't be merged without on-hardware verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)