### PR TITLE
feat(engine): R2′ inference-hang watchdog — halt PTZ + degraded status on ORT stall

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -77,6 +77,13 @@ _FACE_INTERVAL_S = 0.25
 _FACE_TTL_S = 0.12
 _STAGE_WINDOW = 60
 _STAGE_FRESH_S = 2.0
+# Inference-hang watchdog: if the inference thread hasn't completed a tick in
+# this many seconds, the capture thread halts PTZ motion and surfaces a
+# DEGRADED/stalled status.  Must exceed the worst normal per-frame inference
+# time (typically <200 ms even on CPU) by a large margin.
+# NOTE: the value 2.0 coincidentally matches ``_STAGE_FRESH_S`` but the two
+# constants are UNRELATED concepts and should be tuned independently.
+_INFER_STALL_S = 2.0
 _EVENT_MAX = 12
 _FPS_LOG_DELTA = 0.25
 
@@ -359,6 +366,9 @@ class CameraWorker:
 
         # tracking state
         self._tracking_enabled = config.target.mode != "off"
+        # Set True by the capture-thread watchdog when inference appears hung;
+        # cleared automatically when inference resumes.
+        self._watchdog_stalled: bool = False
         self._target_track_id: int | None = None
         self._target_lock = _TargetLockState()
         self._identity_recover_candidate: tuple[str, int, int] | None = None
@@ -526,6 +536,7 @@ class CameraWorker:
         # so sustained overload shows up in the logs instead of silently dropping.
         self._frames_captured = 0
         self._frames_inferred = 0
+        self._last_infer_t: float = 0.0  # monotonic timestamp of last completed inference tick
         self._last_logged_inf_captured = 0
         self._last_logged_inf_inferred = 0
 
@@ -2234,6 +2245,7 @@ class CameraWorker:
 
             # Telemetry pacing (~telemetry_hz) — report the latest inference output.
             if now - last_telemetry >= self._telemetry_period:
+                self._apply_inference_watchdog(now)
                 self._emit_telemetry(
                     tracks=list(self._last_tracks), health=last_health, last_error=last_error
                 )
@@ -2365,6 +2377,9 @@ class CameraWorker:
 
             self._last_tracks = tracks
             self._last_tracks_frame_id = fid
+            # Heartbeat: advance so the capture-thread watchdog knows inference
+            # is alive.  Set AFTER all work for this frame is committed.
+            self._last_infer_t = time.monotonic()
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
                     "camera_id=%s timings detect+track=%.1fms face=%.1fms tracks=%d fps=%.1f",
@@ -3634,6 +3649,15 @@ class CameraWorker:
                 severity="warning",
             )
 
+        if self._watchdog_stalled:
+            return TrackingStatusInfo(
+                state="degraded",
+                headline="Inference stalled",
+                detail="inference stalled — holding",
+                action="holding",
+                severity="warning",
+            )
+
         snap = self._ptz_status_snapshot(now)
         ptz_state = str(snap.get("state", "idle"))
         ptz_action = str(snap.get("action", ""))
@@ -3993,6 +4017,57 @@ class CameraWorker:
         except Exception:  # noqa: BLE001
             return None
         return SwitchStateInfo(**state) if state else None
