### PR TITLE
perf(engine): capture reconnect backoff + clearer source-run camera message

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -117,6 +117,15 @@ _HARVEST_COOLDOWN_S = 2.0
 # spamming a line per missed frame.
 _DROP_LOG_INTERVAL_S = 10.0
 
+# Capture idle/reconnect backoff: a stalled, offline, or permission-denied source
+# returns no frame, and a flat 10 ms retry then spins the capture thread at ~100 Hz
+# (real, measurable idle CPU per camera).  Retry fast for a short window to ride out
+# a transient decode miss on a healthy source, then ramp the sleep up to a cap so a
+# truly dead source costs almost nothing — resetting instantly when a frame returns
+# (so recovery still happens within ~one cap interval).
+_RECONNECT_FAST_RETRIES = 20  # ~0.2 s of 10 ms retries before backing off
+_RECONNECT_BACKOFF_MAX_S = 0.5  # sleep cap for a sustained no-frame source
+
 
 def _async_appearance_enabled() -> bool:
     """Run face + ReID on their own thread (default on; AUTOPTZ_ASYNC_APPEARANCE=0 off)."""
@@ -2142,6 +2151,7 @@ class CameraWorker:
         self._inference_thread.start()
 
         last_telemetry = 0.0
+        miss_streak = 0  # consecutive no-frame reads, drives the reconnect backoff
         fps_window_start = time.monotonic()
         fps_window_frames = 0
         self._next_drop_log_t = time.monotonic() + _DROP_LOG_INTERVAL_S
@@ -2187,6 +2197,7 @@ class CameraWorker:
                 self._record_frame_dims(frame)
                 self._push_frame(frame)
                 fps_window_frames += 1
+                miss_streak = 0  # got a frame → drop back to fast retries
                 last_health = HealthState.OK
                 last_error = None
 
@@ -2218,9 +2229,17 @@ class CameraWorker:
                 )
                 last_telemetry = now
 
-            # Small idle sleep when there is no frame to avoid a busy-spin.
+            # No frame: retry fast briefly (transient decode miss on a healthy
+            # source), then back off a sustained no-frame source up to the cap so a
+            # stalled/offline/denied camera doesn't spin the capture thread.
             if frame is None:
-                self._stop_event.wait(timeout=0.01)
+                miss_streak += 1
+                if miss_streak <= _RECONNECT_FAST_RETRIES:
+                    wait = 0.01
+                else:
+                    over = miss_streak - _RECONNECT_FAST_RETRIES
+                    wait = min(_RECONNECT_BACKOFF_MAX_S, 0.01 + 0.05 * over)
+                self._stop_event.wait(timeout=wait)
 
         # Shutdown: wake + join the inference thread, then release resources.
         self._frame_ready.set()

--- a/autoptz/ui/app.py
+++ b/autoptz/ui/app.py
@@ -97,10 +97,26 @@ def _start_engine_after_macos_camera_preflight(client: object, bridge: object | 
         return
 
     def _report_blocked(reason: str) -> None:
-        message = (
-            f"Camera access is {reason}. Grant access in System Settings > "
-            "Privacy & Security > Camera, then restart AutoPTZ."
-        )
+        if getattr(sys, "frozen", False):
+            # Packaged app: it has the camera-usage entitlement and can be granted
+            # directly in the Camera privacy pane.
+            message = (
+                f"Camera access is {reason}. Grant access in System Settings > "
+                "Privacy & Security > Camera, then restart AutoPTZ."
+            )
+        else:
+            # Source run: the bare Python binary has no NSCameraUsageDescription, so
+            # macOS can't show the consent prompt for it — it attributes camera use
+            # to the *terminal* that launched AutoPTZ. Grant camera access to that
+            # terminal app (Terminal / iTerm / VS Code / PyCharm …), or run the
+            # packaged AutoPTZ app, then restart.
+            message = (
+                "Camera access is unavailable when running AutoPTZ from source: the "
+                "Python interpreter can't request camera permission directly. Grant "
+                "camera access to the terminal app you launched it from (System "
+                "Settings > Privacy & Security > Camera), or use the packaged AutoPTZ "
+                "app, then restart."
+            )
         log.warning(message)
         try:
             client.errorOccurred.emit(message)  # type: ignore[attr-defined]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -132,7 +132,9 @@ class TestMacOSCameraPreflight:
         app_mod._start_engine_after_macos_camera_preflight(client, object())
 
         assert client.starts == 0
-        assert "Camera access is denied" in client.errors[-1]
+        # Message wording differs for packaged ("denied") vs source runs ("from
+        # source"), but both must surface a camera-access error and not start.
+        assert "Camera access" in client.errors[-1]
 
     def test_requests_access_then_starts_when_granted(self, monkeypatch) -> None:
         import autoptz.ui.app as app_mod


### PR DESCRIPTION
## Summary
Two small fixes found while profiling per-camera CPU on a Mac.

### Capture reconnect backoff
A stalled / offline / permission-denied source returns no frame, and the flat **10 ms** retry spun the capture thread at ~100 Hz — measurable idle CPU per camera. Now it retries fast briefly (rides out a transient decode miss on a healthy source) then ramps the sleep to a **0.5 s cap**, resetting instantly on the next good frame (recovery stays within ~one cap interval).

### Clearer source-run camera message (macOS)
Running from source, the bare Python interpreter has no `NSCameraUsageDescription`, so macOS **can't show the camera consent prompt** — it attributes camera use to the launching terminal (which is why launching from a camera-granted Terminal/VS Code/PyCharm works, but a bare `python -m autoptz` under another parent does not). The blocked message now explains this (grant the terminal, or use the packaged app) instead of the misleading "denied", which only applies to the packaged build.

## Tests
- Relaxed the camera-preflight test to accept either the packaged ("denied") or source-run wording.
- Full suite green except the 4 pre-existing `test_ui.py` `offscreen`-Qt failures (environmental on the dev mac; pass on Linux CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)