### PR TITLE
perf(ndi): default to native (fastest) receive format to skip a CPU color pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ follow [Semantic Versioning](https://semver.org/).
   (smoothing/anti-aliasing only on HUD overlays), the preview converter does one
   fewer full-frame copy per frame (`Format_BGR888`), and ORT reserves a core for
   the capture/UI threads.
+- **NDI cameras decode lighter on the CPU** — the receiver now requests the
+  source's native format (usually 8-bit UYVY) instead of asking the NDI SDK to
+  convert every frame to BGRA, so AutoPTZ does a single YUV→BGR pass instead of
+  the SDK's conversion *plus* an alpha strip. The frame reader dispatches on the
+  actual format (UYVY/UYVA/NV12/I420/YV12/BGRA/RGBA…) and falls back to the old
+  universal BGRA path automatically for the rare 16-bit sources. Set
+  `AUTOPTZ_NDI_COLOR_FORMAT=bgra` to force the previous behaviour.
 - **Idle preview costs almost nothing** — each camera tile now repaints only when
   a new frame arrives or its state changes, instead of on every timer tick. On an
   Apple-Silicon Mac an idle / no-signal tile dropped from ~12% CPU to ~2–3%; live

--- a/autoptz/engine/pipeline/ingest.py
+++ b/autoptz/engine/pipeline/ingest.py
@@ -831,6 +831,89 @@ class RTSPAdapter(SourceAdapter):
 # ── NDI Adapter ────────────────────────────────────────────────────────────────
 
 
+def _ndi_color_format_pref() -> str:
+    """Which NDI receive color format to request (``AUTOPTZ_NDI_COLOR_FORMAT``).
+
+    * ``bgra`` (default) — ``RecvColorFormat.BGRX_BGRA``: the NDI SDK converts the
+      source's native YUV to BGRA on the CPU for every frame, then we strip alpha
+      to BGR.  Universal but pays a full-frame color conversion inside the SDK.
+    * ``fastest`` — ``RecvColorFormat.fastest``: the SDK hands back its cheapest
+      native format (usually 8-bit UYVY); we do the single YUV→BGR pass ourselves,
+      skipping the SDK's extra conversion.  This is the lighter path (closer to how
+      NDI Monitor takes native YUV to the GPU) and is what to A/B on a real NDI rig.
+
+    Default stays ``bgra`` so behaviour is unchanged until explicitly opted in for
+    testing; ``_read_frame`` dispatches on the actual FourCC either way.
+    """
+    import os
+
+    val = os.environ.get("AUTOPTZ_NDI_COLOR_FORMAT", "bgra").strip().lower()
+    return "fastest" if val in ("fastest", "fast", "native") else "bgra"
+
+
+def _ndi_fourcc_name(vf: object) -> str:
+    """Best-effort FourCC name for a captured video frame (e.g. ``"UYVY"``).
+
+    Empty string when cyndilib can't report it (older builds), so the converter
+    falls back to its size-based heuristic.
+    """
+    try:
+        fc = vf.get_fourcc()  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        return ""
+    return str(getattr(fc, "name", fc)).upper()
+
+
+def _ndi_frame_to_bgr(
+    arr: NDArray[np.uint8], fourcc: str, h: int, w: int
+) -> NDArray[np.uint8] | None:
+    """Convert a flat NDI frame buffer to a contiguous BGR image.
+
+    Dispatches on the actual FourCC so the ``fastest`` (native-format) receive
+    path is correct for every layout the SDK can hand back — not just the BGRA we
+    used to assume.  Returns ``None`` for the 16-bit P216/PA16 families (no cheap
+    OpenCV path) so the caller can fall back to the universal BGRA receive format.
+
+    Falls back to the original size-based heuristic when the FourCC is unknown, so
+    the default BGRA path is byte-for-byte unchanged.
+    """
+    size = int(arr.size)
+    px = h * w
+    f = fourcc.upper() if fourcc else ""
+
+    # Packed 32-bit (4 bytes/pixel): BGRA/BGRX vs RGBA/RGBX.
+    if f in ("BGRA", "BGRX") and size == px * 4:
+        return cv2.cvtColor(arr.reshape((h, w, 4)), cv2.COLOR_BGRA2BGR)
+    if f in ("RGBA", "RGBX") and size == px * 4:
+        return cv2.cvtColor(arr.reshape((h, w, 4)), cv2.COLOR_RGBA2BGR)
+    # Packed 4:2:2, 8-bit (2 bytes/pixel).
+    if f == "UYVY" and size == px * 2:
+        return cv2.cvtColor(arr.reshape((h, w, 2)), cv2.COLOR_YUV2BGR_UYVY)
+    # UYVY + 8-bit alpha plane (3 bytes/pixel): convert the UYVY part, drop alpha.
+    if f == "UYVA" and size == px * 3:
+        return cv2.cvtColor(arr[: px * 2].reshape((h, w, 2)), cv2.COLOR_YUV2BGR_UYVY)
+    # Planar / semi-planar 4:2:0 (1.5 bytes/pixel).
+    if f in ("NV12", "I420", "YV12") and size == px * 3 // 2:
+        code = {
+            "NV12": cv2.COLOR_YUV2BGR_NV12,
+            "I420": cv2.COLOR_YUV2BGR_I420,
+            "YV12": cv2.COLOR_YUV2BGR_YV12,
+        }[f]
+        return cv2.cvtColor(arr.reshape((h * 3 // 2, w)), code)
+    # 16-bit YUV (P216/PA16): no cheap OpenCV path — signal a BGRA fall back.
+    if f in ("P216", "PA16"):
+        return None
+
+    # Unknown FourCC (older cyndilib): preserve the original size-based heuristic.
+    if size == px * 4:
+        return cv2.cvtColor(arr.reshape((h, w, 4)), cv2.COLOR_BGRA2BGR)
+    if size == px * 2:
+        return cv2.cvtColor(arr.reshape((h, w, 2)), cv2.COLOR_YUV2BGR_UYVY)
+    if size == px * 3:
+        return arr.reshape((h, w, 3))
+    return None
+
+
 class NDIAdapter(SourceAdapter):
     """Capture from an NDI source using cyndilib FrameSync.
 
@@ -854,6 +937,10 @@ class NDIAdapter(SourceAdapter):
         self._receiver: object | None = None
         self._finder: object | None = None
         self._video_frame: object | None = None
+        # "bgra" | "fastest" — see _ndi_color_format_pref. Flipped to "bgra" at
+        # runtime if a source delivers a format we can't convert cheaply, so the
+        # next reconnect self-heals to the universal SDK-converted path.
+        self._color_format_pref = _ndi_color_format_pref()
 
     def _open(self) -> bool:
         if not _probe_ndi():
@@ -889,9 +976,18 @@ class NDIAdapter(SourceAdapter):
                 )
                 return False
 
+            if self._color_format_pref == "fastest":
+                color_format = RecvColorFormat.fastest
+            else:
+                color_format = RecvColorFormat.BGRX_BGRA
             receiver = Receiver(
-                color_format=RecvColorFormat.BGRX_BGRA,
+                color_format=color_format,
                 bandwidth=RecvBandwidth.highest,
+            )
+            log.info(
+                "camera_id=%s NDIAdapter color_format=%s",
+                self.camera_id,
+                self._color_format_pref,
             )
             video_frame = VideoFrameSync()
             receiver.frame_sync.set_video_frame(video_frame)
@@ -953,14 +1049,25 @@ class NDIAdapter(SourceAdapter):
                 return None
             arr: NDArray[np.uint8] = np.asarray(data, dtype=np.uint8).reshape(-1)
 
-            # BGRX_BGRA → 4 bytes/pixel (BGRA); some sources still hand back UYVY
-            # (2 bytes/pixel).  Pick the layout from the actual buffer size.
-            if arr.size == h * w * 4:
-                return cv2.cvtColor(arr.reshape((h, w, 4)), cv2.COLOR_BGRA2BGR)
-            if arr.size == h * w * 2:
-                return cv2.cvtColor(arr.reshape((h, w, 2)), cv2.COLOR_YUV2BGR_UYVY)
-            if arr.size == h * w * 3:
-                return arr.reshape((h, w, 3))
+            # Dispatch on the actual FourCC so the native ("fastest") receive path
+            # is correct for whatever the SDK hands back, not just BGRA.
+            fourcc = _ndi_fourcc_name(vf)
+            bgr = _ndi_frame_to_bgr(arr, fourcc, h, w)
+            if bgr is not None:
+                return np.ascontiguousarray(bgr)
+
+            # Unsupported native format (16-bit P216/PA16) on the fastest path:
+            # self-heal by flipping to the universal BGRA format so the next
+            # reconnect re-opens with the SDK doing the conversion.  Drop this
+            # frame (the stall/reconnect path will re-open shortly).
+            if self._color_format_pref != "bgra":
+                log.warning(
+                    "camera_id=%s NDI native format %r has no cheap BGR path; "
+                    "falling back to BGRA on reconnect",
+                    self.camera_id,
+                    fourcc or f"{arr.size // max(1, h * w)}bpp",
+                )
+                self._color_format_pref = "bgra"
             return None
 
         except Exception as exc:  # noqa: BLE001

--- a/autoptz/engine/pipeline/ingest.py
+++ b/autoptz/engine/pipeline/ingest.py
@@ -834,21 +834,24 @@ class RTSPAdapter(SourceAdapter):
 def _ndi_color_format_pref() -> str:
     """Which NDI receive color format to request (``AUTOPTZ_NDI_COLOR_FORMAT``).
 
-    * ``bgra`` (default) — ``RecvColorFormat.BGRX_BGRA``: the NDI SDK converts the
-      source's native YUV to BGRA on the CPU for every frame, then we strip alpha
-      to BGR.  Universal but pays a full-frame color conversion inside the SDK.
-    * ``fastest`` — ``RecvColorFormat.fastest``: the SDK hands back its cheapest
-      native format (usually 8-bit UYVY); we do the single YUV→BGR pass ourselves,
-      skipping the SDK's extra conversion.  This is the lighter path (closer to how
-      NDI Monitor takes native YUV to the GPU) and is what to A/B on a real NDI rig.
+    * ``fastest`` (default) — ``RecvColorFormat.fastest``: the SDK hands back its
+      cheapest native format (usually 8-bit UYVY); we do the single YUV→BGR pass
+      ourselves, skipping a full-frame color conversion.  This is the lighter path,
+      closer to how NDI Monitor takes native YUV to the GPU.
+    * ``bgra`` — ``RecvColorFormat.BGRX_BGRA``: the NDI SDK converts the source's
+      native YUV to BGRA on the CPU for every frame, then we strip alpha to BGR.
+      Universal but pays that extra conversion inside the SDK; kept as an escape
+      hatch (set ``AUTOPTZ_NDI_COLOR_FORMAT=bgra``) for any source the native path
+      misbehaves on.
 
-    Default stays ``bgra`` so behaviour is unchanged until explicitly opted in for
-    testing; ``_read_frame`` dispatches on the actual FourCC either way.
+    ``_read_frame`` dispatches on the actual FourCC either way, and self-heals to
+    ``bgra`` on reconnect if a source delivers a 16-bit format we can't convert
+    cheaply — so ``fastest`` is safe as the default.
     """
     import os
 
-    val = os.environ.get("AUTOPTZ_NDI_COLOR_FORMAT", "bgra").strip().lower()
-    return "fastest" if val in ("fastest", "fast", "native") else "bgra"
+    val = os.environ.get("AUTOPTZ_NDI_COLOR_FORMAT", "fastest").strip().lower()
+    return "bgra" if val in ("bgra", "bgrx", "bgr") else "fastest"
 
 
 def _ndi_fourcc_name(vf: object) -> str:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -559,24 +559,24 @@ class TestDeliverToShm:
 
 
 class TestNDIColorFormatPref:
-    def test_default_is_bgra(self, monkeypatch) -> None:  # noqa: ANN001
+    def test_default_is_fastest(self, monkeypatch) -> None:  # noqa: ANN001
         from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
 
         monkeypatch.delenv("AUTOPTZ_NDI_COLOR_FORMAT", raising=False)
-        assert _ndi_color_format_pref() == "bgra"
+        assert _ndi_color_format_pref() == "fastest"
 
-    def test_fastest_aliases(self, monkeypatch) -> None:  # noqa: ANN001
+    def test_bgra_escape_hatch(self, monkeypatch) -> None:  # noqa: ANN001
         from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
 
-        for val in ("fastest", "FAST", " native ", "Fastest"):
+        for val in ("bgra", "BGRA", " bgrx ", "bgr"):
             monkeypatch.setenv("AUTOPTZ_NDI_COLOR_FORMAT", val)
-            assert _ndi_color_format_pref() == "fastest"
+            assert _ndi_color_format_pref() == "bgra"
 
-    def test_unknown_value_is_bgra(self, monkeypatch) -> None:  # noqa: ANN001
+    def test_unknown_value_is_fastest(self, monkeypatch) -> None:  # noqa: ANN001
         from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
 
         monkeypatch.setenv("AUTOPTZ_NDI_COLOR_FORMAT", "purple")
-        assert _ndi_color_format_pref() == "bgra"
+        assert _ndi_color_format_pref() == "fastest"
 
 
 class TestNDIFrameToBGR:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -553,3 +553,133 @@ class TestDeliverToShm:
         adapter._deliver(frame)
         adapter._deliver(frame)
         assert adapter.status.frames_total == 2
+
+
+# ── NDI native color format (fastest path) ─────────────────────────────────────
+
+
+class TestNDIColorFormatPref:
+    def test_default_is_bgra(self, monkeypatch) -> None:  # noqa: ANN001
+        from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
+
+        monkeypatch.delenv("AUTOPTZ_NDI_COLOR_FORMAT", raising=False)
+        assert _ndi_color_format_pref() == "bgra"
+
+    def test_fastest_aliases(self, monkeypatch) -> None:  # noqa: ANN001
+        from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
+
+        for val in ("fastest", "FAST", " native ", "Fastest"):
+            monkeypatch.setenv("AUTOPTZ_NDI_COLOR_FORMAT", val)
+            assert _ndi_color_format_pref() == "fastest"
+
+    def test_unknown_value_is_bgra(self, monkeypatch) -> None:  # noqa: ANN001
+        from autoptz.engine.pipeline.ingest import _ndi_color_format_pref
+
+        monkeypatch.setenv("AUTOPTZ_NDI_COLOR_FORMAT", "purple")
+        assert _ndi_color_format_pref() == "bgra"
+
+
+class TestNDIFrameToBGR:
+    """The native-format converter must dispatch on the actual FourCC and return
+    a contiguous (H, W, 3) BGR image for every layout the SDK can hand back."""
+
+    def test_bgra_exact_channels(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        # One known pixel: B=10 G=20 R=30 A=40 → BGR must be (10, 20, 30).
+        arr = np.tile(np.array([10, 20, 30, 40], dtype=np.uint8), _H * _W)
+        out = _ndi_frame_to_bgr(arr, "BGRA", _H, _W)
+        assert out is not None
+        assert out.shape == (_H, _W, 3)
+        assert tuple(int(c) for c in out[0, 0]) == (10, 20, 30)
+
+    def test_rgba_swaps_to_bgr(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        # R=30 G=20 B=10 A=40 → BGR must be (10, 20, 30).
+        arr = np.tile(np.array([30, 20, 10, 40], dtype=np.uint8), _H * _W)
+        out = _ndi_frame_to_bgr(arr, "RGBA", _H, _W)
+        assert out is not None
+        assert tuple(int(c) for c in out[0, 0]) == (10, 20, 30)
+
+    def test_uyvy_two_bytes_per_pixel(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        arr = np.full(_H * _W * 2, 128, dtype=np.uint8)
+        out = _ndi_frame_to_bgr(arr, "UYVY", _H, _W)
+        assert out is not None
+        assert out.shape == (_H, _W, 3)
+        assert out.dtype == np.uint8
+
+    def test_uyva_drops_alpha_plane(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        # 3 bytes/pixel total (UYVY + 8-bit alpha); converter uses the UYVY part.
+        arr = np.full(_H * _W * 3, 128, dtype=np.uint8)
+        out = _ndi_frame_to_bgr(arr, "UYVA", _H, _W)
+        assert out is not None
+        assert out.shape == (_H, _W, 3)
+
+    def test_planar_420_formats(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        for fourcc in ("NV12", "I420", "YV12"):
+            arr = np.full(_H * _W * 3 // 2, 128, dtype=np.uint8)
+            out = _ndi_frame_to_bgr(arr, fourcc, _H, _W)
+            assert out is not None, fourcc
+            assert out.shape == (_H, _W, 3), fourcc
+
+    def test_16bit_formats_return_none_for_fallback(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        for fourcc in ("P216", "PA16"):
+            arr = np.full(_H * _W * 4, 128, dtype=np.uint8)  # 16-bit 4:2:2
+            assert _ndi_frame_to_bgr(arr, fourcc, _H, _W) is None, fourcc
+
+    def test_unknown_fourcc_falls_back_to_size_heuristic(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        # Empty FourCC (older cyndilib): 4 bytes/px must still decode as BGRA.
+        arr = np.tile(np.array([10, 20, 30, 40], dtype=np.uint8), _H * _W)
+        out = _ndi_frame_to_bgr(arr, "", _H, _W)
+        assert out is not None
+        assert tuple(int(c) for c in out[0, 0]) == (10, 20, 30)
+
+    def test_mismatched_size_returns_none(self) -> None:
+        from autoptz.engine.pipeline.ingest import _ndi_frame_to_bgr
+
+        arr = np.full(_H * _W * 4 + 7, 128, dtype=np.uint8)  # not a clean layout
+        assert _ndi_frame_to_bgr(arr, "", _H, _W) is None
+
+
+class TestNDIReadFrame:
+    """`_read_frame` end-to-end with a mocked receiver + video frame."""
+
+    def _adapter(self, fourcc: str, buf: np.ndarray, pref: str) -> NDIAdapter:
+        adapter = NDIAdapter("cam-ndi", ndi_name="SRC (CAM)")
+        adapter._color_format_pref = pref
+        vf = MagicMock()
+        vf.xres = _W
+        vf.yres = _H
+        vf.get_array.return_value = buf
+        vf.get_fourcc.return_value = types.SimpleNamespace(name=fourcc)
+        adapter._video_frame = vf
+        adapter._receiver = MagicMock()
+        return adapter
+
+    def test_fastest_uyvy_returns_bgr(self) -> None:
+        buf = np.full(_H * _W * 2, 128, dtype=np.uint8)
+        adapter = self._adapter("UYVY", buf, pref="fastest")
+        out = adapter._read_frame()
+        assert out is not None
+        assert out.shape == (_H, _W, 3)
+        # Supported format must NOT trip the fallback.
+        assert adapter._color_format_pref == "fastest"
+
+    def test_unsupported_native_format_self_heals_to_bgra(self) -> None:
+        buf = np.full(_H * _W * 4, 128, dtype=np.uint8)  # 16-bit P216 layout
+        adapter = self._adapter("P216", buf, pref="fastest")
+        out = adapter._read_frame()
+        assert out is None
+        # Flipped so the next reconnect re-opens with the universal BGRA format.
+        assert adapter._color_format_pref == "bgra"


### PR DESCRIPTION
## What

Requesting `RecvColorFormat.BGRX_BGRA` made the NDI SDK convert the source's native YUV to BGRA on the CPU **every frame**, after which we stripped alpha to BGR — a full-frame color conversion NDI Monitor avoids by handing native YUV to the GPU.

This switches the default to `RecvColorFormat.fastest` (the SDK's cheapest native format, usually 8-bit UYVY) and does the single YUV→BGR pass ourselves, skipping the SDK's extra conversion.

`_read_frame` now dispatches on the **actual FourCC** (`BGRA/BGRX/RGBA/RGBX/UYVY/UYVA/NV12/I420/YV12`) instead of guessing from buffer size, and **self-heals to BGRA on reconnect** for the 16-bit `P216`/`PA16` families that have no cheap OpenCV path.

## Why

The other half of the NDI-vs-Monitor CPU investigation: the `BGRX_BGRA` config forced a CPU color conversion the SDK does for us. `fastest` is closer to how Monitor takes native YUV to the GPU.

## Safety / escape hatch

- `AUTOPTZ_NDI_COLOR_FORMAT=bgra` forces the previous universal path.
- The FourCC-aware reader + self-heal-to-BGRA on 16-bit sources keep `fastest` safe as the default.
- **To be validated on a real NDI rig** (check CPU **and** that colors/image are correct) — this RC build is the test vehicle.

## Tests

- `tests/test_ingest.py`: `_ndi_frame_to_bgr` converter across every FourCC + size-heuristic fallback; `_read_frame` end-to-end including the P216 → BGRA self-heal. No NDI source needed.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)