### PR TITLE
perf(inference): CoreML compile-cache (one-time MLProgram compile per machine)

### DIFF
--- a/autoptz/engine/runtime/inference.py
+++ b/autoptz/engine/runtime/inference.py
@@ -151,19 +151,29 @@ def get_best_ep(prefs: HardwarePrefs | None = None) -> EP:
     return EP.CPU  # always available
 
 
-def _trt_engine_cache_dir() -> str:
-    """Persistent TensorRT engine-cache dir (so the multi-minute build is one-time)."""
+def _cache_dir(subdir: str) -> str:
+    """Persistent per-machine cache dir for an EP's compiled artifacts."""
     try:
         from autoptz.config.store import default_config_dir
 
-        cache = default_config_dir() / "trt_cache"
+        cache = default_config_dir() / subdir
     except Exception:  # noqa: BLE001 — config import must never break inference
-        cache = Path.home() / ".cache" / "AutoPTZ" / "trt_cache"
+        cache = Path.home() / ".cache" / "AutoPTZ" / subdir
     try:
         cache.mkdir(parents=True, exist_ok=True)
     except Exception:  # noqa: BLE001
-        logger.debug("Could not create TRT cache dir %s", cache, exc_info=True)
+        logger.debug("Could not create cache dir %s", cache, exc_info=True)
     return str(cache)
+
+
+def _trt_engine_cache_dir() -> str:
+    """Persistent TensorRT engine-cache dir (so the multi-minute build is one-time)."""
+    return _cache_dir("trt_cache")
+
+
+def _coreml_cache_dir() -> str:
+    """Persistent CoreML compiled-model cache dir (skips per-session MLProgram compile)."""
+    return _cache_dir("coreml_cache")
 
 
 def _wants_fp16(prefs: HardwarePrefs | None) -> bool:
@@ -194,7 +204,14 @@ def _provider_options(ep: EP, prefs: HardwarePrefs | None) -> dict[str, object]:
     if ep is EP.COREML:
         # MLProgram routes to the Apple Neural Engine / GPU (incl. AMD on Intel
         # Macs via Metal); ALL lets CoreML pick the fastest unit per op.
-        return {"ModelFormat": "MLProgram", "MLComputeUnits": "ALL"}
+        # ModelCacheDirectory persists the compiled MLProgram so the slow first
+        # compile is one-time per machine, not paid on every session build
+        # (acute with many camera workers / process-per-camera).
+        return {
+            "ModelFormat": "MLProgram",
+            "MLComputeUnits": "ALL",
+            "ModelCacheDirectory": _coreml_cache_dir(),
+        }
     if ep is EP.TENSORRT:
         opts: dict[str, object] = {
             "trt_engine_cache_enable": True,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -92,6 +92,27 @@ def test_get_best_ep_force_ep_unavailable_falls_back() -> None:
     assert ep == EP.CPU  # best available after forced EP fails
 
 
+def test_cache_dir_creates_directory() -> None:
+    import os
+
+    from autoptz.engine.runtime.inference import _cache_dir
+
+    d = _cache_dir("pytest_coreml_cache_probe")
+    assert os.path.isdir(d)
+
+
+def test_coreml_provider_options_include_model_cache() -> None:
+    import os
+
+    from autoptz.engine.runtime.inference import EP, _provider_options
+
+    opts = _provider_options(EP.COREML, None)
+    assert opts["ModelFormat"] == "MLProgram"
+    assert opts["MLComputeUnits"] == "ALL"
+    assert "ModelCacheDirectory" in opts
+    assert os.path.isdir(str(opts["ModelCacheDirectory"]))
+
+
 def test_make_session_cpu(tmp_path: Path) -> None:
     """Create a minimal ONNX model and verify make_session returns a session."""
     import onnx


### PR DESCRIPTION
Persist the CoreML EP compiled MLProgram via `ModelCacheDirectory` so the slow first compile is one-time per machine instead of paid on every ORT session build — meaningful with 3-6 camera workers and process-per-camera, and cuts cold-start on both Apple Silicon and Intel Mac.

- Extracts a shared `_cache_dir(subdir)` helper (DRY with the existing TensorRT engine-cache); adds `_coreml_cache_dir()`; wires `ModelCacheDirectory` into the CoreML provider options.
- Verified ORT 1.24.1 CoreML accepts the option (active EP stays CoreML).
- 12 tests pass; ruff + mypy strict clean.

Roadmap item **P3** (perf/scalability track). Validate cold-start improvement on real hardware before the 2.2.0 GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)