### PR TITLE
perf(engine): adaptive subservice cadence + phase-stagger to cut CPU usage & spikes

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -404,6 +404,9 @@ class CameraWorker:
         self._reid_probed = False
         self._last_reid_t = 0.0
         self._reid_recover_candidate: tuple[int, int] | None = None
+        # Phase-stagger: seeded once on the first inference-loop tick so face,
+        # ReID, and pose don't all fire on the same appearance-thread iteration.
+        self._phase_seeded = False
 
         # Aim-error velocity estimate (normalized error units / second), fed to the
         # PTZ controller so its feed-forward + motion prediction actually engage —
@@ -1619,7 +1622,7 @@ class CameraWorker:
         reid = self._ensure_reid()
         if reid is None or not getattr(reid, "available", False):
             return
-        if now - self._last_reid_t < _REID_INTERVAL_S:
+        if now - self._last_reid_t < self._effective_reid_interval():
             return
         self._last_reid_t = now
 
@@ -2022,8 +2025,11 @@ class CameraWorker:
             self._pose_keypoints = None
             self._reset_pose_aim()
 
-        # Re-estimate only every _POSE_INTERVAL_S; reuse last keypoints between.
-        if self._pose_keypoints is None or now - self._last_pose_t >= _POSE_INTERVAL_S:
+        # Re-estimate only every _effective_pose_interval(); reuse last keypoints between.
+        if (
+            self._pose_keypoints is None
+            or now - self._last_pose_t >= self._effective_pose_interval()
+        ):
             pose_t0 = time.perf_counter()
             kps = pose.estimate(frame, bbox)
             self._pose_ms = (time.perf_counter() - pose_t0) * 1000.0
@@ -2328,6 +2334,7 @@ class CameraWorker:
             self._frames_inferred += 1
             self._current_inference_frame_id = fid
             now = time.monotonic()
+            self._seed_subservice_phases(now)
 
             detect_t0 = time.perf_counter()
             tracks = self._maybe_track(frame)
@@ -3121,7 +3128,7 @@ class CameraWorker:
         if frame is None or face is None or not getattr(face.recognizer, "available", False):
             self._clear_face_overlay()
             return
-        if now - self._last_face_t < _FACE_INTERVAL_S:
+        if now - self._last_face_t < self._effective_face_interval():
             self._expire_face_overlay(now, tracks)
             # Still keep identity-targeting honest even without the face stack:
             # if an explicit identity target can't be resolved we leave the
@@ -3553,6 +3560,54 @@ class CameraWorker:
             snapshot = list(samples)
         return float(sum(snapshot) / len(snapshot))
 
+    # ── adaptive subservice cadence (CPU governor) ──────────────────────────────
+
+    def _quality_scale(self) -> float:
+        """Multiplier for subservice intervals based on active quality tier.
+
+        ``high`` / ``auto`` (stable headroom) → 1.0 (run at the base cadence)
+        ``balanced`` (near budget) → 1.25 (modest relaxation under moderate load)
+        ``low`` (over budget) → 2.0 (run at half speed when the machine is over budget)
+
+        Subservices run at FULL cadence unless the machine is near or over its
+        frame budget.  The phase-stagger still smooths burst spikes at all load
+        levels, so there is no need to throttle proactively at idle.
+        """
+        q = self._quality_active
+        if q == "low":
+            return 2.0
+        if q == "balanced":
+            return 1.25
+        return 1.0  # "high", "auto", or any unrecognised value → full cadence
+
+    def _effective_face_interval(self) -> float:
+        """Face-recognition run period after quality scaling (seconds)."""
+        return _FACE_INTERVAL_S * self._quality_scale()
+
+    def _effective_reid_interval(self) -> float:
+        """ReID run period after quality scaling (seconds)."""
+        return _REID_INTERVAL_S * self._quality_scale()
+
+    def _effective_pose_interval(self) -> float:
+        """Pose-estimation run period after quality scaling (seconds)."""
+        return _POSE_INTERVAL_S * self._quality_scale()
+
+    def _seed_subservice_phases(self, now: float) -> None:
+        """One-time phase-stagger: offset ReID and pose from face so they don't
+        all fire on the same appearance-thread tick.
+
+        Called from the inference loop the first time ``now`` is known; guarded
+        by ``_phase_seeded`` so it is a no-op on every subsequent call.
+        """
+        if self._phase_seeded:
+            return
+        # Offset ReID by half a period and pose by a third so the three heavy
+        # appearance passes are evenly distributed across the cadence window
+        # instead of all firing at t=0.
+        self._last_reid_t = now - _REID_INTERVAL_S * 0.5
+        self._last_pose_t = now - _POSE_INTERVAL_S * 0.33
+        self._phase_seeded = True
+
     def _effective_detect_interval(self) -> int:
         """Return the actual detector cadence after quality policy is applied."""
         base = max(1, int(getattr(self.config.tracking, "detect_interval", 1) or 1))