+
+    # ── inference-hang watchdog ───────────────────────────────────────────────
+
+    def _inference_stalled(self, now: float) -> bool:
+        """Return True iff the inference thread appears to have hung.
+
+        Pure predicate — no side effects.  Safe to call from the capture thread
+        at any time.
+
+        Conditions (all must hold):
+        - At least one inference tick has completed (``_frames_inferred > 0``),
+          so we never fire on a fresh worker that hasn't started yet.
+        - Tracking is enabled (``_tracking_enabled``), because a stall only
+          matters when auto PTZ would be driven.
+        - The heartbeat timestamp is older than ``_INFER_STALL_S`` seconds.
+        """
+        return (
+            self._frames_inferred > 0
+            and self._tracking_enabled
+            and (now - self._last_infer_t) > _INFER_STALL_S
+        )
+
+    def _apply_inference_watchdog(self, now: float) -> None:
+        """Watchdog action — called once per telemetry tick from the capture thread.
+
+        If ``_inference_stalled`` is True:
+        - Stops PTZ motion ONCE on the False→True transition of ``_watchdog_stalled``
+          (edge-triggered) so VISCA-IP/ONVIF hardware is not flooded with stop
+          packets every tick.
+        - Keeps ``_watchdog_stalled`` set (level) so ``_tracking_status_info``
+          continues to surface a DEGRADED/stalled state with
+          ``severity="warning"`` each tick until inference recovers.
+
+        Recovery is automatic when ``_last_infer_t`` advances (next successful
+        inference tick); ``_watchdog_stalled`` is cleared and re-armed so a
+        subsequent stall issues a fresh stop.
+        """
+        if self._inference_stalled(now):
+            if not self._watchdog_stalled:  # edge: stop once on entering the stall
+                backend = self._ptz_backend
+                if backend is not None and hasattr(backend, "stop"):
+                    try:
+                        with self._ptz_lock:
+                            backend.stop()
+                    except Exception:  # noqa: BLE001
+                        log.debug(
+                            "camera_id=%s watchdog stop failed", self.camera_id, exc_info=True
+                        )
+            self._watchdog_stalled = True
+        else:
+            self._watchdog_stalled = False
 
     def _emit_telemetry(
         self,

--- a/tests/test_inference_watchdog.py
+++ b/tests/test_inference_watchdog.py
@@ -1,0 +1,318 @@
+"""Inference-hang watchdog tests (R2′).
+
+Tests for:
+  - ``CameraWorker._inference_stalled`` — pure predicate, no threads.
+  - ``CameraWorker._apply_inference_watchdog`` — action: PTZ stop + status.
+  - ``CameraWorker._tracking_status_info`` — surfaces ``degraded`` when stalled.
+
+All tests construct a ``CameraWorker`` WITHOUT starting it (no threads, no
+camera hardware, no ML models).  State is set directly on the worker instance
+and the methods under test are called synchronously.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any  # noqa: UP035
+
+import numpy as np
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _camera_config(camera_id: str = "watchdog1234abcd", *, tracking_on: bool = True):
+    """Build a minimal CameraConfig with tracking on or off."""
+    from autoptz.config.models import CameraConfig, SourceConfig, TargetConfig
+
+    return CameraConfig(
+        id=camera_id,
+        name="Watchdog Cam",
+        source=SourceConfig(type="usb", address="usb://0"),
+        target=TargetConfig(mode="identity" if tracking_on else "off"),
+    )
+
+
+class _FakeSource:
+    """Minimal FrameSource stub — never called in these tests."""
+
+    def open(self) -> bool:
+        return True
+
+    def read(self):
+        return np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def close(self) -> None:
+        pass
+
+
+def _make_worker(camera_id: str = "watchdog1234abcd", *, tracking_on: bool = True):
+    """Construct a CameraWorker without starting it."""
+    from autoptz.engine.camera_worker import CameraWorker
+
+    return CameraWorker(
+        camera_id,
+        _camera_config(camera_id, tracking_on=tracking_on),
+        lambda _msg: None,
+        frame_source=_FakeSource(),
+    )
+
+
+class _FakePTZBackend:
+    """Records stop() calls; no real hardware."""
+
+    def __init__(self) -> None:
+        self.stop_calls: int = 0
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def move_velocity(self, pan: float, tilt: float, zoom: float) -> None:  # noqa: D401
+        pass
+
+
+# ── _inference_stalled tests ──────────────────────────────────────────────────
+
+
+class TestInferenceStalled:
+    """Unit tests for the pure ``_inference_stalled`` predicate."""
+
+    def _worker(self, **kw: Any):
+        return _make_worker(**kw)
+
+    def test_false_when_fresh_no_inferred_frames(self) -> None:
+        """Stall predicate is False on a fresh worker (no frames inferred yet)."""
+        w = self._worker()
+        w._last_infer_t = 0.0
+        w._frames_inferred = 0
+        assert w._inference_stalled(now=100.0) is False
+
+    def test_false_when_tracking_disabled(self) -> None:
+        """Stall predicate is False when tracking is off — nothing to protect."""
+        w = self._worker(tracking_on=False)
+        w._frames_inferred = 10
+        w._last_infer_t = 0.0  # very old heartbeat
+        assert w._inference_stalled(now=100.0) is False
+
+    def test_false_when_heartbeat_is_recent(self) -> None:
+        """Stall predicate is False when the heartbeat is within the threshold."""
+        from autoptz.engine import camera_worker as cw
+
+        w = self._worker()
+        w._frames_inferred = 5
+        now = 100.0
+        # heartbeat only 0.5 s ago — well within _INFER_STALL_S (2.0 s)
+        w._last_infer_t = now - (cw._INFER_STALL_S - 0.5)
+        assert w._inference_stalled(now=now) is False
+
+    def test_true_when_stale_and_started_and_tracking_on(self) -> None:
+        """Stall predicate is True when inference started and heartbeat is old."""
+        from autoptz.engine import camera_worker as cw
+
+        w = self._worker()
+        w._frames_inferred = 1
+        now = 100.0
+        # heartbeat exactly at the boundary (just over the threshold)
+        w._last_infer_t = now - cw._INFER_STALL_S - 0.01
+        assert w._inference_stalled(now=now) is True
+
+    def test_true_with_many_frames_and_old_heartbeat(self) -> None:
+        """Stall with many inferred frames and a very old heartbeat."""
+        w = self._worker()
+        w._frames_inferred = 9999
+        w._last_infer_t = 0.0
+        assert w._inference_stalled(now=100.0) is True
+
+    def test_boundary_exactly_at_threshold_is_false(self) -> None:
+        """Exactly at the threshold should NOT be stalled (strict greater-than)."""
+        from autoptz.engine import camera_worker as cw
+
+        w = self._worker()
+        w._frames_inferred = 1
+        now = 100.0
+        w._last_infer_t = now - cw._INFER_STALL_S  # exactly at threshold
+        assert w._inference_stalled(now=now) is False
+
+    def test_recovery_after_heartbeat_advances(self) -> None:
+        """Once the heartbeat is updated, the stall clears automatically."""
+        from autoptz.engine import camera_worker as cw
+
+        w = self._worker()
+        w._frames_inferred = 5
+        now = 100.0
+        # Initially stalled
+        w._last_infer_t = now - cw._INFER_STALL_S - 1.0
+        assert w._inference_stalled(now=now) is True
+        # Inference resumes — heartbeat advances
+        w._last_infer_t = now - 0.05
+        assert w._inference_stalled(now=now) is False
+
+
+# ── _apply_inference_watchdog action tests ────────────────────────────────────
+
+
+class TestApplyInferenceWatchdog:
+    """Tests for the watchdog action method."""
+
+    def _stalled_worker_with_fake_ptz(self) -> tuple[Any, _FakePTZBackend]:
+        """Return a worker in a stalled state with a fake PTZ backend."""
+        from autoptz.engine import camera_worker as cw
+
+        w = _make_worker()
+        w._frames_inferred = 5
+        # Make it stalled
+        w._last_infer_t = 0.0
+
+        backend = _FakePTZBackend()
+        w._ptz_backend = backend
+        w._ptz_lock = threading.Lock()
+
+        now = cw._INFER_STALL_S + 10.0
+        return w, backend, now
+
+    def test_watchdog_calls_backend_stop_when_stalled(self) -> None:
+        """When stalled, _apply_inference_watchdog must call backend.stop()."""
+        w, backend, now = self._stalled_worker_with_fake_ptz()
+        w._apply_inference_watchdog(now)
+        assert backend.stop_calls >= 1
+
+    def test_watchdog_sets_stalled_flag(self) -> None:
+        """When stalled, _watchdog_stalled must be set to True."""
+        w, _backend, now = self._stalled_worker_with_fake_ptz()
+        w._apply_inference_watchdog(now)
+        assert w._watchdog_stalled is True
+
+    def test_watchdog_stops_once_per_stall_episode(self) -> None:
+        """stop() is called ONCE on entry to a stall; re-armed after recovery."""
+        from autoptz.engine import camera_worker as cw
+
+        w, backend, now = self._stalled_worker_with_fake_ptz()
+
+        # --- first stall episode ---
+        # Three consecutive ticks while continuously stalled → stop called once.
+        w._apply_inference_watchdog(now)
+        w._apply_inference_watchdog(now)
+        w._apply_inference_watchdog(now)
+        assert w._watchdog_stalled is True
+        assert backend.stop_calls == 1
+
+        # --- recovery ---
+        # Advance the heartbeat so _inference_stalled returns False.
+        w._last_infer_t = now - 0.05
+        w._apply_inference_watchdog(now)
+        assert w._watchdog_stalled is False
+        assert backend.stop_calls == 1  # no new stop on recovery
+
+        # --- second stall episode ---
+        # Drop the heartbeat again; watchdog must re-arm and stop once more.
+        w._last_infer_t = 0.0
+        stall_now2 = now + cw._INFER_STALL_S + 1.0
+        w._apply_inference_watchdog(stall_now2)
+        w._apply_inference_watchdog(stall_now2)
+        assert w._watchdog_stalled is True
+        assert backend.stop_calls == 2
+
+    def test_watchdog_no_stop_without_ptz_backend(self) -> None:
+        """Watchdog with no PTZ backend configured must not raise."""
+        from autoptz.engine import camera_worker as cw
+
+        w = _make_worker()
+        w._frames_inferred = 5
+        w._last_infer_t = 0.0
+        w._ptz_backend = None
+
+        now = cw._INFER_STALL_S + 5.0
+        w._apply_inference_watchdog(now)  # must not raise
+        assert w._watchdog_stalled is True
+
+    def test_watchdog_clears_flag_on_recovery(self) -> None:
+        """After inference resumes (heartbeat advances), watchdog clears the flag."""
+        from autoptz.engine import camera_worker as cw
+
+        w, _backend, _now = self._stalled_worker_with_fake_ptz()
+        stalled_now = cw._INFER_STALL_S + 10.0
+
+        # Trigger stall
+        w._apply_inference_watchdog(stalled_now)
+        assert w._watchdog_stalled is True
+
+        # Simulate inference recovery: heartbeat advances
+        w._last_infer_t = stalled_now - 0.05
+        # Watchdog detects recovery
+        w._apply_inference_watchdog(stalled_now)
+        assert w._watchdog_stalled is False
+
+    def test_watchdog_no_stop_when_not_stalled(self) -> None:
+        """If inference is healthy, backend.stop() must NOT be called."""
+        w = _make_worker()
+        backend = _FakePTZBackend()
+        w._ptz_backend = backend
+        w._ptz_lock = threading.Lock()
+
+        now = 100.0
+        w._frames_inferred = 10
+        w._last_infer_t = now - 0.1  # very recent heartbeat
+
+        w._apply_inference_watchdog(now)
+        assert backend.stop_calls == 0
+        assert w._watchdog_stalled is False
+
+
+# ── _tracking_status_info degraded state tests ───────────────────────────────
+
+
+class TestTrackingStatusInfoWhenStalled:
+    """Tests that _tracking_status_info surfaces the stalled/degraded state."""
+
+    def _worker_with_target(self) -> Any:
+        """Build a worker that has a target set (status would be non-idle)."""
+        w = _make_worker()
+        # Simulate having a target identity set so status is non-trivial
+        w._target_identity_id = "identity-abc"
+        w._target_track_id = None
+        return w
+
+    def test_status_degraded_when_watchdog_stalled(self) -> None:
+        """When _watchdog_stalled is True, tracking status must be 'degraded'."""
+        w = self._worker_with_target()
+        w._watchdog_stalled = True
+        status = w._tracking_status_info([], now=100.0)
+        assert status.state == "degraded"
+
+    def test_status_detail_mentions_stall(self) -> None:
+        """The detail field must mention 'inference stalled'."""
+        w = self._worker_with_target()
+        w._watchdog_stalled = True
+        status = w._tracking_status_info([], now=100.0)
+        assert "inference stalled" in status.detail.lower()
+
+    def test_status_severity_is_warning(self) -> None:
+        """The severity must be 'warning' so the UI highlights it."""
+        w = self._worker_with_target()
+        w._watchdog_stalled = True
+        status = w._tracking_status_info([], now=100.0)
+        assert status.severity == "warning"
+
+    def test_status_action_is_holding(self) -> None:
+        """Action must be 'holding' — PTZ has been stopped."""
+        w = self._worker_with_target()
+        w._watchdog_stalled = True
+        status = w._tracking_status_info([], now=100.0)
+        assert status.action == "holding"
+
+    def test_status_idle_when_no_target(self) -> None:
+        """With no target, the stall state is not reached (idle short-circuit)."""
+        w = _make_worker()
+        # No target at all
+        w._target_identity_id = None
+        w._target_track_id = None
+        w._watchdog_stalled = True
+        status = w._tracking_status_info([], now=100.0)
+        # The early-return path fires — state is 'idle' (default)
+        assert status.state == "idle"
+
+    def test_status_normal_when_not_stalled(self) -> None:
+        """When watchdog is not stalled, the normal tracking state is returned."""
+        w = self._worker_with_target()
+        w._watchdog_stalled = False
+        status = w._tracking_status_info([], now=100.0)
+        assert status.state != "degraded"


### PR DESCRIPTION
If an ORT forward pass *hangs* inside `_maybe_track`, the inference thread blocks: tracks freeze (never marked lost), so the controller would keep driving the PTZ toward a frozen target while telemetry stays stale. `_STAGE_FRESH_S` only *labels* staleness — nothing acted on it.

This adds a watchdog on the **capture thread** (which keeps running independent of a hung inference thread):
- Heartbeat `_last_infer_t` updated at the end of each completed inference iteration.
- Pure `_inference_stalled(now)` predicate (inference started + tracking on + age > `_INFER_STALL_S=2.0s`).
- `_apply_inference_watchdog` (per telemetry tick) **edge-triggers** `backend.stop()` once on entering the stall (under `_ptz_lock`, same lock as `_drive_ptz_auto` — race-safe; no 10Hz packet flood), and surfaces a `degraded`/`warning` `TrackingStatusInfo` ("inference stalled — holding"). Auto-recovers when inference resumes.
- 19 synchronous tests (no thread races): predicate across all conditions, edge-triggered stop (once per stall episode, re-arms on recovery), degraded-status surfacing.

Roadmap item **R2′** (safety track). Real-camera stall validation deferred to the 2.2.0 RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)