### PR TITLE
fix(ui): visible log-row selection + smoother collapsible-section animation

### DIFF
--- a/autoptz/ui/widgets/common.py
+++ b/autoptz/ui/widgets/common.py
@@ -27,6 +27,7 @@ log = logging.getLogger(__name__)
 
 _QWIDGETSIZE_MAX = (1 << 24) - 1
 _ANIM_MS = 125
+_COLLAPSE_MS = 180  # expand/collapse height anim — a touch longer reads as smoother
 
 
 def animate_widget_visibility(widget: QWidget, visible: bool, *, duration: int = _ANIM_MS) -> None:
@@ -295,9 +296,14 @@ class CollapsibleGroup(QWidget):
         self._content.setMaximumHeight(_QWIDGETSIZE_MAX if expanded else 0)
         outer.addWidget(self._content)
         self._height_anim = QPropertyAnimation(self._content, b"maximumHeight", self)
-        self._height_anim.setDuration(_ANIM_MS)
+        self._height_anim.setDuration(_COLLAPSE_MS)
         self._height_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
         self._height_anim.finished.connect(self._on_anim_finished)
+        # Drive minimumHeight in lockstep with the animated maximumHeight so the
+        # widget is pinned to ONE exact height each frame.  Animating only the max
+        # (min stayed 0) let the layout pick any in-between height per frame, which
+        # is what made the expand/collapse stutter and jump.
+        self._height_anim.valueChanged.connect(self._on_anim_value)
 
     def _natural_height(self) -> int:
         """Accurate expanded height, including height-for-width (word-wrap) content.
@@ -313,6 +319,11 @@ class CollapsibleGroup(QWidget):
             hfw = lay.heightForWidth(width)
         return max(1, self._content.sizeHint().height(), hfw)
 
+    def _on_anim_value(self, value: int) -> None:
+        # Pin the widget to exactly the animated height (min == max) so the parent
+        # layout can't reflow it to an in-between size mid-frame.
+        self._content.setMinimumHeight(int(value))
+
     def _on_toggle(self, checked: bool) -> None:
         self._expanded = checked
         self._toggle.setArrowType(Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow)
@@ -321,17 +332,22 @@ class CollapsibleGroup(QWidget):
         current = max(0, self._content.height() if self._content.isVisible() else 0)
         if checked:
             self._content.setVisible(True)
-            self._content.setMaximumHeight(current)
-            self._height_anim.setStartValue(current)
-            self._height_anim.setEndValue(natural)
+            start = current
+            end = natural
         else:
             start = current or min(self._content.maximumHeight(), natural)
-            self._content.setMaximumHeight(start)
-            self._height_anim.setStartValue(start)
-            self._height_anim.setEndValue(0)
+            end = 0
+        # Pin both bounds to the start height so the first frame doesn't pop.
+        self._content.setMinimumHeight(start)
+        self._content.setMaximumHeight(start)
+        self._height_anim.setStartValue(start)
+        self._height_anim.setEndValue(end)
         self._height_anim.start()
 
     def _on_anim_finished(self) -> None:
+        # Release the min floor so static content can size naturally; the content is
+        # already at its natural height, so releasing max to MAX causes no jump.
+        self._content.setMinimumHeight(0)
         if self._expanded:
             self._content.setVisible(True)
             self._content.setMaximumHeight(_QWIDGETSIZE_MAX)

--- a/autoptz/ui/widgets/common.py
+++ b/autoptz/ui/widgets/common.py
@@ -306,18 +306,28 @@ class CollapsibleGroup(QWidget):
         self._height_anim.valueChanged.connect(self._on_anim_value)
 
     def _natural_height(self) -> int:
-        """Accurate expanded height, including height-for-width (word-wrap) content.
+        """True expanded content height at the current width — side-effect-free.
 
         ``sizeHint().height()`` is width-independent and under-reports wrapped
-        labels, so the expand animation would stop short and then *snap* to the
-        real height on finish — the "jump".  Prefer the layout's
-        ``heightForWidth`` at the content's actual width when available."""
-        lay = self._content.layout()
-        width = self._content.width() or self.width()
-        hfw = -1
+        labels, so animating to it leaves a gap that *snaps* on finish (the "end
+        pop").  Lift the height clamp, activate the layout, and read the real
+        (height-for-width) size, then restore the clamp — all synchronously, so
+        nothing renders mid-measure.
+        """
+        content = self._content
+        prev_min, prev_max = content.minimumHeight(), content.maximumHeight()
+        content.setMinimumHeight(0)
+        content.setMaximumHeight(_QWIDGETSIZE_MAX)
+        lay = content.layout()
+        if lay is not None:
+            lay.activate()
+        width = content.width() or self.width()
+        h = content.sizeHint().height()
         if lay is not None and lay.hasHeightForWidth() and width > 0:
-            hfw = lay.heightForWidth(width)
-        return max(1, self._content.sizeHint().height(), hfw)
+            h = max(h, lay.heightForWidth(width))
+        content.setMinimumHeight(prev_min)
+        content.setMaximumHeight(prev_max)
+        return max(1, h)
 
     def _on_anim_value(self, value: int) -> None:
         # Pin the widget to exactly the animated height (min == max) so the parent
@@ -328,18 +338,19 @@ class CollapsibleGroup(QWidget):
         self._expanded = checked
         self._toggle.setArrowType(Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow)
         self._height_anim.stop()
-        natural = self._natural_height()
-        current = max(0, self._content.height() if self._content.isVisible() else 0)
         if checked:
+            # Clip to 0 BEFORE showing so the content never flashes at full height
+            # for a frame (the "start pop"); then measure the true target and grow.
+            self._content.setMinimumHeight(0)
+            self._content.setMaximumHeight(0)
             self._content.setVisible(True)
-            start = current
-            end = natural
+            start, end = 0, self._natural_height()
         else:
-            start = current or min(self._content.maximumHeight(), natural)
+            start = max(0, self._content.height() if self._content.isVisible() else 0)
+            start = start or self._natural_height()
             end = 0
-        # Pin both bounds to the start height so the first frame doesn't pop.
-        self._content.setMinimumHeight(start)
-        self._content.setMaximumHeight(start)
+            self._content.setMinimumHeight(start)
+            self._content.setMaximumHeight(start)
         self._height_anim.setStartValue(start)
         self._height_anim.setEndValue(end)
         self._height_anim.start()

--- a/autoptz/ui/widgets/logs_panel.py
+++ b/autoptz/ui/widgets/logs_panel.py
@@ -295,6 +295,11 @@ class LogsPanel(QWidget):
             f" selection-background-color: {T.SELECTION}; selection-color: {pal.text};"
             f" outline: none; }}"
             f"QTableView::item {{ background-color: {pal.surface}; color: {pal.text}; }}"
+            # A per-item background overrides selection-background-color, so selected
+            # rows looked unselected (the "selection does nothing" bug) — restate the
+            # highlight explicitly for :selected so a click/drag is actually visible.
+            f"QTableView::item:selected {{ background-color: {T.SELECTION};"
+            f" color: {pal.text}; }}"
         )
         self._table.viewport().setStyleSheet(f"background-color: {pal.surface};")
         self._table.viewport().update()


### PR DESCRIPTION
## Log-row selection (confirmed broken live)
Drove the running app: selecting log rows (click / shift-click) showed **no highlight at all** — the "select rows → Copy Selected" feature looked dead.

**Root cause:** the log table set `QTableView::item { background-color: surface }`, which **overrides** `selection-background-color`, so selected rows kept the normal background. The copy logic was already correct — selection was just invisible.

**Fix:** add an explicit `QTableView::item:selected { background-color: SELECTION }` rule so a click/shift-drag actually shows.

## Collapsible-section animation (Properties panel) — janky/jumps
Only `maximumHeight` was animated while `minimumHeight` stayed 0, so the layout could size the content to *anything* between 0 and max each frame — that's the stutter/jump.

**Fix:** drive `minimumHeight` in lockstep with the animated `maximumHeight` (the widget is pinned to one exact height per frame), release the min floor cleanly on finish (no end-snap), and lengthen the duration 125 → 180 ms for a smoother read.

## Testing
- The selection bug was **reproduced in the live app** (zoomed screenshot: no highlight on selected rows).
- The animation is sub-second, so screenshots can't capture it — it needs a human to watch. **Please verify the look in a run** before merging (run the dev build from PyCharm, select a camera, expand/collapse the Properties sections; and select log rows to confirm the highlight).
- Existing tests pass (only the 4 `offscreen`-plugin UI tests fail on the dev mac; they pass on Linux CI).

Not merging until you've eyeballed the animation and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)