@@ -3586,8 +3641,8 @@ class CameraWorker:
             reason = "Auto quality: runtime cost is near frame budget; detector cadence balanced."
         else:
             interval = base
-            active = "balanced"
-            reason = "Auto quality: latency headroom stable."
+            active = "high"
+            reason = "Auto quality: latency headroom stable; quality high, full cadence."
         if interval != self._quality_interval or active != self._quality_active:
             self._add_event("quality", reason)
         self._quality_interval = interval

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -1,0 +1,231 @@
+"""CPU subservice governor — adaptive cadence + phase-stagger tests.
+
+Tests the quality-scale helpers and one-time phase-stagger seeding added to
+CameraWorker.  No real threads are started — the worker is constructed but
+never ``start()``-ed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from autoptz.engine.camera_worker import (
+    _FACE_INTERVAL_S,
+    _POSE_INTERVAL_S,
+    _REID_INTERVAL_S,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared fixture
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeSource:
+    """Minimal frame source — never called in these tests."""
+
+    def open(self) -> bool:
+        return True
+
+    def read(self):
+        return np.full((240, 320, 3), 100, dtype=np.uint8)
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture()
+def worker():
+    from autoptz.config.models import CameraConfig, SourceConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    config = CameraConfig(
+        id="govtest01abcd",
+        name="Gov",
+        source=SourceConfig(type="usb", address="usb://0"),
+    )
+    w = CameraWorker(
+        "govtest01abcd",
+        config,
+        lambda _m: None,
+        frame_source=_FakeSource(),
+    )
+    # Worker is intentionally NOT started — pure attribute inspection.
+    return w
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _quality_scale
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestQualityScale:
+    def test_high_returns_1_0(self, worker) -> None:
+        worker._quality_active = "high"
+        assert worker._quality_scale() == pytest.approx(1.0)
+
+    def test_balanced_returns_1_25(self, worker) -> None:
+        worker._quality_active = "balanced"
+        assert worker._quality_scale() == pytest.approx(1.25)
+
+    def test_auto_returns_1_0(self, worker) -> None:
+        worker._quality_active = "auto"
+        assert worker._quality_scale() == pytest.approx(1.0)
+
+    def test_low_returns_2_0(self, worker) -> None:
+        worker._quality_active = "low"
+        assert worker._quality_scale() == pytest.approx(2.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Effective interval getters
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEffectiveIntervals:
+    @pytest.mark.parametrize(
+        "quality, scale",
+        [
+            ("high", 1.0),
+            ("balanced", 1.25),
+            ("auto", 1.0),
+            ("low", 2.0),
+        ],
+    )
+    def test_face_interval(self, worker, quality, scale) -> None:
+        worker._quality_active = quality
+        assert worker._effective_face_interval() == pytest.approx(_FACE_INTERVAL_S * scale)
+
+    @pytest.mark.parametrize(
+        "quality, scale",
+        [
+            ("high", 1.0),
+            ("balanced", 1.25),
+            ("auto", 1.0),
+            ("low", 2.0),
+        ],
+    )
+    def test_reid_interval(self, worker, quality, scale) -> None:
+        worker._quality_active = quality
+        assert worker._effective_reid_interval() == pytest.approx(_REID_INTERVAL_S * scale)
+
+    @pytest.mark.parametrize(
+        "quality, scale",
+        [
+            ("high", 1.0),
+            ("balanced", 1.25),
+            ("auto", 1.0),
+            ("low", 2.0),
+        ],
+    )
+    def test_pose_interval(self, worker, quality, scale) -> None:
+        worker._quality_active = quality
+        assert worker._effective_pose_interval() == pytest.approx(_POSE_INTERVAL_S * scale)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression: high quality == base constants exactly
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHighQualityRegression:
+    """At high quality the effective intervals must equal the base constants."""
+
+    def test_face_equals_base(self, worker) -> None:
+        worker._quality_active = "high"
+        assert worker._effective_face_interval() == _FACE_INTERVAL_S
+
+    def test_reid_equals_base(self, worker) -> None:
+        worker._quality_active = "high"
+        assert worker._effective_reid_interval() == _REID_INTERVAL_S
+
+    def test_pose_equals_base(self, worker) -> None:
+        worker._quality_active = "high"
+        assert worker._effective_pose_interval() == _POSE_INTERVAL_S
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase-stagger: _seed_subservice_phases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPhaseStagger:
+    def test_seed_sets_reid_offset(self, worker) -> None:
+        """_last_reid_t is set to now - _REID_INTERVAL_S * 0.5."""
+        worker._phase_seeded = False
+        now = 1000.0
+        worker._seed_subservice_phases(now)
+        assert worker._last_reid_t == pytest.approx(now - _REID_INTERVAL_S * 0.5)
+
+    def test_seed_sets_pose_offset(self, worker) -> None:
+        """_last_pose_t is set to now - _POSE_INTERVAL_S * 0.33."""
+        worker._phase_seeded = False
+        now = 1000.0
+        worker._seed_subservice_phases(now)
+        assert worker._last_pose_t == pytest.approx(now - _POSE_INTERVAL_S * 0.33)
+
+    def test_seed_marks_seeded(self, worker) -> None:
+        worker._phase_seeded = False
+        worker._seed_subservice_phases(1000.0)
+        assert worker._phase_seeded is True
+
+    def test_seed_is_idempotent(self, worker) -> None:
+        """Calling seed a second time must NOT overwrite the timestamps."""
+        worker._phase_seeded = False
+        now = 1000.0
+        worker._seed_subservice_phases(now)
+        # Advance time and call again — values must not change.
+        worker._seed_subservice_phases(now + 999.0)
+        assert worker._last_reid_t == pytest.approx(now - _REID_INTERVAL_S * 0.5)
+        assert worker._last_pose_t == pytest.approx(now - _POSE_INTERVAL_S * 0.33)
+
+    def test_reid_becomes_due_before_face(self, worker) -> None:
+        """After seeding, reid fires ~0.125 s before face (half-period offset).
+
+        Both are seeded at the same real ``now``.  Face has _last_face_t=0,
+        so it becomes due at now (well in the past already).  ReID was seeded
+        with _last_reid_t = now - 0.5 * _REID_INTERVAL_S, so it becomes due at
+        now + 0.5 * _REID_INTERVAL_S (= 0.125 s later).
+
+        The test confirms the timing arithmetic rather than waiting real time.
+        """
+        # Seed with last_face_t at 0 (default) and now = 1000.0.
+        worker._phase_seeded = False
+        now = 1000.0
+        worker._seed_subservice_phases(now)
+
+        # face is already due because _last_face_t==0 (>> interval ago)
+        face_elapsed = now - worker._last_face_t  # 1000 s >> 0.25 s → due
+        reid_elapsed = now - worker._last_reid_t  # exactly 0.5 * interval → not yet due
+
+        assert face_elapsed > _FACE_INTERVAL_S, "face should already be overdue"
+        assert reid_elapsed < _REID_INTERVAL_S, "reid should not yet be due immediately after seed"
+
+        # The seeding must not touch the face timestamp — it stays at its default 0.0.
+        assert worker._last_face_t == 0.0
+
+        # The next reid fire-time is last_reid_t + _REID_INTERVAL_S
+        reid_next_due = worker._last_reid_t + _REID_INTERVAL_S
+        # That is now + 0.5 * _REID_INTERVAL_S = 1000.125
+        assert reid_next_due == pytest.approx(now + _REID_INTERVAL_S * 0.5)
+
+    def test_pose_becomes_due_after_seed(self, worker) -> None:
+        """After seeding, pose fires ~0.066 s after the seed moment.
+
+        Pose is seeded with _last_pose_t = now - 0.33 * _POSE_INTERVAL_S, so
+        the next due time is last_pose_t + _POSE_INTERVAL_S
+                           = now - 0.33*_POSE_INTERVAL_S + _POSE_INTERVAL_S
+                           = now + 0.67 * _POSE_INTERVAL_S
+        With the default _POSE_INTERVAL_S=0.2 that is now + 0.134 s.
+        """
+        worker._phase_seeded = False
+        now = 1000.0
+        worker._seed_subservice_phases(now)
+
+        pose_elapsed = now - worker._last_pose_t  # exactly 0.33 * interval → not yet due
+        assert pose_elapsed < _POSE_INTERVAL_S, "pose should not yet be due immediately after seed"
+
+        # The next pose fire-time is last_pose_t + _POSE_INTERVAL_S
+        pose_next_due = worker._last_pose_t + _POSE_INTERVAL_S
+        # That is now + (1 - 0.33) * _POSE_INTERVAL_S = now + 0.67 * _POSE_INTERVAL_S
+        assert pose_next_due == pytest.approx(now + _POSE_INTERVAL_S * 0.67)


### PR DESCRIPTION
Targets CPU **usage** and **spikes** when all subservices (detection, tracking, ReID, pose, face) run together.

**Spikes:** face and ReID both used a 0.25s interval seeded from 0, so they fired on the *same* appearance-thread ticks every 0.25s — a recurring double-model spike. A one-time `_seed_subservice_phases(now)` now offsets ReID by half a period and pose by a third, so the heavy appearance models **alternate instead of coinciding**.

**Usage under load:** the adaptive quality policy previously throttled only detection. Now face/ReID/pose cadence also scales with the cached `_quality_active` state via `_quality_scale()` (high 1.0x, balanced 1.25x, low 2.0x) and `_effective_{face,reid,pose}_interval()` — so the appearance subservices **run less often when the machine is over budget**, cutting sustained CPU. Subservice *correctness* is unchanged; only cadence/phase. Comparison semantics at all three gates preserved.

25 new tests (scale per quality tier, effective intervals, stagger offsets + staggered due-times, high-quality regression). No real threads.

CPU-perf focus item. Real CPU savings (lower peak + lower avg under load) to be validated on the camera rig at the final RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)