### PR TITLE
feat(engine): R3′ worker liveness monitoring + auto-restart

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -613,6 +613,17 @@ class CameraWorker:
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
+    def is_alive(self) -> bool:
+        """Return True iff the worker has been started and its capture thread is alive.
+
+        False before ``start()``, after ``stop()``, or if the thread died unexpectedly.
+        Uniform interface with ``ProcessWorkerHandle.is_alive()`` so the supervisor
+        can treat both worker types identically for health monitoring.
+
+        Delegates to :attr:`is_running` so liveness logic lives in exactly one place.
+        """
+        return self.is_running
+
     # ── command intake (thread-safe; called from supervisor/command pump) ────────
 
     def enable_tracking(self, enabled: bool) -> None:

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -64,6 +64,12 @@ log = logging.getLogger(__name__)
 
 _PUMP_INTERVAL_S = 0.05  # 20 Hz command pump when run internally
 
+# Worker liveness / auto-restart constants
+_HEALTH_SCAN_INTERVAL_S = 2.0  # how often tick() runs the health scan
+_BASE_BACKOFF_S = 1.0  # initial restart back-off
+_MAX_BACKOFF_S = 30.0  # maximum restart back-off (exponential cap)
+_MAX_RESTART_ATTEMPTS = 5  # give up after this many consecutive failures
+
 
 def _log_macos_capture_path() -> None:
     """Log (once at start) which USB capture path macOS will use.
@@ -140,6 +146,14 @@ class Supervisor:
         self._pump_thread: threading.Thread | None = None
         self._pump_stop = threading.Event()
         self._startup_thread: threading.Thread | None = None
+
+        # ── worker health monitoring + auto-restart ──────────────────────────────
+        # Per-camera backoff state: cid → (attempts, next_allowed_t).
+        # Cleared when a worker is healthy again or the camera is removed.
+        self._restart_state: dict[str, tuple[int, float]] = {}
+        # Monotonic timestamp of the last health scan (throttled to
+        # _HEALTH_SCAN_INTERVAL_S so tick() doesn't scan every 50 ms).
+        self._last_health_scan_t: float = 0.0
 
     # ── lifecycle ───────────────────────────────────────────────────────────────
 
@@ -405,6 +419,10 @@ class Supervisor:
                 self._route(cmd)
             except Exception:  # noqa: BLE001
                 log.warning("error routing command %s", getattr(cmd, "kind", "?"), exc_info=True)
+        now = time.monotonic()
+        if now - self._last_health_scan_t >= _HEALTH_SCAN_INTERVAL_S:
+            self._last_health_scan_t = now
+            self._scan_worker_health(now)
 
     def _pump_loop(self) -> None:
         while not self._pump_stop.is_set():
@@ -415,6 +433,88 @@ class Supervisor:
                 log.debug("pump tick error", exc_info=True)
             elapsed = time.monotonic() - t0
             self._pump_stop.wait(max(0.0, _PUMP_INTERVAL_S - elapsed))
+
+    # ── worker health monitoring ─────────────────────────────────────────────────
+
+    def _scan_worker_health(self, now: float) -> None:
+        """Check every worker's liveness and restart any that have died.
+
+        Throttled by the caller (``tick()``) to run at most every
+        ``_HEALTH_SCAN_INTERVAL_S`` seconds.  Uses a locked snapshot of
+        ``_workers`` so the scan never holds the lock across blocking calls
+        (``worker.stop()`` or ``_spawn_worker()``).
+        """
+        if not self._running:
+            return
+        with self._lock:
+            snapshot = list(self._workers.items())
+
+        for cid, worker in snapshot:
+            alive = False
+            try:
+                alive = bool(worker.is_alive())
+            except Exception:  # noqa: BLE001
+                log.debug("camera_id=%s is_alive() raised", cid, exc_info=True)
+
+            if alive:
+                # Worker is healthy — clear any stale restart state.
+                self._restart_state.pop(cid, None)
+                continue
+
+            # Worker appears dead.  Check back-off state.
+            attempts, next_allowed_t = self._restart_state.get(cid, (0, 0.0))
+
+            if attempts >= _MAX_RESTART_ATTEMPTS:
+                # Already gave up — log once (when attempts first hits the cap
+                # the counter was bumped; subsequent scans see == cap, skip).
+                # The "log once" is enforced by the sentinel value stored below.
+                continue
+
+            if now < next_allowed_t:
+                # Still in the back-off window — do nothing this scan.
+                continue
+
+            # Attempt a restart.
+            log.info(
+                "camera_id=%s capture thread died — restarting (attempt %d/%d)",
+                cid,
+                attempts + 1,
+                _MAX_RESTART_ATTEMPTS,
+            )
+            try:
+                worker.stop()
+            except Exception:  # noqa: BLE001
+                log.debug("camera_id=%s stop() before restart failed", cid, exc_info=True)
+
+            with self._lock:
+                # Guard: camera may have been explicitly removed since the snapshot.
+                # Note: tick() (command routing + health scan) runs on a single
+                # thread, so _on_remove_camera and this scan cannot truly interleave;
+                # this re-check is belt-and-suspenders against external direct calls.
+                if cid in self._workers:
+                    del self._workers[cid]
+                else:
+                    # Removed concurrently — clear state and skip the respawn.
+                    self._restart_state.pop(cid, None)
+                    continue
+
+            new_attempts = attempts + 1
+            backoff = min(_MAX_BACKOFF_S, _BASE_BACKOFF_S * (2 ** (new_attempts - 1)))
+            self._restart_state[cid] = (new_attempts, now + backoff)
+
+            if new_attempts >= _MAX_RESTART_ATTEMPTS:
+                log.warning(
+                    "camera_id=%s worker failed %d times — giving up on auto-restart",
+                    cid,
+                    new_attempts,
+                )
+                # Don't respawn; keep the sentinel so future scans skip this camera.
+                continue
+
+            try:
+                self._spawn_worker(cid)
+            except Exception:  # noqa: BLE001
+                log.warning("camera_id=%s respawn failed", cid, exc_info=True)
 
     # ── command routing ─────────────────────────────────────────────────────────
 
@@ -459,15 +559,18 @@ class Supervisor:
             self._spawn_worker(cmd.camera_id)
 
     def _on_remove_camera(self, cmd: RemoveCameraCmd) -> None:
+        cid = cmd.camera_id or ""
         with self._lock:
-            worker = self._workers.pop(cmd.camera_id or "", None)
+            worker = self._workers.pop(cid, None)
+        # Clear any pending restart state so a removed camera isn't resurrected.
+        self._restart_state.pop(cid, None)
         if worker is not None:
             try:
                 worker.stop()
             except Exception:  # noqa: BLE001
                 log.warning("error stopping removed worker %s", cmd.camera_id, exc_info=True)
             try:
-                self._client.request_provider_detach(cmd.camera_id or "")
+                self._client.request_provider_detach(cid)
             except Exception:  # noqa: BLE001
                 log.debug("provider detach request failed for %s", cmd.camera_id, exc_info=True)
 

--- a/tests/test_supervisor_health.py
+++ b/tests/test_supervisor_health.py
@@ -1,0 +1,268 @@
+"""Tests for R3' — worker liveness monitoring + auto-restart.
+
+All tests are headless and use no real threads: they drive
+``_scan_worker_health(now)`` directly with a synthetic monotonic clock so
+backoff / cap behaviour is deterministic.  The supervisor's ``worker_factory``
+injection keeps the existing fake-worker pattern from ``test_orchestration.py``.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.supervisor import (
+    _BASE_BACKOFF_S,
+    _MAX_BACKOFF_S,
+    _MAX_RESTART_ATTEMPTS,
+)
+
+# ── helpers / fakes ──────────────────────────────────────────────────────────
+
+
+def _camera_config(camera_id: str = "cam-1234abcd5678", name: str = "Cam"):
+    from autoptz.config.models import CameraConfig, SourceConfig
+
+    return CameraConfig(
+        id=camera_id,
+        name=name,
+        source=SourceConfig(type="usb", address="usb://0"),
+    )
+
+
+class _HealthFakeWorker:
+    """Minimal fake worker with a settable is_alive() result."""
+
+    def __init__(self, camera_id: str, config, on_telemetry) -> None:
+        self.camera_id = camera_id
+        self.config = config
+        self.on_telemetry = on_telemetry
+        self.shm_name = f"cam_{camera_id[:8]}_preview"
+        self._alive = True
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    @property
+    def is_running(self) -> bool:  # compat with _spawn_worker guards
+        return self._alive
+
+    def start(self) -> None:
+        self.start_calls += 1
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self.stop_calls += 1
+        self._alive = False
+
+
+def _make_client(qapp):
+    from autoptz.ui.engine_client import EngineClient
+
+    return EngineClient()
+
+
+def _make_sup_with_factory(client, factory):
+    from autoptz.engine.supervisor import Supervisor
+
+    return Supervisor(client, store=None, worker_factory=factory)
+
+
+def _build(qapp):
+    """Return (supervisor, client, factory_log, camera_id).
+
+    ``factory_log`` is a list of every worker the factory ever created
+    (one entry per factory call), so ``len(factory_log)`` counts total spawns
+    and ``factory_log[0]`` is the first worker, ``factory_log[-1]`` the latest.
+    """
+    client = _make_client(qapp)
+    cid = client.addCamera("usb://0", "X")
+    client.drain_commands()  # clear the add cmd
+
+    factory_log: list[_HealthFakeWorker] = []
+
+    def factory(camera_id, config, on_tel):
+        w = _HealthFakeWorker(camera_id, config, on_tel)
+        factory_log.append(w)
+        return w
+
+    sup = _make_sup_with_factory(client, factory)
+    # Stub out heavyweight helpers so the test stays headless.
+    sup._ensure_identity_service = lambda: None  # type: ignore[method-assign]
+    sup._ensure_inference_pool = lambda: None  # type: ignore[method-assign]
+    sup.start()
+    return sup, client, factory_log, cid
+
+
+# ── CameraWorker.is_alive() unit test ────────────────────────────────────────
+
+
+class TestCameraWorkerIsAlive:
+    def test_false_before_start(self, qapp) -> None:
+        """is_alive() is False before start(): _thread is None, no thread running."""
+        from autoptz.engine.camera_worker import CameraWorker
+
+        worker = CameraWorker(
+            "hltcam01abcd",
+            _camera_config("hltcam01abcd"),
+            lambda m: None,
+        )
+        assert worker._thread is None
+        assert worker.is_alive() is False
+
+
+# ── _scan_worker_health ───────────────────────────────────────────────────────
+
+
+class TestScanWorkerHealth:
+    def test_healthy_worker_is_not_touched(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            original = factory_log[0]
+            assert original._alive is True
+            sup._scan_worker_health(1000.0)
+            assert len(factory_log) == 1  # no new worker built
+            assert original.stop_calls == 0
+        finally:
+            sup.stop()
+
+    def test_dead_worker_is_respawned(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            factory_log[0]._alive = False
+            sup._scan_worker_health(1000.0)
+            # Factory called again → a second worker in the log.
+            assert len(factory_log) == 2
+            assert sup.has_worker(cid)
+            assert sup._workers[cid] is factory_log[1]
+        finally:
+            sup.stop()
+
+    def test_backoff_prevents_immediate_second_respawn(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            factory_log[0]._alive = False
+            now = 1000.0
+            sup._scan_worker_health(now)  # first respawn at t=1000
+            assert len(factory_log) == 2
+            # Simulate the new worker dying too.
+            factory_log[1]._alive = False
+            # Second scan immediately (before backoff expires) → no extra spawn.
+            sup._scan_worker_health(now + 0.1)
+            assert len(factory_log) == 2  # still just 2 workers
+        finally:
+            sup.stop()
+
+    def test_backoff_expires_and_allows_respawn(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            factory_log[0]._alive = False
+            now = 1000.0
+            sup._scan_worker_health(now)  # attempt 1 → factory_log[1] spawned
+            assert len(factory_log) == 2
+            # Kill the second worker.
+            factory_log[1]._alive = False
+            # Advance past the base backoff window (1 s).
+            sup._scan_worker_health(now + _BASE_BACKOFF_S + 0.1)  # attempt 2
+            assert len(factory_log) == 3  # original + 2 respawns
+        finally:
+            sup.stop()
+
+    def test_cap_stops_respawning(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            now = 1000.0
+            # Drive through all MAX attempts.
+            for _attempt in range(_MAX_RESTART_ATTEMPTS):
+                sup._workers[cid]._alive = False
+                # Advance well past any back-off.
+                now += _MAX_BACKOFF_S + 1.0
+                sup._scan_worker_health(now)
+
+            # After the cap is reached the last attempt is logged but no new
+            # worker is spawned; the restart_state stays at MAX.
+            count_at_cap = len(factory_log)
+            # Kill any remaining worker (may or may not still be registered).
+            if cid in sup._workers:
+                sup._workers[cid]._alive = False
+            now += _MAX_BACKOFF_S + 1.0
+            sup._scan_worker_health(now)
+            assert len(factory_log) == count_at_cap
+        finally:
+            sup.stop()
+
+    def test_remove_camera_clears_restart_state(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import RemoveCameraCmd
+
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            # Seed some restart state.
+            sup._restart_state[cid] = (2, 9999.0)
+            # Route a RemoveCamera command.
+            sup._on_remove_camera(RemoveCameraCmd(camera_id=cid))
+            assert cid not in sup._restart_state
+            assert not sup.has_worker(cid)
+        finally:
+            sup.stop()
+
+    def test_exponential_backoff_values(self, qapp) -> None:
+        """Back-off doubles each attempt, capped at _MAX_BACKOFF_S."""
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            now = 1000.0
+            for i in range(_MAX_RESTART_ATTEMPTS - 1):
+                sup._workers[cid]._alive = False
+                # Advance well past previous back-off so this attempt always fires.
+                now += _MAX_BACKOFF_S + 1.0
+                sup._scan_worker_health(now)
+                attempts, next_t = sup._restart_state.get(cid, (0, now))
+                expected_backoff = min(_MAX_BACKOFF_S, _BASE_BACKOFF_S * (2**i))
+                assert abs((next_t - now) - expected_backoff) < 0.01, (
+                    f"attempt {i + 1}: expected backoff {expected_backoff}, got {next_t - now}"
+                )
+        finally:
+            sup.stop()
+
+    def test_reset_on_recovery(self, qapp) -> None:
+        """A recovered worker resets backoff state so re-crash starts at attempt 1.
+
+        Scenario:
+        1. Worker crashes twice → _restart_state[cid] = (2, <future>).
+        2. Re-spawned worker is healthy on the next scan → state cleared.
+        3. Worker crashes again → next_allowed_t reflects the 1 s base delay
+           (attempt 1), NOT a continued-from-2 delay.
+        """
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            now = 1000.0
+
+            # --- Phase 1: crash twice so attempts accumulate to 2 ---
+            # First crash + respawn.
+            sup._workers[cid]._alive = False
+            now += _MAX_BACKOFF_S + 1.0
+            sup._scan_worker_health(now)  # attempt 1 → factory_log[1] spawned
+            assert len(factory_log) == 2
+
+            # Kill the second worker immediately.
+            factory_log[1]._alive = False
+            now += _MAX_BACKOFF_S + 1.0
+            sup._scan_worker_health(now)  # attempt 2 → factory_log[2] spawned
+            assert len(factory_log) == 3
+            assert sup._restart_state[cid][0] == 2  # two attempts recorded
+
+            # --- Phase 2: new worker is healthy → state cleared ---
+            # factory_log[2] starts alive (default); a scan sees it healthy.
+            sup._scan_worker_health(now + 1.0)
+            assert cid not in sup._restart_state  # recovery cleared the slate
+
+            # --- Phase 3: crash again → backoff starts over from attempt 1 ---
+            sup._workers[cid]._alive = False
+            t_crash = now + 2.0
+            sup._scan_worker_health(t_crash)  # attempt 1 fresh start
+            attempts, next_allowed_t = sup._restart_state[cid]
+            assert attempts == 1
+            # next_allowed_t should reflect _BASE_BACKOFF_S (1 s), not a 2^2 delay.
+            assert abs((next_allowed_t - t_crash) - _BASE_BACKOFF_S) < 0.01, (
+                f"expected base backoff {_BASE_BACKOFF_S} s after recovery, "
+                f"got {next_allowed_t - t_crash:.3f} s"
+            )
+        finally:
+            sup.stop()


### PR DESCRIPTION
The `Supervisor` spawned/stopped/routed but never monitored workers: if a `CameraWorker` capture thread died (unhandled exception), the camera went silently dark with no restart.

- `CameraWorker.is_alive()` (delegates to `is_running` — primary `_run` thread alive); process-per-camera already exposed `is_alive()`, so the interface is uniform.
- `Supervisor._scan_worker_health(now)` runs from `tick()`, throttled to `_HEALTH_SCAN_INTERVAL_S=2.0s`. A dead worker is restarted with exponential backoff (1,2,4,8,16,cap 30s), capped at `_MAX_RESTART_ATTEMPTS=5` (terminal warning logged once), and restart state RESETS when a worker recovers so a later crash starts fresh. `_on_remove_camera` clears restart state.
- Snapshot-under-lock then act (no deadlock with `_spawn_worker`); single-thread `tick()` serializes scan vs command routing.
- 9 new tests (synthetic clock, no real threads): dead→respawn, healthy→untouched, backoff values, cap, reset-on-recovery, remove-clears-state.

Roadmap item **R3′** (safety track). Real-camera crash/restart validation deferred to the 2.2.0 RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)