### PR TITLE
perf(engine): cap preview push rate (~20fps) to cut per-frame resize CPU

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -65,6 +65,12 @@ log = logging.getLogger(__name__)
 # shape it reads.
 _PREVIEW_W = 1280
 _PREVIEW_H = 720
+# Cap the preview ShmWriter push rate. The UI tile is a monitoring view (overlays
+# come from the ~10 Hz telemetry, not the preview frame), so it doesn't need the
+# full capture fps — capping it skips the per-frame resize/copy cost on faster
+# sources. Detection/tracking use the full-rate frame on a separate path.
+_PREVIEW_PUSH_FPS = 20.0
+_PREVIEW_PUSH_MIN_PERIOD_S = 1.0 / _PREVIEW_PUSH_FPS
 
 _DEFAULT_TELEMETRY_HZ = 10.0
 
@@ -314,6 +320,7 @@ class CameraWorker:
         self._injected_face_stack = face_stack
         self._face: Any | None = None
         self._last_face_t = 0.0
+        self._last_preview_push_t = 0.0
         self._last_harvest_t = 0.0
         self._last_crop_t = 0.0
         # Most recent face→identity bindings seen this tick: track_id → (id, conf).
@@ -2920,6 +2927,13 @@ class CameraWorker:
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:
             return
+        # Cap the preview rate: skip the resize/push when the last preview frame
+        # was pushed less than one preview period ago (saves CPU on >20fps sources
+        # without affecting tracking, which uses the full-rate frame elsewhere).
+        now = time.monotonic()
+        if now - self._last_preview_push_t < _PREVIEW_PUSH_MIN_PERIOD_S:
+            return
+        self._last_preview_push_t = now
         try:
             f = self._fit_frame(frame)
             self._shm.push(f)

--- a/tests/test_preview_rate_cap.py
+++ b/tests/test_preview_rate_cap.py
@@ -1,0 +1,60 @@
+"""The preview ShmWriter push is rate-capped to save per-frame resize CPU."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from autoptz.config.models import CameraConfig, SourceConfig
+from autoptz.engine import camera_worker as cw
+from autoptz.engine.camera_worker import CameraWorker
+
+
+class _RecordingShm:
+    # _fit_frame reads .height/.width to decide whether to resize; match the
+    # preview dims so a preview-sized test frame is passed straight through.
+    height = cw._PREVIEW_H
+    width = cw._PREVIEW_W
+
+    def __init__(self) -> None:
+        self.pushes = 0
+
+    def push(self, frame: object) -> None:
+        self.pushes += 1
+
+
+def _worker() -> CameraWorker:
+    config = CameraConfig(
+        id="prevcap01abcd",
+        name="Cam",
+        source=SourceConfig(type="usb", address="usb://0"),
+    )
+    return CameraWorker("prevcap01abcd", config, lambda m: None)
+
+
+def test_preview_push_is_rate_capped(monkeypatch) -> None:
+    w = _worker()
+    w._shm = _RecordingShm()  # type: ignore[assignment]
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(cw.time, "monotonic", lambda: clock["t"])
+    frame = np.zeros((cw._PREVIEW_H, cw._PREVIEW_W, 3), dtype=np.uint8)
+
+    w._push_frame(frame)  # first push always lands
+    assert w._shm.pushes == 1
+
+    clock["t"] += 0.01  # < one preview period later → skipped
+    w._push_frame(frame)
+    assert w._shm.pushes == 1
+
+    clock["t"] += cw._PREVIEW_PUSH_MIN_PERIOD_S  # a full period later → pushes again
+    w._push_frame(frame)
+    assert w._shm.pushes == 2
+
+
+def test_preview_first_frame_always_pushes(monkeypatch) -> None:
+    # With _last_preview_push_t seeded at 0.0, the very first frame must push
+    # immediately regardless of the absolute clock value.
+    w = _worker()
+    w._shm = _RecordingShm()  # type: ignore[assignment]
+    monkeypatch.setattr(cw.time, "monotonic", lambda: 9_999.0)
+    w._push_frame(np.zeros((cw._PREVIEW_H, cw._PREVIEW_W, 3), dtype=np.uint8))
+    assert w._shm.pushes == 1


### PR DESCRIPTION
CPU-perf: the worker resized and pushed a preview frame to shared memory on EVERY captured frame (up to source fps). The UI camera tile is a monitoring view — its overlays come from the ~10Hz telemetry, not the preview frame — so it does not need the full capture rate.

Caps the preview push to ~20fps (`_PREVIEW_PUSH_FPS`), skipping the per-frame `cv2.resize`/copy on >20fps sources. Detection/tracking are untouched (they consume the full-rate frame on a separate path). First frame always pushes; rate resumes after a stall.

2 tests (rate cap with a controlled clock; first-frame-always-pushes). Full suite green.

CPU-perf focus item. Real savings (especially with multiple cameras) validated on the rig at the final RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)