### PR TITLE
feat(ptz): R4′ auto-reconnect for VISCA-IP and VISCA-USB transports

### DIFF
--- a/autoptz/engine/ptz/reconnect.py
+++ b/autoptz/engine/ptz/reconnect.py
@@ -1,0 +1,49 @@
+"""Pure reconnect-policy helper for PTZ transports.
+
+No I/O — only time-based backoff bookkeeping.  Both ViscaIPBackend and
+ViscaUSBBackend hold one instance and consult it after every transport error.
+"""
+
+from __future__ import annotations
+
+
+class ReconnectPolicy:
+    """Exponential-backoff reconnect gate.
+
+    Args:
+        base_s: Base backoff delay in seconds (first failure waits this long).
+        cap_s:  Maximum backoff delay; subsequent failures are capped at this.
+
+    Usage::
+
+        policy = ReconnectPolicy()
+        ...
+        except OSError:
+            policy.record_failure(now)
+            if policy.should_attempt(now):
+                _open()
+                policy.record_success()
+    """
+
+    def __init__(self, base_s: float = 1.0, cap_s: float = 30.0) -> None:
+        self._base_s = base_s
+        self._cap_s = cap_s
+        self._attempts: int = 0
+        self._next_allowed_t: float = 0.0
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def should_attempt(self, now: float) -> bool:
+        """Return True when a reconnect attempt is permitted right now."""
+        return now >= self._next_allowed_t
+
+    def record_failure(self, now: float) -> None:
+        """Record a transport failure and schedule the next permitted attempt."""
+        self._attempts += 1
+        delay = min(self._cap_s, self._base_s * (2 ** (self._attempts - 1)))
+        self._next_allowed_t = now + delay
+
+    def record_success(self) -> None:
+        """Reset the policy after a successful (re)connection."""
+        self._attempts = 0
+        self._next_allowed_t = 0.0

--- a/autoptz/engine/ptz/visca_ip.py
+++ b/autoptz/engine/ptz/visca_ip.py
@@ -7,6 +7,11 @@ Supports two wire formats:
 Preset memory, zoom, and pan/tilt all use standard VISCA serial commands wrapped
 in the chosen transport framing.  Position inquiry (InqPanTiltPos) is issued on
 get_position() for cameras that answer it; others return None.
+
+Auto-reconnect: on any OSError the socket is closed and a ReconnectPolicy gate
+is consulted; if the backoff interval has elapsed a single reconnect attempt is
+made and the command is retried once.  Neither move_velocity nor stop ever raise
+into the caller.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ import logging
 import socket
 import struct
 import threading
