### PR TITLE
feat(ui): A-2 surface GPU-acceleration verdict live in the Services panel

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3860,6 +3860,19 @@ class CameraWorker:
             str(getattr(pool, "detector_ep", "") or "") if pool is not None else ""
         )
         detector_error = str(getattr(pool, "detector_error", "") or "") if pool is not None else ""
+        # Read cached acceleration verdict (never triggers a measurement here —
+        # that runs once on a daemon thread from warmup_detector).
+        _no_accel: Any = lambda: ""  # noqa: E731
+        accel_summary = (
+            str(getattr(pool, "detector_accel_summary", _no_accel)() or "")
+            if pool is not None
+            else ""
+        )
+        accel_verdict = (
+            str(getattr(pool, "detector_accel_verdict", _no_accel)() or "")
+            if pool is not None
+            else ""
+        )
         cap = self._source_fps_cap()
         target_fps = self._target_fps()
         tracking = self.config.tracking
@@ -3870,6 +3883,13 @@ class CameraWorker:
         det_enabled = self._feature("detection")
         det_available = self._detect is not None
         det_failed = det_enabled and not det_available and bool(detector_error)
+        # Base detail for the detector row; append the accel summary when available.
+        if det_failed:
+            det_detail = detector_error
+        else:
+            det_detail = detector_model or "per-camera detector"
+            if accel_summary:
+                det_detail = f"{det_detail} · {accel_summary}"
         return [
             RuntimeServiceInfo(
                 key="detector",
@@ -3881,10 +3901,11 @@ class CameraWorker:
                 state="failed"
                 if det_failed
                 else self._stage_status("detect", enabled=det_enabled, available=det_available),
-                detail=detector_error if det_failed else (detector_model or "per-camera detector"),
+                detail=det_detail,
                 model=detector_model,
                 tier=detector_tier,
                 ep=detector_ep,
+                confidence=accel_verdict,
             ),
             RuntimeServiceInfo(
                 key="tracker",

--- a/autoptz/engine/pipeline/pool.py
+++ b/autoptz/engine/pipeline/pool.py
@@ -168,6 +168,10 @@ class InferencePool:
         # Reason the detector couldn't be built ("" = fine / not yet tried),
         # surfaced to the UI so a silent live-preview-only fall-back is visible.
         self._detector_error = ""
+        # Acceleration verdict — measured once, lazily, off the hot path.
+        # State: "idle" → "measuring" → "done" | "unavailable"
+        self._detector_accel: Any | None = None  # AccelReport | None
+        self._accel_state: str = "idle"
         self._switch_lock = threading.Lock()
         self._switch_state: dict[str, Any] | None = None
 
@@ -552,6 +556,58 @@ class InferencePool:
 
         return np.zeros((size, size, 3), dtype=np.uint8)
 
+    # ── acceleration verdict (measure once, lazily, off the hot path) ───────────────
+
+    def measure_detector_acceleration(self) -> None:
+        """Time the detector EP vs CPU baseline and cache the verdict.
+
+        Designed to run on a daemon thread (spawned from ``warmup_detector``
+        after the dummy inference warms the EP).  Safe to call directly in tests
+        — no thread is created here.
+
+        Guards:
+        - Only runs for the plain detector path (not unified-pose).
+        - Requires a real ``_detector_model_path`` (not empty / placeholder).
+        - Only transitions from "idle"; re-entry is a no-op.
+        - Never raises (BLE001).
+        """
+        if self._accel_state != "idle":
+            return
+        # Skip unified-pose path — model path is a placeholder, not an ONNX file.
+        if self._unified_pose:
+            return
+        path = self._detector_model_path
+        if not path or path.startswith("<"):
+            return
+        self._accel_state = "measuring"
+        try:
+            from autoptz.engine.runtime.bench import measure_acceleration
+
+            report = measure_acceleration(path, warmup=2, runs=8)
+            self._detector_accel = report
+            self._accel_state = "done"
+            log.info(
+                "inference pool: detector accel verdict=%s (%s)",
+                report.verdict,
+                report.summary(),
+            )
+        except Exception:  # noqa: BLE001 — acceleration bench is a nicety
+            self._detector_accel = None
+            self._accel_state = "unavailable"
+            log.debug("inference pool: detector acceleration measurement failed", exc_info=True)
+
+    def detector_accel_summary(self) -> str:
+        """Human-readable acceleration summary, or "" if not yet measured."""
+        if self._accel_state != "done" or self._detector_accel is None:
+            return ""
+        return str(self._detector_accel.summary())
+
+    def detector_accel_verdict(self) -> str:
+        """Verdict string ("accelerated"/"no-benefit"/"cpu-only"), or "" if not done."""
+        if self._accel_state != "done" or self._detector_accel is None:
+            return ""
+        return str(self._detector_accel.verdict)
+
     def warmup_detector(self) -> None:
         """Build the detector and run one dummy frame so its EP compiles now."""
         det = self.detector()
@@ -561,6 +617,11 @@ class InferencePool:
             det.detect(self._dummy_frame())
         except Exception:  # noqa: BLE001 — warmup must never break startup
             log.debug("inference pool: detector warmup inference failed", exc_info=True)
+        # Kick off the acceleration measurement on a background daemon thread so
+        # warmup never blocks startup.  Tests call measure_detector_acceleration()
+        # directly instead (no thread).
+        t = threading.Thread(target=self.measure_detector_acceleration, daemon=True)
+        t.start()
 
     def warmup_face(self) -> None:
         """Build the face stack and run one dummy frame to pre-compile it."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -367,3 +367,104 @@ class TestLogExport:
         # A path under a non-existent directory cannot be written.
         ok = client.exportLogs("/no/such/dir/AUTOPTZ/logs.txt")
         assert ok is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _runtime_services: detector row accel verdict (A-2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRuntimeServicesAccelVerdict:
+    """Detector row in _runtime_services reflects the cached accel summary/verdict.
+
+    Uses a fake pool that pre-exposes detector_accel_summary/verdict so no real
+    ONNX session or model file is needed.  Calls _runtime_services() directly
+    (no thread, no frame loop).
+    """
+
+    def _make_worker_with_pool(self, pool):
+        from autoptz.config.models import CameraConfig, SourceConfig
+        from autoptz.engine.camera_worker import CameraWorker
+
+        config = CameraConfig(
+            id="svctest01accd",
+            name="Cam",
+            source=SourceConfig(type="usb", address="usb://0"),
+        )
+        worker = CameraWorker(
+            "svctest01accd",
+            config,
+            lambda m: None,
+            frame_source=_FakeSource(),
+        )
+        worker.set_inference_pool(pool)
+        return worker
+
+    def test_detector_row_contains_accel_summary(self) -> None:
+        import types
+
+        fake_pool = types.SimpleNamespace(
+            detector_model_name="yolo11n.onnx",
+            detector_tier="auto",
+            detector_ep="CoreMLExecutionProvider",
+            detector_error="",
+            detector_accel_summary=lambda: "CoreML · fp32 · 1.24× CPU (accelerated: GPU/accelerator is helping)",
+            detector_accel_verdict=lambda: "accelerated",
+        )
+        worker = self._make_worker_with_pool(fake_pool)
+        rows = worker._runtime_services()
+        det_row = next(r for r in rows if r.key == "detector")
+        assert "1.24×" in det_row.detail
+        assert "CoreML" in det_row.detail
+
+    def test_detector_row_confidence_is_verdict(self) -> None:
+        import types
+
+        fake_pool = types.SimpleNamespace(
+            detector_model_name="yolo11n.onnx",
+            detector_tier="auto",
+            detector_ep="CoreMLExecutionProvider",
+            detector_error="",
+            detector_accel_summary=lambda: "CoreML · fp32 · 0.98× CPU (no-benefit: accelerator selected but no faster than CPU)",
+            detector_accel_verdict=lambda: "no-benefit",
+        )
+        worker = self._make_worker_with_pool(fake_pool)
+        rows = worker._runtime_services()
+        det_row = next(r for r in rows if r.key == "detector")
+        assert det_row.confidence == "no-benefit"
+
+    def test_detector_row_no_accel_summary_when_not_ready(self) -> None:
+        """When pool has not yet measured (summary=""), detail has no '·' suffix."""
+        import types
+
+        fake_pool = types.SimpleNamespace(
+            detector_model_name="yolo11n.onnx",
+            detector_tier="auto",
+            detector_ep="CPUExecutionProvider",
+            detector_error="",
+            detector_accel_summary=lambda: "",
+            detector_accel_verdict=lambda: "",
+        )
+        worker = self._make_worker_with_pool(fake_pool)
+        rows = worker._runtime_services()
+        det_row = next(r for r in rows if r.key == "detector")
+        # Detail should just be the model name, no appended accel text.
+        assert det_row.detail == "yolo11n.onnx"
+        assert det_row.confidence == ""
+
+    def test_detector_row_no_crash_when_pool_lacks_accel_attrs(self) -> None:
+        """getattr guard: a pool without accel methods does not crash the tick."""
+        import types
+
+        # Old-style fake pool without accel attributes.
+        fake_pool = types.SimpleNamespace(
+            detector_model_name="yolo11n.onnx",
+            detector_tier="auto",
+            detector_ep="CPUExecutionProvider",
+            detector_error="",
+            # no detector_accel_summary / detector_accel_verdict
+        )
+        worker = self._make_worker_with_pool(fake_pool)
+        rows = worker._runtime_services()  # must not raise
+        det_row = next(r for r in rows if r.key == "detector")
+        assert det_row.confidence == ""

--- a/tests/test_pool_accel.py
+++ b/tests/test_pool_accel.py
@@ -1,0 +1,180 @@
+"""Tests for InferencePool acceleration caching (A-2).
+
+Covers:
+- measure_detector_acceleration() happy path → state "done", verdict/summary exposed.
+- Failure path → state "unavailable", verdict/summary empty.
+- Unified-pose path → skipped (state stays "idle").
+- Empty model path → skipped (state stays "idle").
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.runtime.bench import AccelReport, LatencyStats
+from autoptz.engine.runtime.inference import EP
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _fake_report(verdict_str: str = "accelerated", summary_str: str = "") -> AccelReport:
+    """Build a real AccelReport with synthetic but valid latency stats."""
+    stats = LatencyStats(runs=8, median_ms=2.0, p95_ms=3.0, mean_ms=2.2, fps=500.0)
+    return AccelReport(
+        model="yolo11n.onnx",
+        requested_ep=EP.COREML.value,
+        actual_ep=EP.COREML.value if verdict_str == "accelerated" else EP.CPU.value,
+        precision="fp32",
+        speedup=1.24 if verdict_str == "accelerated" else 0.98,
+        verdict=verdict_str,
+        accel=stats,
+        cpu=stats,
+    )
+
+
+def _make_pool(unified_pose: bool = False, model_path: str = "/fake/model.onnx") -> object:
+    """Return an InferencePool with pre-seeded detector state (no I/O)."""
+    from autoptz.engine.pipeline.pool import InferencePool
+
+    pool = InferencePool(allow_model_download=False)
+    pool._unified_pose = unified_pose
+    pool._detector_model_path = model_path
+    # Simulate "detector already built" so measure_detector_acceleration can check state.
+    pool._detector_built = True
+    return pool
+
+
+# ── pool: happy path ─────────────────────────────────────────────────────────
+
+
+class TestMeasureDetectorAcceleration:
+    def test_done_state_and_verdict(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        report = _fake_report("accelerated")
+        monkeypatch.setattr(bench_mod, "measure_acceleration", lambda p, warmup, runs: report)
+        pool = _make_pool()
+        pool.measure_detector_acceleration()
+
+        assert pool._accel_state == "done"
+        assert pool.detector_accel_verdict() == "accelerated"
+        assert pool.detector_accel_summary() != ""
+        assert "CoreML" in pool.detector_accel_summary()
+
+    def test_accel_summary_non_empty_on_done(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        report = _fake_report("accelerated")
+        monkeypatch.setattr(bench_mod, "measure_acceleration", lambda p, warmup, runs: report)
+        pool = _make_pool()
+        pool.measure_detector_acceleration()
+        assert pool.detector_accel_summary() != ""
+
+    def test_no_benefit_verdict_exposed(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        report = _fake_report("no-benefit")
+        monkeypatch.setattr(bench_mod, "measure_acceleration", lambda p, warmup, runs: report)
+        pool = _make_pool()
+        pool.measure_detector_acceleration()
+        assert pool.detector_accel_verdict() == "no-benefit"
+
+    def test_cpu_only_verdict_exposed(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        report = _fake_report("cpu-only")
+        monkeypatch.setattr(bench_mod, "measure_acceleration", lambda p, warmup, runs: report)
+        pool = _make_pool()
+        pool.measure_detector_acceleration()
+        assert pool.detector_accel_verdict() == "cpu-only"
+
+
+# ── pool: failure path ────────────────────────────────────────────────────────
+
+
+class TestMeasureDetectorAccelFailure:
+    def test_unavailable_on_exception(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        monkeypatch.setattr(
+            bench_mod,
+            "measure_acceleration",
+            lambda p, warmup, runs: (_ for _ in ()).throw(RuntimeError("ort broken")),
+        )
+        pool = _make_pool()
+        pool.measure_detector_acceleration()  # must not raise
+        assert pool._accel_state == "unavailable"
+        assert pool.detector_accel_verdict() == ""
+        assert pool.detector_accel_summary() == ""
+
+
+# ── pool: skip guards ─────────────────────────────────────────────────────────
+
+
+class TestMeasureDetectorAccelSkips:
+    def test_skips_unified_pose(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        called = []
+        monkeypatch.setattr(
+            bench_mod,
+            "measure_acceleration",
+            lambda p, warmup, runs: called.append(p) or _fake_report(),
+        )
+        pool = _make_pool(unified_pose=True)
+        pool.measure_detector_acceleration()
+        assert not called, "measure_acceleration must not be called for unified-pose"
+        assert pool._accel_state == "idle"
+
+    def test_skips_empty_model_path(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        called = []
+        monkeypatch.setattr(
+            bench_mod,
+            "measure_acceleration",
+            lambda p, warmup, runs: called.append(p) or _fake_report(),
+        )
+        pool = _make_pool(model_path="")
+        pool.measure_detector_acceleration()
+        assert not called
+        assert pool._accel_state == "idle"
+
+    def test_skips_placeholder_model_path(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        called = []
+        monkeypatch.setattr(
+            bench_mod,
+            "measure_acceleration",
+            lambda p, warmup, runs: called.append(p) or _fake_report(),
+        )
+        pool = _make_pool(model_path="<yolo11-pose unified>")
+        pool.measure_detector_acceleration()
+        assert not called
+        assert pool._accel_state == "idle"
+
+    def test_skips_if_already_done(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import bench as bench_mod
+
+        called = []
+        monkeypatch.setattr(
+            bench_mod,
+            "measure_acceleration",
+            lambda p, warmup, runs: called.append(p) or _fake_report(),
+        )
+        pool = _make_pool()
+        pool._accel_state = "done"
+        pool.measure_detector_acceleration()
+        assert not called, "must not re-measure if state is already done"
+
+
+# ── pool: initial state ───────────────────────────────────────────────────────
+
+
+class TestPoolAccelInitialState:
+    def test_summary_empty_before_measurement(self) -> None:
+        from autoptz.engine.pipeline.pool import InferencePool
+
+        pool = InferencePool(allow_model_download=False)
+        assert pool.detector_accel_summary() == ""
+        assert pool.detector_accel_verdict() == ""
+        assert pool._accel_state == "idle"


### PR DESCRIPTION
Follow-up to #82: the `--bench` GPU-acceleration verdict now shows **in the running app** (Services panel), not just the CLI — so you can see e.g. *CoreML · 1.24× CPU (accelerated)* or, on an Intel Mac silently on CPU, *CoreML · 0.98× CPU (no-benefit)* without leaving the app.

- `InferencePool` measures the detector acceleration ONCE, **lazily on a background daemon thread** kicked off from `warmup_detector` (never blocks startup; small warmup=2/runs=8; never raises — a nicety, not load-bearing). Cached + exposed via `detector_accel_summary()/verdict()`.
- `_runtime_services` enriches the detector `RuntimeServiceInfo` row: verdict in `confidence`, human summary appended to `detail`. Reads the CACHED value only — never measures on the telemetry tick.
- 14 new tests (pool caching incl. failure/skip paths + `_runtime_services` integration), reusing the real `AccelReport` shape.

Roadmap item **A-2** (rc2). The live verdict is the operator-facing payoff of the bench tooling — validate on real hardware at the RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)