### PR TITLE
perf(engine): stop spinning up follow-only work when nothing is tracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ follow [Semantic Versioning](https://semver.org/).
   returns no frames, the capture loop backs its retry off (up to 0.5 s) instead of
   polling at ~100 Hz, while a manual PTZ command still wakes it instantly so the
   joystick stays responsive during a reconnect.
+- **Tracking-off cameras spin up less work** — the inference loop ran camera
+  ego-motion (per-frame optical flow) and woke the appearance thread on *every*
+  frame even with nothing to track. Both are now gated on what's actually on
+  (ego-motion only while tracking, appearance only with Face/ReID on), so a camera
+  with services off no longer burns a chunk of a core computing values nothing
+  reads. Measured on a synthetic 1080p60 source with services off, the worker's
+  idle CPU dropped from ~47% to ~29% of one core, with no change to follow
+  behaviour.
 - **Experimental: process-per-camera mode** (`AUTOPTZ_PROCESS_PER_CAMERA=1`, off by
   default) — runs each camera in its own OS process for true multi-core
   parallelism (GIL bypass) under many cameras, instead of threads in the UI

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -2318,7 +2318,11 @@ class CameraWorker:
                 # control loop.  Shared target/identity state is serialised by
                 # _appearance_lock inside those methods; the hot loop re-reads the
                 # (possibly rebound) target via _apply_target_lock each tick.
-                self._publish_appearance_input(frame, tracks, now, fid)
+                # Only publish when there's actually appearance work — otherwise we
+                # wake the appearance thread every frame for two passes that both
+                # immediately no-op with face + ReID off (pure idle overhead).
+                if self._feature("face_recognition") or self._feature("reid"):
+                    self._publish_appearance_input(frame, tracks, now, fid)
             else:
                 # Inline (sync) path — preserves the exact original ordering.
                 self._maybe_reid_recover(tracks, frame, now)
@@ -2342,7 +2346,17 @@ class CameraWorker:
             # feed-forward follows the subject's world motion, not the frame shift.
             # (_ptz_last_cmd still holds the *previous* command here — exactly the
             # one that produced this frame's observed shift.)
-            self._update_ego_motion(tracks, frame, now)
+            #
+            # Ego-motion runs sparse optical flow on every frame, but its only
+            # consumer is the aim-velocity feed-forward, which only runs while
+            # actively following (tracking on).  With tracking off it burned ~15%
+            # of a core computing a value nothing reads — so gate it on tracking
+            # and keep the estimate zeroed otherwise.
+            if self._feature("tracking"):
+                self._update_ego_motion(tracks, frame, now)
+            elif self._ego_source != "none":
+                self._ego_vel = (0.0, 0.0)
+                self._ego_source = "none"
 
             # Auto PTZ control (suspended during a manual-override window).  Lock
             # the backend so a concurrent telemetry position read can't interleave.

--- a/tests/test_idle_gating.py
+++ b/tests/test_idle_gating.py
@@ -1,0 +1,129 @@
+"""Idle-headroom gating: the inference loop must not do follow-only work when
+nothing is being tracked.
+
+Two per-frame costs used to run unconditionally, every frame, even with all AI
+services off:
+
+* ``_update_ego_motion`` — sparse optical flow whose *only* consumer is the
+  PTZ aim-velocity feed-forward (runs only while actively following).  It burned
+  ~15% of a core computing a value nothing read when tracking was off.
+* the async appearance hand-off — woke the appearance thread every frame to run
+  ReID + face passes that both immediately no-op with face + ReID off.
+
+These tests pin the gates: ego-motion runs iff ``tracking`` is on, and the
+appearance hand-off fires iff ``face_recognition`` or ``reid`` is on.  Models are
+never built (``_build_inference_stacks`` is stubbed) so the loop body runs with a
+cheap synthetic frame source.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+
+from autoptz.config.models import CameraConfig, SourceConfig
+from autoptz.engine.camera_worker import CameraWorker
+
+_ALL_OFF = {
+    "detection": False,
+    "tracking": False,
+    "face_recognition": False,
+    "pose": False,
+    "reid": False,
+}
+
+
+class _PacedSource:
+    """A trivial frame source paced ~120 fps so the loop gets fresh frame ids."""
+
+    def __init__(self) -> None:
+        self._frame = np.zeros((120, 160, 3), dtype=np.uint8)
+
+    def open(self) -> bool:
+        return True
+
+    def read(self) -> np.ndarray:
+        time.sleep(1 / 120)
+        return self._frame
+
+    def close(self) -> None:
+        pass
+
+
+def _worker() -> CameraWorker:
+    cfg = CameraConfig(
+        id="cam-idle-1234abcd",
+        name="Idle",
+        source=SourceConfig(type="usb", address="usb://0"),
+    )
+    w = CameraWorker(
+        "cam-idle-1234abcd", cfg, on_telemetry=lambda _m: None, frame_source=_PacedSource()
+    )
+    # Never build real models — we only care about the per-frame gating.
+    w._build_inference_stacks = lambda: None  # type: ignore[method-assign]
+    return w
+
+
+def _run_briefly(w: CameraWorker, seconds: float = 0.6) -> None:
+    w.start()
+    try:
+        time.sleep(seconds)
+    finally:
+        w.stop()
+        time.sleep(0.1)
+
+
+def test_egomotion_skipped_when_tracking_off() -> None:
+    w = _worker()
+    calls: list[int] = []
+    w._update_ego_motion = lambda *a, **k: calls.append(1)  # type: ignore[method-assign]
+    w.set_features(dict(_ALL_OFF))
+    _run_briefly(w)
+    assert calls == [], f"ego-motion ran {len(calls)}x with tracking off — idle headroom regressed"
+
+
+def test_egomotion_runs_when_tracking_on() -> None:
+    w = _worker()
+    ran = threading.Event()
+    w._update_ego_motion = lambda *a, **k: ran.set()  # type: ignore[method-assign]
+    feats = dict(_ALL_OFF)
+    feats["tracking"] = True
+    w.set_features(feats)
+    w.start()
+    try:
+        assert ran.wait(2.0), (
+            "ego-motion never ran with tracking on — feed-forward would lose ego compensation"
+        )
+    finally:
+        w.stop()
+        time.sleep(0.1)
+
+
+def test_appearance_not_published_when_face_and_reid_off() -> None:
+    w = _worker()
+    pubs: list[int] = []
+    w._publish_appearance_input = lambda *a, **k: pubs.append(1)  # type: ignore[method-assign]
+    w.set_features(dict(_ALL_OFF))
+    _run_briefly(w)
+    assert pubs == [], (
+        f"appearance thread woken {len(pubs)}x with face+ReID off — idle headroom regressed"
+    )
+
+
+def test_appearance_published_when_face_on() -> None:
+    w = _worker()
+    pub = threading.Event()
+    w._publish_appearance_input = lambda *a, **k: pub.set()  # type: ignore[method-assign]
+    feats = dict(_ALL_OFF)
+    feats["face_recognition"] = True
+    w.set_features(feats)
+    w.start()
+    try:
+        assert pub.wait(2.0), (
+            "appearance input never published with face on — identity would never run"
+        )
+    finally:
+        w.stop()
+        time.sleep(0.1)


### PR DESCRIPTION
## What

The inference loop ran two per-frame costs **unconditionally — every frame, even with all AI services off**:

- `_update_ego_motion()` runs sparse optical flow, but its only consumer is the PTZ aim-velocity feed-forward, which runs only while actively following. With tracking off it burned ~15% of a core computing a value nothing reads.
- the async appearance hand-off woke the appearance thread every frame to run ReID + face passes that both immediately no-op with Face + ReID off.

This gates ego-motion on the `tracking` feature and the appearance hand-off on `face_recognition`/`reid`.

## Why

Diagnosing why AutoPTZ uses more CPU than NDI Monitor for one camera with services off — the worker pipeline copies turned out cheap (~3% machine), but this follow-only machinery was running for nothing. This is the "spun-up headroom" half of that investigation; helps **every** camera type.

## Impact (measured)

Synthetic 1080p60 source, all services off: worker idle CPU **47% → 29% of one core (~38% less idle engine overhead)**. No change to follow behaviour.

## Tests

- `tests/test_idle_gating.py` — ego-motion runs iff tracking on; appearance hand-off fires iff Face/ReID on.
- Full suite green (826 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)