### PR TITLE
release: 2.2.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to AutoPTZ are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project aims to
 follow [Semantic Versioning](https://semver.org/).
 
+## [2.2.0-rc1] — 2026-06-24
+
+> Pre-release for testing — please validate on your real cameras and report back
+> before this becomes the stable 2.2.0.
+
+### Added
+
+- **GPU acceleration check (`--bench`)** — run `python -m autoptz --bench` to see
+  whether your GPU/accelerator is actually faster than the CPU, with a plain verdict
+  (*accelerated* / *no-benefit* / *cpu-only*). It times the auto-selected execution
+  provider (CoreML, CUDA/TensorRT, DirectML, OpenVINO) against a CPU baseline, so you
+  can tell when, e.g., CoreML on an Intel Mac is silently running on the CPU.
+- **CoreML compile-cache** — the CoreML model is compiled once per machine and cached,
+  cutting cold-start on Apple Silicon and Intel Macs (and per-camera warmup when
+  running several cameras).
+- **Inference-hang watchdog** — if detection inference stalls, the camera now holds
+  position and shows a *degraded — inference stalled* status instead of driving the
+  PTZ toward a frozen target; it recovers automatically when inference resumes.
+- **Automatic camera recovery** — if a camera's processing thread crashes, the engine
+  detects it and restarts that camera automatically (with backoff) instead of letting
+  it go silently dark.
+- **PTZ auto-reconnect** — VISCA over IP and USB now reconnect automatically after a
+  network blip or a USB re-enumeration, instead of staying dead until you restart.
+
+### Fixed
+
+- CI reliability: deflaked the macOS app-memory test and the Qt widget-smoke subprocess
+  tests so continuous integration is no longer intermittently red.
+
 ## [2.1.0] — 2026-06-23
 
 ### Added

--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.1.0"
+__version__ = "2.2.0-rc1"
 
 
 def version() -> str:


### PR DESCRIPTION
First **pre-release** of the 2.2.0 reliability + performance roadmap, for real-hardware validation before the stable 2.2.0.

Bumps `autoptz.__version__` to `2.2.0-rc1` and adds the CHANGELOG entry. On merge, tag `v2.2.0-rc1` triggers the pre-release installer build (the `-` marks it pre-release for the in-app updater).

Bundled in rc1 (all merged, CI-green, multi-agent-reviewed):
- #82 `--bench` GPU-acceleration verdict (P1)
- #83 CoreML compile-cache (P3)
- #85 inference-hang watchdog (R2-prime)
- #86 worker liveness + auto-restart (R3-prime)
- #87 VISCA PTZ auto-reconnect (R4-prime)
- #84/#88 CI deflakes

More to come in rc2: live bench verdict in the UI, OpenVINO-CPU + auto model-tier, stable Win/Linux device binding, installer auto-detect, scene-adaptive thresholds, and the heavy target-association/batching/int8 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)