### PR TITLE
feat(install): auto-select OpenVINO for Intel CPU/iGPU on Linux (P6)

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -61,6 +61,25 @@ def test_linux_nvidia_auto_uses_nvidia_swap() -> None:
     assert ("install", "-r", "requirements/gpu-nvidia.txt") in args
 
 
+def test_linux_intel_auto_uses_openvino_swap() -> None:
+    # Intel CPU/iGPU on Linux with no NVIDIA → OpenVINO (faster than the stock CPU EP).
+    system = SystemInfo("Linux", "x86_64", ("Intel Corporation UHD Graphics 770",))
+
+    args = _step_args(system)
+
+    assert ("install", "-r", "requirements/openvino.txt") in args
+
+
+def test_linux_nvidia_beats_intel_when_both_present() -> None:
+    # A box with both an NVIDIA dGPU and an Intel iGPU should pick NVIDIA, not OpenVINO.
+    system = SystemInfo("Linux", "x86_64", ("Intel UHD Graphics", "NVIDIA RTX 4090"))
+
+    args = _step_args(system)
+
+    assert ("install", "-r", "requirements/gpu-nvidia.txt") in args
+    assert ("install", "-r", "requirements/openvino.txt") not in args
+
+
 def test_macos_auto_stays_on_base_coreml_wheel() -> None:
     system = SystemInfo("Darwin", "arm64", ("Apple M3",))
 

--- a/tools/install.py
+++ b/tools/install.py
@@ -55,6 +55,10 @@ class SystemInfo:
     def has_nvidia_gpu(self) -> bool:
         return any("nvidia" in name.lower() for name in self.gpu_names)
 
+    @property
+    def has_intel_gpu(self) -> bool:
+        return any("intel" in name.lower() for name in self.gpu_names)
+
     def label(self) -> str:
         gpu_label = ", ".join(self.gpu_names) if self.gpu_names else "no GPU name detected"
         return f"{self.os_name} {self.machine} ({gpu_label})"
@@ -178,6 +182,9 @@ def _auto_accelerator(system: SystemInfo) -> Accelerator | None:
         return "directml"
     if system.is_linux and system.has_nvidia_gpu:
         return "nvidia"
+    # Intel CPU/iGPU (no discrete NVIDIA): OpenVINO beats the stock CPU EP on Intel.
+    if system.is_linux and system.has_intel_gpu:
+        return "openvino"
     return None
 
 


### PR DESCRIPTION
The `auto` installer already auto-detects and picks the right accelerator wheel — DirectML on Windows, NVIDIA (TensorRT/CUDA) on Linux+NVIDIA, CoreML on macOS. The one gap: Intel Linux machines (no discrete NVIDIA) fell through to the stock CPU ONNX Runtime, when **OpenVINO is meaningfully faster on Intel CPUs/iGPUs**.

This adds a `has_intel_gpu` probe and makes `_auto_accelerator` return `openvino` for Linux + Intel (no NVIDIA), so `python tools/install.py` picks the OpenVINO wheel automatically there. NVIDIA still wins when both an NVIDIA dGPU and Intel iGPU are present.

2 new tests (Intel→OpenVINO, NVIDIA-beats-Intel). Roadmap item **P6** (folds in P5s OpenVINO-on-Intel intent). The in-app accelerator switch remains a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)