### PR TITLE
fix(ui): keep USB camera menu fresh via background hotplug poll

### DIFF
--- a/autoptz/engine/discovery/usb.py
+++ b/autoptz/engine/discovery/usb.py
@@ -304,6 +304,24 @@ def _enumerate_macos_cameras() -> list[dict] | None:
     return cameras
 
 
+def usb_enumeration_is_cheap() -> bool:
+    """True when camera enumeration is a cheap metadata listing (no device opens).
+
+    macOS + AVFoundation lists devices via a discovery session *without* opening
+    them, so it is safe for the UI to poll periodically for hotplug.  The
+    cross-platform fallback (:func:`_probed_fallback_cameras`) instead OPENS each
+    ``VideoCapture`` index to confirm a real frame — far too costly to poll — so
+    callers should refresh on-demand only when this returns ``False``.
+    """
+    if platform.system() != "Darwin":
+        return False
+    try:
+        import AVFoundation  # type: ignore  # noqa: F401, PLC0415
+    except Exception:  # noqa: BLE001 — PyObjC / framework not installed
+        return False
+    return True
+
+
 def enumerate_cameras() -> list[dict]:
     """Return discovered video cameras as ``{name, unique_id, index, is_continuity}``.
 

--- a/autoptz/ui/engine_client.py
+++ b/autoptz/ui/engine_client.py
@@ -1775,6 +1775,21 @@ class EngineClient(QObject):
 
     # ── source discovery ──────────────────────────────────────────────────────
 
+    @Slot(result=bool)
+    def usbEnumerationCheap(self) -> bool:
+        """True when USB enumeration is cheap enough to poll for hotplug.
+
+        macOS/AVFoundation lists devices without opening them; the cross-platform
+        fallback opens each index, so the UI should only background-poll when this
+        is True (otherwise it refreshes the camera menu on-demand).
+        """
+        try:
+            from autoptz.engine.discovery.usb import usb_enumeration_is_cheap
+
+            return bool(usb_enumeration_is_cheap())
+        except Exception:  # noqa: BLE001
+            return False
+
     @Slot(result="QVariantList")
     def scanUSBCameras(self) -> list[dict[str, Any]]:
         """Return USB cameras as ``[{name, uri, unique_id, in_use, source_label}]``.

--- a/autoptz/ui/widgets/main_window.py
+++ b/autoptz/ui/widgets/main_window.py
@@ -134,6 +134,19 @@ class MainWindow(QMainWindow):
         QTimer.singleShot(0, self._refresh_usb_async)
         QTimer.singleShot(0, self._refresh_ndi_async)
 
+        # Keep the USB cache hot in the background so plugging/unplugging a camera
+        # is reflected the FIRST time the menu is opened — previously the menu showed
+        # the stale cache and only kicked off a scan on open, so a hotplug took a few
+        # reopens to appear.  Only when enumeration is cheap (macOS/AVFoundation lists
+        # devices without opening them); the cross-platform fallback opens each device,
+        # which is too costly to poll, so there we keep the on-open refresh.
+        self._usb_poll_timer: QTimer | None = None
+        if _safe(lambda: self._client.usbEnumerationCheap(), False):
+            self._usb_poll_timer = QTimer(self)
+            self._usb_poll_timer.setInterval(3000)
+            self._usb_poll_timer.timeout.connect(self._refresh_usb_async)
+            self._usb_poll_timer.start()
+
     # ── section title bars ──────────────────────────────────────────────────────
 
     def _install_section_title_bars(self) -> None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -264,6 +264,26 @@ class TestEnumerateCameras:
         assert enumerate_cameras() == []
 
 
+class TestEnumerationIsCheap:
+    """``usb_enumeration_is_cheap`` gates the UI's background hotplug poll: only
+    the AVFoundation listing (no device opens) is cheap enough to poll."""
+
+    def test_non_darwin_is_never_cheap(self, monkeypatch) -> None:
+        monkeypatch.setattr(usb_mod.platform, "system", lambda: "Linux")
+        assert usb_mod.usb_enumeration_is_cheap() is False
+
+    def test_darwin_with_avfoundation_is_cheap(self, monkeypatch) -> None:
+        monkeypatch.setattr(usb_mod.platform, "system", lambda: "Darwin")
+        # AVFoundation importable → cheap (stub the module so it "imports").
+        monkeypatch.setitem(sys.modules, "AVFoundation", types.ModuleType("AVFoundation"))
+        assert usb_mod.usb_enumeration_is_cheap() is True
+
+    def test_darwin_without_avfoundation_is_not_cheap(self, monkeypatch) -> None:
+        monkeypatch.setattr(usb_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setitem(sys.modules, "AVFoundation", None)  # import → ImportError
+        assert usb_mod.usb_enumeration_is_cheap() is False
+
+
 # ── NDIDiscovery ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Fixes the reported bug: after plugging/unplugging a USB camera you had to open the Cameras menu **a few times** before the checkmark updated.

**Root cause:** `_populate_cameras_menu` rendered the *stale* `_usb_devices_cache` on open and only then kicked off a background scan — whose result (`_on_usb_refresh`) updated the cache but never repopulated the already-open menu. So you always saw the *previous* scan's result.

**Fix:** a 3s background refresh keeps `_usb_devices_cache` current, so the menu is correct the first time it's opened. Gated on `usb_enumeration_is_cheap()`:
- **macOS/AVFoundation** lists devices *without opening them* → safe to poll.
- The cross-platform fallback **opens each `VideoCapture` index** → too costly to poll, so there the existing on-open refresh is kept (no regression).

## Tests
- `+TestEnumerationIsCheap`: non-Darwin → not cheap; Darwin + AVFoundation → cheap; Darwin without AVFoundation → not cheap.
- Full suite 798 pass; ruff + mypy (CI scope) clean. (The 4 `test_ui.py` `offscreen` failures are environmental on the dev mac; they pass on Linux CI.)

## Note on the inference-drop observation
The "~50% inference dropped frames" log is expected, not a bug: the inference thread processes the *latest* captured frame and drops intermediates (latest-wins), so ~50% skip = inference running at ~half the capture rate, which is normal for detection on CPU/CoreML and fine for tracking (the PTZ controller uses velocity lead between detections). The adaptive quality policy already relaxes detector cadence under load, and the log is gated at ≥50% so that's the floor you see. Happy to profile detect-vs-track time on your hardware in a follow-up if you want to push inference fps higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)