### PR TITLE
fix(updater): Windows in-app update is visible and relaunches the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ follow [Semantic Versioning](https://semver.org/).
 - **Model Manager** (Engine → Models) — review every AutoPTZ-managed model with
   per-row status, download or remove the ones you want, pick the active detector
   tier (un-downloaded tiers are greyed out), with live download progress.
-- **Seamless in-app updates** — the updater now shows a **download progress bar**,
-  and on Windows installs **silently** (no setup wizard) and restarts, the
-  closest to a "it just updated" experience.
+- **Seamless in-app updates** — the updater shows a **download progress bar**, and
+  on Windows installs with **no setup wizard** (just a progress window) then
+  **relaunches AutoPTZ automatically**, the closest to a "it just updated"
+  experience.
 - **Copy selected log lines** — select a range of rows in the Logs panel and copy
   just those with `Ctrl`/`Cmd`+`C` or right-click → *Copy Selected*; the toolbar
   button is now *Copy All*.
@@ -112,6 +113,12 @@ follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Windows updates are visible and relaunch the app** — the silent install used
+  `/VERYSILENT` (no window at all) and the installer's launch step was flagged
+  `skipifsilent`, so an in-app update showed no installer/progress *and* never
+  reopened AutoPTZ — you couldn't tell it had finished. It now installs with
+  `/SILENT` (a progress window, still no wizard) and the installer relaunches
+  AutoPTZ itself when done.
 - **UI no longer hangs while cameras launch** — service probes use `find_spec`
   instead of importing boxmot/torch on the GUI thread, worker startup runs off the
   GUI thread (no lock held during camera open), and the detector never silently

--- a/autoptz/update/installer.py
+++ b/autoptz/update/installer.py
@@ -126,23 +126,31 @@ def _copy_stream(
 def launch_update(path: Path) -> None:
     """Launch a downloaded installer/app bundle for the current OS.
 
-    Windows installs **silently** (Inno Setup ``/VERYSILENT``): it closes the
-    running app, updates in place, and relaunches — no wizard clicks, the
-    closest to a seamless "it just updated" experience.  macOS opens the ``.dmg``
-    (the user drags to Applications) and Linux runs the new AppImage.
+    Windows installs with Inno Setup ``/SILENT``: **no wizard pages**, but a
+    visible progress window so the update is obviously happening (``/VERYSILENT``
+    showed nothing at all, so the user couldn't tell it was working or done).  The
+    installer closes the running app, updates in place, and **relaunches it
+    itself** via a silent-only ``[Run]`` entry — see ``packaging/autoptz.iss``.
+
+    We deliberately do *not* pass ``/RESTARTAPPLICATIONS``: the app self-quits
+    right after launching the installer, so the Restart Manager never registers it
+    and that flag was a no-op — worse, it could double-launch once the installer's
+    own relaunch entry works.  macOS opens the ``.dmg`` (the user drags to
+    Applications) and Linux runs the new AppImage.
     """
     try:
         if sys.platform == "win32":
             if path.suffix.lower() == ".exe":
-                # Inno Setup silent flags: no wizard, auto-close the running app,
-                # relaunch when done.  Detached so this process can quit.
+                # Inno Setup silent flags: no wizard pages, suppress prompts (so
+                # closing the running app is automatic), don't reboot.  The
+                # installer relaunches AutoPTZ when done (its silent [Run] entry).
+                # Detached so this process can quit.
                 subprocess.Popen(  # noqa: S603
                     [
                         str(path),
-                        "/VERYSILENT",
+                        "/SILENT",
                         "/SUPPRESSMSGBOXES",
                         "/NORESTART",
-                        "/RESTARTAPPLICATIONS",
                     ]
                 )
             else:

--- a/packaging/autoptz.iss
+++ b/packaging/autoptz.iss
@@ -34,6 +34,12 @@ WizardStyle=modern
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 DisableProgramGroupPage=yes
+; In-app updates run this installer silently.  Let Setup close the running
+; AutoPTZ so its files can be replaced, but don't let the Restart Manager
+; relaunch it — the silent [Run] entry below does the relaunch deterministically
+; (avoids a double launch when an older app build also passed /RESTARTAPPLICATIONS).
+CloseApplications=yes
+RestartApplications=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -50,4 +56,16 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
+; Interactive installs: the usual "launch AutoPTZ" checkbox on the Finished page.
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
+; Silent installs (the in-app auto-updater): relaunch AutoPTZ automatically, since
+; the Finished-page checkbox above is skipped when silent.  runasoriginaluser so
+; the relaunched app runs as the user, not the elevated installer.
+Filename: "{app}\{#MyAppExeName}"; Flags: nowait runasoriginaluser; Check: IsSilentInstall
+
+[Code]
+function IsSilentInstall(): Boolean;
+begin
+  { True for both /SILENT and /VERYSILENT — i.e. an in-app auto-update. }
+  Result := WizardSilent();
+end;

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import autoptz.update.checker as checker
+import autoptz.update.installer as installer
 from autoptz.update.checker import UpdateInfo, check_for_update
-from autoptz.update.installer import download_update
+from autoptz.update.installer import download_update, launch_update
 
 
 def _release(tag: str, *, prerelease: bool = False, assets: list[str] | None = None) -> dict:
@@ -239,3 +242,36 @@ def test_download_update_reports_progress(tmp_path, monkeypatch) -> None:
     assert [d for d, _ in seen] == [1000, 2000, 2500]
     assert all(t == total for _, t in seen)
     assert seen[-1] == (total, total)
+
+
+# ── launch_update: Windows silent-install flags ─────────────────────────────────
+
+
+def _capture_windows_launch(monkeypatch) -> list[str]:  # noqa: ANN001
+    monkeypatch.setattr(installer.sys, "platform", "win32")
+    captured: list[list[str]] = []
+    monkeypatch.setattr(installer.subprocess, "Popen", lambda args, *a, **k: captured.append(args))
+    launch_update(Path("C:/Users/x/Downloads/AutoPTZ-2.1.0-windows-x64-setup.exe"))
+    assert captured, "Popen was not called"
+    return captured[0]
+
+
+def test_windows_launch_uses_silent_not_verysilent(monkeypatch) -> None:  # noqa: ANN001
+    args = _capture_windows_launch(monkeypatch)
+    # /SILENT shows a progress window (visible feedback); /VERYSILENT showed nothing.
+    assert "/SILENT" in args
+    assert "/VERYSILENT" not in args
+
+
+def test_windows_launch_drops_restartapplications(monkeypatch) -> None:  # noqa: ANN001
+    # The installer now relaunches via its own silent [Run] entry; passing
+    # /RESTARTAPPLICATIONS was a no-op (app self-quits) and risks a double launch.
+    args = _capture_windows_launch(monkeypatch)
+    assert "/RESTARTAPPLICATIONS" not in args
+
+
+def test_windows_launch_keeps_no_wizard_and_no_reboot(monkeypatch) -> None:  # noqa: ANN001
+    args = _capture_windows_launch(monkeypatch)
+    assert "/SUPPRESSMSGBOXES" in args
+    assert "/NORESTART" in args
+    assert str(args[0]).endswith(".exe")


### PR DESCRIPTION
## Problem (reported)

On Windows, an in-app update showed **no installer or progress**, **didn't relaunch** AutoPTZ when done, and gave no "it's finished" signal — *"I would never know if it's done."*

## Root causes

1. **No relaunch** — `packaging/autoptz.iss` flagged the post-install launch entry `skipifsilent`, so the in-app update (installed with `/VERYSILENT`) **skipped the relaunch entirely**.
2. **No feedback** — `/VERYSILENT` shows *no* window at all, so nothing indicates an install is happening or done.
3. `/RESTARTAPPLICATIONS` was a no-op: the app self-quits right after launching the installer, so the Restart Manager never registers it to relaunch.

## Fix

- **App side** (`launch_update`): launch with `/SILENT` (a progress window, still no wizard pages) instead of `/VERYSILENT`; drop `/RESTARTAPPLICATIONS`.
- **Installer** (`autoptz.iss`): add a **silent-only** `[Run]` relaunch entry (`Check: WizardSilent`, `runasoriginaluser nowait`) so a silent install reopens AutoPTZ; set `CloseApplications=yes` / `RestartApplications=no` so Setup can replace the running app's files while the relaunch stays deterministic (no double launch).

Because the update runs the **newly downloaded** installer, this fix takes effect on the very next update (rc11/rc12 → next).

## Note

Per-machine installs (Program Files) still raise a UAC prompt on elevation — that's inherent to Windows and unchanged here.

## Tests

`tests/test_update.py`: asserts the Windows launch uses `/SILENT`, drops `/VERYSILENT` + `/RESTARTAPPLICATIONS`, and keeps `/SUPPRESSMSGBOXES` + `/NORESTART`. Full suite green (833).

🤖 Generated with [Claude Code](https://claude.com/claude-code)