+import time
 
 from autoptz.engine.ptz.base import (
     PTZBackend,
@@ -29,6 +35,7 @@ from autoptz.engine.ptz.base import (
     visca_zoom_cmd,
     visca_zoom_stop_cmd,
 )
+from autoptz.engine.ptz.reconnect import ReconnectPolicy
 
 log = logging.getLogger(__name__)
 
@@ -61,8 +68,13 @@ class ViscaIPBackend(PTZBackend):
         if mode not in ("sony", "raw"):
             raise ValueError(f"mode must be 'sony' or 'raw', got {mode!r}")
         self._mode = mode
+        self._host = host
+        self._port = port
+        self._timeout = timeout
         self._lock = threading.Lock()
         self._seq = 0  # VISCA-over-IP sequence counter (Sony mode)
+        self._policy = ReconnectPolicy()
+        self._connected: bool = False
 
         self.caps = PTZCaps(
             continuous_pan_tilt=True,
@@ -70,9 +82,32 @@ class ViscaIPBackend(PTZBackend):
             native_presets=True,
             query_position=True,  # best-effort; cameras that don't answer return None
         )
-        self._sock = socket.create_connection((host, port), timeout=timeout)
-        self._sock.settimeout(timeout)
-        log.info("ViscaIP connected to %s:%d (%s mode)", host, port, mode)
+        self._sock: socket.socket | None = None
+        self._open()
+
+    # ── connection management ─────────────────────────────────────────────────
+
+    def _open(self) -> None:
+        """Open (or reopen) the TCP socket; sets _connected=True on success."""
+        self._sock = socket.create_connection((self._host, self._port), timeout=self._timeout)
+        self._sock.settimeout(self._timeout)
+        self._connected = True
+        log.info("ViscaIP connected to %s:%d (%s mode)", self._host, self._port, self._mode)
+
+    def _close_sock(self) -> None:
+        """Close the current socket without raising."""
+        self._connected = False
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+
+    @property
+    def connected(self) -> bool:
+        """True while the TCP connection is believed to be live."""
+        return self._connected
 
     # ── framing ───────────────────────────────────────────────────────────────
 
@@ -85,12 +120,45 @@ class ViscaIPBackend(PTZBackend):
 
     def _send(self, visca_cmd: bytes) -> None:
         with self._lock:
-            self._sock.sendall(self._frame(visca_cmd))
+            # Fast path: socket is open and healthy.
+            if self._sock is not None:
+                try:
+                    self._sock.sendall(self._frame(visca_cmd))
+                    return
+                except OSError as _exc:
+                    log.debug("ViscaIP send failed (will reconnect): %s", _exc)
+                # Transport error on the existing socket — close it.
+                self._close_sock()
+
+            # Socket is None (either from a previous failure or just closed above).
+            # Check whether the policy allows a reconnect attempt right now.
+            now = time.monotonic()
+            if not self._policy.should_attempt(now):
+                return  # still in backoff window; swallow silently
+
+            # Attempt exactly one reconnect.
+            try:
+                self._open()
+                self._policy.record_success()
+            except OSError as exc:
+                log.warning("ViscaIP reconnect to %s:%d failed: %s", self._host, self._port, exc)
+                self._policy.record_failure(time.monotonic())
+                return
+
+            # Retry the command once on the fresh socket.
+            try:
+                self._sock.sendall(self._frame(visca_cmd))  # type: ignore[union-attr]
+            except OSError as exc:
+                log.warning("ViscaIP retry send failed: %s", exc)
+                self._close_sock()
+                self._policy.record_failure(time.monotonic())
 
     def _query(self, visca_inq: bytes, response_len: int) -> bytes | None:
         """Send inquiry and read fixed-length response; returns None on error."""
         try:
             with self._lock:
+                if self._sock is None:
+                    return None
                 self._sock.sendall(self._frame(visca_inq))
                 if self._mode == "sony":
                     # Sony: 8-byte header before payload
@@ -101,6 +169,11 @@ class ViscaIPBackend(PTZBackend):
                     return self._sock.recv(plen)
                 else:
                     return self._sock.recv(response_len)
+        except OSError:
+            now = time.monotonic()
+            self._close_sock()
+            self._policy.record_failure(now)
+            return None
         except Exception:
             return None
 
@@ -167,10 +240,7 @@ class ViscaIPBackend(PTZBackend):
             self.stop()
         except Exception:
             pass
-        try:
-            self._sock.close()
-        except Exception:
-            pass
+        self._close_sock()
         log.info("ViscaIP closed")
 
 

--- a/autoptz/engine/ptz/visca_usb.py
+++ b/autoptz/engine/ptz/visca_usb.py
@@ -3,11 +3,17 @@
 Wraps a pyserial connection to any Sony/compatible VISCA camera (EVI-D100, etc.).
 Normalized [-1, 1] pan/tilt/zoom maps to VISCA speed bytes 0x01–0x18 / 0x01–0x14 / 0x01–0x07.
 Presets are native VISCA memory commands (81 01 04 3F 01/02 MM FF).
+
+Auto-reconnect: on SerialException or OSError the port is closed and a
+ReconnectPolicy gate is consulted; if the backoff interval has elapsed a single
+reconnect is attempted and the command is retried once.  Neither move_velocity
+nor stop ever raise into the caller.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from autoptz.engine.ptz.base import (
@@ -23,8 +29,12 @@ from autoptz.engine.ptz.base import (
     visca_zoom_cmd,
     visca_zoom_stop_cmd,
 )
+from autoptz.engine.ptz.reconnect import ReconnectPolicy
 
 log = logging.getLogger(__name__)
+
+# Import serial at module level so tests can monkeypatch visca_usb.serial
+import serial  # noqa: E402  pyserial — already in requirements/base.txt
 
 
 class ViscaUSBBackend(PTZBackend):
@@ -38,8 +48,6 @@ class ViscaUSBBackend(PTZBackend):
 
     def __init__(self, port: str, baud: int = 9600, address: int = 1) -> None:
         super().__init__()
-        import serial  # pyserial — already in requirements/base.txt
-
         self.caps = PTZCaps(
             continuous_pan_tilt=True,
             continuous_zoom=True,
@@ -48,15 +56,82 @@ class ViscaUSBBackend(PTZBackend):
         )
         # address byte: camera 1 = 0x81, camera 2 = 0x82, …
         self._addr = 0x80 | (address & 0x07)
-        self._ser: Any = serial.Serial(port, baud, timeout=0.1)
-        log.info("ViscaUSB opened %s @ %d baud", port, baud)
+        self._port = port
+        self._baud = baud
+        self._policy = ReconnectPolicy()
+        self._connected: bool = False
+        self._ser: Any = None
+        self._open()
+
+    # ── connection management ─────────────────────────────────────────────────
+
+    def _open(self) -> None:
+        """Open (or reopen) the serial port; sets _connected=True on success."""
+        self._ser = serial.Serial(self._port, self._baud, timeout=0.1)
+        self._connected = True
+        log.info("ViscaUSB opened %s @ %d baud", self._port, self._baud)
+
+    def _close_ser(self) -> None:
+        """Close the serial port without raising."""
+        self._connected = False
+        if self._ser is not None:
+            try:
+                self._ser.close()
+            except Exception:
+                pass
+            self._ser = None
+
+    @property
+    def connected(self) -> bool:
+        """True while the serial port is believed to be live."""
+        return self._connected
 
     # ── helpers ───────────────────────────────────────────────────────────────
 
     def _send(self, cmd: bytes) -> None:
-        """Write VISCA command; drain any pending ACK/completion bytes first."""
+        """Write VISCA command; drain any pending ACK/completion bytes first.
+
+        On SerialException or OSError the port is closed and a reconnect is
+        attempted once (subject to backoff policy).  Never raises.
+        """
         # Patch address byte (index 0) to match configured camera address
         patched = bytes([self._addr]) + cmd[1:]
+
+        # Fast path: serial port is open and healthy.
+        if self._ser is not None:
+            try:
+                self._do_write(patched)
+                return
+            except (serial.SerialException, OSError) as _exc:
+                log.debug("ViscaUSB write failed (will reconnect): %s", _exc)
+            # Transport error on the existing port — close it.
+            self._close_ser()
+
+        # Port is None (either from a previous failure or just closed above).
+        # Check whether the policy allows a reconnect attempt right now.
+        now = time.monotonic()
+        if not self._policy.should_attempt(now):
+            return  # still in backoff window; swallow silently
+
+        # Attempt exactly one reconnect.
+        try:
+            self._open()
+            self._policy.record_success()
+        except (serial.SerialException, OSError) as exc:
+            log.warning("ViscaUSB reconnect to %s failed: %s", self._port, exc)
+            self._policy.record_failure(time.monotonic())
+            return
+
+        # Retry the command once on the fresh port.
+        try:
+            self._do_write(patched)
+        except (serial.SerialException, OSError) as exc:
+            log.warning("ViscaUSB retry write failed: %s", exc)
+            self._close_ser()
+            self._policy.record_failure(time.monotonic())
+
+    def _do_write(self, patched: bytes) -> None:
+        """Actually write to the serial port (factored out for clarity)."""
         pending = self._ser.in_waiting
         if pending:
             self._ser.read(pending)
@@ -94,8 +169,5 @@ class ViscaUSBBackend(PTZBackend):
             self.stop()
         except Exception:
             pass
-        try:
-            self._ser.close()
-        except Exception:
-            pass
+        self._close_ser()
         log.info("ViscaUSB closed")

--- a/tests/test_ptz_reconnect.py
+++ b/tests/test_ptz_reconnect.py
@@ -1,0 +1,442 @@
+"""Tests for PTZ transport auto-reconnect (R4').
+
+No real hardware — socket and serial are replaced by fake implementations
+injected via monkeypatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import autoptz.engine.ptz.visca_ip as visca_ip_mod
+import autoptz.engine.ptz.visca_usb as visca_usb_mod
+from autoptz.engine.ptz.reconnect import ReconnectPolicy
+from autoptz.engine.ptz.visca_ip import ViscaIPBackend
+from autoptz.engine.ptz.visca_usb import ViscaUSBBackend
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ReconnectPolicy unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReconnectPolicy:
+    def test_initially_allowed(self) -> None:
+        """Policy starts with _next_allowed_t=0 so any 'now' passes the gate."""
+        policy = ReconnectPolicy()
+        assert policy.should_attempt(0.0) is True
+        assert policy.should_attempt(100.0) is True
+
+    def test_failure_blocks_immediate_retry(self) -> None:
+        """After the first failure the next attempt must wait at least base_s."""
+        policy = ReconnectPolicy(base_s=1.0, cap_s=30.0)
+        policy.record_failure(now=0.0)
+        # Just-after the failure: still blocked
+        assert policy.should_attempt(0.0) is False
+        assert policy.should_attempt(0.99) is False
+
+    def test_failure_allows_after_backoff(self) -> None:
+        policy = ReconnectPolicy(base_s=1.0, cap_s=30.0)
+        policy.record_failure(now=0.0)
+        # Exactly at base_s the gate should open
+        assert policy.should_attempt(1.0) is True
+        assert policy.should_attempt(2.0) is True
+
+    def test_exponential_backoff_values(self) -> None:
+        """Delays should double each failure: 1, 2, 4, 8 (capped at 30)."""
+        policy = ReconnectPolicy(base_s=1.0, cap_s=30.0)
+        t = 0.0
+        expected_delays = [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0]
+        for expected in expected_delays:
+            policy.record_failure(now=t)
+            # Gate should open exactly at t+expected
+            assert policy.should_attempt(t + expected - 0.001) is False
+            assert policy.should_attempt(t + expected) is True
+            t += expected  # advance time past the backoff for the next iteration
+
+    def test_cap_limits_backoff(self) -> None:
+        """Backoff must never exceed cap_s."""
+        policy = ReconnectPolicy(base_s=1.0, cap_s=5.0)
+        t = 0.0
+        for _ in range(10):
+            policy.record_failure(now=t)
+            t += 5.0  # advance past any cap
+        # After many failures the delay is still capped at cap_s
+        policy.record_failure(now=t)
+        assert policy.should_attempt(t + 5.0) is True
+        assert policy.should_attempt(t + 4.99) is False
+
+    def test_record_success_resets(self) -> None:
+        """record_success must reset the attempts counter and unblock immediately."""
+        policy = ReconnectPolicy(base_s=1.0, cap_s=30.0)
+        policy.record_failure(now=0.0)
+        policy.record_failure(now=1.0)
+        assert policy.should_attempt(1.0) is False  # still blocked
+        policy.record_success()
+        assert policy.should_attempt(0.0) is True  # fully reset
+
+    def test_success_resets_exponential_growth(self) -> None:
+        """After success the next failure starts back from base_s."""
+        policy = ReconnectPolicy(base_s=1.0, cap_s=30.0)
+        # Wind up to a large backoff
+        t = 0.0
+        for _ in range(5):
+            policy.record_failure(now=t)
+            t += 32.0  # advance well past any delay
+        # Reset
+        policy.record_success()
+        # First failure after reset should use base_s again
+        policy.record_failure(now=t)
+        assert policy.should_attempt(t + 1.0) is True
+        assert policy.should_attempt(t + 0.5) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ViscaIPBackend reconnect tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class FakeSocket:
+    """Fake TCP socket that records sendall calls and can be flipped to raise."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.should_fail: bool = False
+        self.closed: bool = False
+
+    def sendall(self, data: bytes) -> None:
+        if self.should_fail:
+            raise OSError("simulated network failure")
+        self.sent.append(data)
+
+    def settimeout(self, t: float) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestViscaIPReconnect:
+    def _make_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[ViscaIPBackend, list[FakeSocket]]:
+        """Build a ViscaIPBackend with a monkeypatched create_connection.
+
+        Returns (backend, sockets_created) so tests can inspect/flip the fakes.
+        """
+        sockets: list[FakeSocket] = []
+
+        def fake_create_connection(
+            addr: tuple[str, int], timeout: float | None = None
+        ) -> FakeSocket:
+            s = FakeSocket()
+            sockets.append(s)
+            return s
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", fake_create_connection)
+        backend = ViscaIPBackend("192.0.2.1", port=52381, mode="raw", timeout=0.5)
+        return backend, sockets
+
+    def test_initial_connection_made(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Constructor must call create_connection exactly once."""
+        backend, sockets = self._make_backend(monkeypatch)
+        assert len(sockets) == 1
+        assert backend.connected is True
+
+    def test_normal_send_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """move_velocity over a healthy socket sends bytes without reconnecting."""
+        backend, sockets = self._make_backend(monkeypatch)
+        backend.move_velocity(0.5, 0.0)
+        assert len(sockets[0].sent) == 2  # pantilt + zoom
+
+    def test_error_disconnects(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError on sendall marks the backend as disconnected."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+        # Policy initially allows an attempt → a reconnect socket is created.
+        # The reconnect itself succeeds (new fake socket won't fail).
+        backend.move_velocity(0.5, 0.0)
+        # After reconnect succeeds, connected should be True
+        assert backend.connected is True
+
+    def test_reconnects_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After a transport error create_connection is called again."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        # A second socket should have been created during the reconnect
+        assert len(sockets) == 2
+
+    def test_retry_command_sent_on_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The failed command is retried on the fresh socket after reconnect."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        # The fresh socket (sockets[1]) should have received the retry
+        assert len(sockets) == 2
+        assert len(sockets[1].sent) >= 1
+
+    def test_connected_true_after_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """connected property is True after successful reconnect."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is True
+
+    def test_backoff_throttles_second_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A second immediate failure after a reconnect is throttled by the policy.
+
+        Uses a fake clock so the test is deterministic on any CI load.
+        """
+        # Pin the clock at t=0 so both _send calls see the same 'now'.
+        fake_now = [0.0]
+        monkeypatch.setattr(visca_ip_mod.time, "monotonic", lambda: fake_now[0])
+
+        backend, sockets = self._make_backend(monkeypatch)
+        # First failure → reconnect succeeds but we flip the new socket too
+        sockets[0].should_fail = True
+
+        def fake_create_connection_fail(
+            addr: tuple[str, int], timeout: float | None = None
+        ) -> FakeSocket:
+            s = FakeSocket()
+            s.should_fail = True  # reconnect socket also fails
+            sockets.append(s)
+            return s
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", fake_create_connection_fail)
+
+        # First call at t=0: original socket fails → reconnect socket also fails →
+        # policy records failure at t=0, sets _next_allowed_t = 1.0 → disconnected
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is False
+        sockets_after_first = len(sockets)
+
+        # Second call still at t=0 (< _next_allowed_t=1.0): policy blocks
+        backend.move_velocity(0.5, 0.0)
+        assert len(sockets) == sockets_after_first  # no new socket created
+
+        # Advance clock past the backoff window → policy now allows a reconnect
+        fake_now[0] = 2.0
+        backend.move_velocity(0.5, 0.0)
+        assert len(sockets) > sockets_after_first  # new reconnect attempt was made
+
+    def test_no_exception_from_move_velocity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """move_velocity must never raise even when the socket stays broken."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+
+        def always_fail(addr: tuple[str, int], timeout: float | None = None) -> FakeSocket:
+            raise OSError("still down")
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", always_fail)
+        backend.move_velocity(0.5, 0.0)  # must not raise
+
+    def test_no_exception_from_stop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stop() must never raise even when the socket stays broken."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+
+        def always_fail(addr: tuple[str, int], timeout: float | None = None) -> FakeSocket:
+            raise OSError("still down")
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", always_fail)
+        backend.stop()  # must not raise
+
+    def test_zoom_send_failure_triggers_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """move_velocity: pantilt send succeeds, zoom send fails → reconnect, no exception.
+
+        move_velocity calls _send(pantilt) then _send(zoom).  If the socket dies
+        between the two sends (e.g. the camera rebooted mid-frame), the zoom
+        _send must trigger a reconnect and must not raise into the caller.
+        """
+        backend, sockets = self._make_backend(monkeypatch)
+
+        # The initial socket (sockets[0]) succeeds the first sendall (pantilt)
+        # then fails on the second (zoom): flip should_fail after the first call.
+        send_count = [0]
+        _orig_sendall = sockets[0].sendall
+
+        def first_socket_sendall(data: bytes) -> None:
+            send_count[0] += 1
+            if send_count[0] >= 2:
+                raise OSError("simulated mid-move failure on zoom")
+            sockets[0].sent.append(data)
+
+        sockets[0].sendall = first_socket_sendall  # type: ignore[method-assign]
+
+        # move_velocity: first _send (pantilt) succeeds, second _send (zoom) fails
+        # → _send closes the socket, policy allows reconnect (first failure), reconnects
+        backend.move_velocity(0.5, 0.2)  # must not raise
+        # A second socket was created during the reconnect
+        assert len(sockets) == 2
+        assert backend.connected is True  # reconnect succeeded
+
+    def test_connected_false_when_down(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """connected is False when every attempt fails."""
+        backend, sockets = self._make_backend(monkeypatch)
+        sockets[0].should_fail = True
+
+        def always_fail(addr: tuple[str, int], timeout: float | None = None) -> FakeSocket:
+            raise OSError("still down")
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", always_fail)
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ViscaUSBBackend reconnect tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class FakeSerial:
+    """Fake pyserial Serial instance."""
+
+    def __init__(self, port: str, baud: int, timeout: float = 0.1) -> None:
+        self.port = port
+        self.baud = baud
+        self.written: list[bytes] = []
+        self.should_fail: bool = False
+        self.closed: bool = False
+        self.in_waiting: int = 0
+
+    def write(self, data: bytes) -> None:
+        if self.should_fail:
+            raise visca_usb_mod.serial.SerialException("simulated serial failure")
+        self.written.append(data)
+
+    def read(self, n: int) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSerialFactory:
+    """Collects all FakeSerial instances created so tests can inspect them."""
+
+    def __init__(self) -> None:
+        self.instances: list[FakeSerial] = []
+
+    def __call__(self, port: str, baud: int, timeout: float = 0.1) -> FakeSerial:
+        s = FakeSerial(port, baud, timeout)
+        self.instances.append(s)
+        return s
+
+
+class TestViscaUSBReconnect:
+    def _make_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[ViscaUSBBackend, FakeSerialFactory]:
+        factory = FakeSerialFactory()
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", factory)
+        backend = ViscaUSBBackend("/dev/ttyUSB0", baud=9600)
+        return backend, factory
+
+    def test_initial_open_called(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Constructor must open the serial port exactly once."""
+        backend, factory = self._make_backend(monkeypatch)
+        assert len(factory.instances) == 1
+        assert backend.connected is True
+
+    def test_normal_write_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """move_velocity over a healthy port writes bytes without reconnecting."""
+        backend, factory = self._make_backend(monkeypatch)
+        backend.move_velocity(0.5, 0.0)
+        assert len(factory.instances[0].written) == 2  # pantilt + zoom
+
+    def test_error_triggers_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SerialException causes a reconnect (second Serial() call)."""
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        assert len(factory.instances) == 2
+
+    def test_retry_on_fresh_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The command is retried on the fresh serial port after reconnect."""
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        assert len(factory.instances) == 2
+        assert len(factory.instances[1].written) >= 1
+
+    def test_connected_true_after_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is True
+
+    def test_backoff_throttles_second_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Backoff blocks a second reconnect attempt immediately after a failure.
+
+        Uses a fake clock so the test is deterministic on any CI load.
+        """
+        # Pin the clock at t=0 so both _send calls see the same 'now'.
+        fake_now = [0.0]
+        monkeypatch.setattr(visca_usb_mod.time, "monotonic", lambda: fake_now[0])
+
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+
+        # Override factory so second Serial() also fails
+        call_count = [0]
+
+        def failing_factory(port: str, baud: int, timeout: float = 0.1) -> FakeSerial:
+            call_count[0] += 1
+            s = FakeSerial(port, baud, timeout)
+            s.should_fail = True
+            factory.instances.append(s)
+            return s
+
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", failing_factory)
+
+        # First call at t=0: write fails → reconnect also fails →
+        # policy records failure at t=0, sets _next_allowed_t = 1.0 → disconnected
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is False
+        calls_after_first = call_count[0]
+
+        # Second call still at t=0 (< _next_allowed_t=1.0): policy blocks
+        backend.move_velocity(0.5, 0.0)
+        assert call_count[0] == calls_after_first  # no new Serial() call
+
+        # Advance clock past the backoff window → policy now allows a reconnect
+        fake_now[0] = 2.0
+        backend.move_velocity(0.5, 0.0)
+        assert call_count[0] > calls_after_first  # new Serial() call was made
+
+    def test_no_exception_from_move_velocity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """move_velocity must never raise even with a broken port."""
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+
+        def always_fail(port: str, baud: int, timeout: float = 0.1) -> Any:
+            raise visca_usb_mod.serial.SerialException("still down")
+
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", always_fail)
+        backend.move_velocity(0.5, 0.0)  # must not raise
+
+    def test_no_exception_from_stop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stop() must never raise even with a broken port."""
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+
+        def always_fail(port: str, baud: int, timeout: float = 0.1) -> Any:
+            raise visca_usb_mod.serial.SerialException("still down")
+
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", always_fail)
+        backend.stop()  # must not raise
+
+    def test_connected_false_when_down(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """connected is False when every Serial() attempt fails."""
+        backend, factory = self._make_backend(monkeypatch)
+        factory.instances[0].should_fail = True
+
+        def always_fail(port: str, baud: int, timeout: float = 0.1) -> Any:
+            raise visca_usb_mod.serial.SerialException("still down")
+
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", always_fail)
+        backend.move_velocity(0.5, 0.0)
+        assert backend.connected is False


### PR DESCRIPTION
The persistent-connection PTZ backends built their connection once and never reconnected: `ViscaIPBackend` (socket) and `ViscaUSBBackend` (serial) silently swallowed send errors, so a network blip or USB re-enumeration killed PTZ until app restart.

- New pure `ReconnectPolicy` (exponential backoff 1→2→4→8→16→cap 30s, reset on success).
- Both VISCA backends: connection creation extracted into `_open()`; on a transport error `_send`/`_query` close + mark `connected=False` + `record_failure`, then if the backoff allows, reopen + `record_success` + retry the send ONCE. Commands still never raise.
- **Control-thread safe:** `should_attempt()` is a pure time check (instant no-op during backoff); at most one reconnect per backoff interval, bounded by the short connect timeout — so it cannot stall the control loop or trip the R2′ watchdog.
- Additive `connected` health property.
- 26 new tests (injected fake socket/serial, no hardware): reconnect+retry, deterministic clock-controlled backoff throttling, `connected` transitions, never-raise.

Roadmap item **R4′** (safety track). ONVIF/NDI reconnect + manual/auto arbitration are noted follow-ups. Real-hardware blip validation deferred to the 2.2.0 RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)