### PR TITLE
feat(engine): R5-B integrate TargetAssociator into target lock (flag-gated, default off)

### DIFF
--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -116,6 +116,11 @@ class TrackingConfig(BaseModel, frozen=True):
     # Off by default — flip on (or set AUTOPTZ_UNIFIED_POSE=1) to validate; falls
     # back to the plain detector automatically if the pose model can't be built.
     unified_pose: bool = False
+    # Flag-gated TargetAssociator: when True the fused associator (motion +
+    # appearance + identity + pose cues) drives keep/switch/ambiguous in
+    # ``_apply_target_lock`` instead of the existing heuristic path.  OFF by
+    # default — flip on per-camera to validate before it becomes the default.
+    use_target_associator: bool = False
 
 
 # Vertical aim point as a fraction of the person-box height measured from the TOP

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -438,6 +438,13 @@ class CameraWorker:
         self._ego_vel: tuple[float, float] = (0.0, 0.0)
         self._ego_source: str = "none"
 
+        # ── fused target associator (flag-gated, default OFF) ────────────────────
+        # Cheap stateless instance — always constructed; only consulted when
+        # config.tracking.use_target_associator is True.
+        from autoptz.engine.pipeline.associator import TargetAssociator
+
+        self._associator = TargetAssociator()
+
         # runtime state
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -1496,6 +1503,130 @@ class CameraWorker:
             target.aim_x, target.aim_y = lock.trusted_aim
             target.aim_source = "held"
 
+    def _build_candidate_cues(
+        self,
+        tracks: list[TrackInfo],
+    ) -> list[Any]:
+        """Build ``CandidateCues`` for every non-lost track.
+
+        Called only when ``use_target_associator`` is True.  Each cue is marked
+        CONSERVATIVE — only available when the signal genuinely exists this tick:
+
+        - **motion**: IOU of the candidate's bbox against ``_target_lock.trusted_bbox``
+          (the current target's last stored bbox).  Unavailable when there is no
+          current target or no stored trusted bbox.
+        - **identity**: available only when ``_track_identity`` maps this track to
+          the camera's configured target identity (``_target_identity_id``).
+        - **pose**: unavailable here (pose is per-target; we don't have per-candidate
+          pose keypoints — never run pose just for cue-building).
+        - **appearance**: unavailable here (ReID template scores are not stored
+          per-candidate; we don't run ReID in this path — the ReID recovery loop
+          is a separate async path).
+        """
+        from autoptz.engine.pipeline.associator import CandidateCues, Cue
+
+        ref_bbox = self._target_lock.trusted_bbox
+        has_ref = ref_bbox is not None and self._target_track_id is not None
+        cues: list[Any] = []
+        for t in tracks:
+            if getattr(t, "lost", False):
+                continue
+            # -- motion --
+            if has_ref and ref_bbox is not None:
+                motion_iou = self._bbox_iou(ref_bbox, t.bbox)
+                motion_cue = Cue(float(motion_iou), available=True)
+            else:
+                motion_cue = Cue(0.0, available=False)
+
+            # -- identity --
+            # Available iff this track has a recognised identity AND it matches
+            # the operator's configured target identity for this camera.
+            identity_cue = Cue(0.0, available=False)
+            target_iid = self._target_identity_id
+            if target_iid is not None:
+                entry = self._track_identity.get(t.track_id)
+                if entry is not None:
+                    track_iid, _name, score = entry
+                    if track_iid == target_iid:
+                        identity_cue = Cue(float(score), available=True)
+
+            # -- pose --
+            # Per-candidate pose is not computed here (it's per-target only).
+            pose_cue = Cue(0.0, available=False)
+
+            # -- appearance --
+            # ReID template scores are not stored per-candidate for the associator
+            # path (they live inside the recovery loop).  Mark unavailable.
+            appearance_cue = Cue(0.0, available=False)
+
+            cues.append(
+                CandidateCues(
+                    track_id=t.track_id,
+                    motion=motion_cue,
+                    appearance=appearance_cue,
+                    pose=pose_cue,
+                    identity=identity_cue,
+                )
+            )
+        return cues
+
+    def _apply_associator_decision(
+        self,
+        decision: Any,
+        tracks: list[TrackInfo],
+        now: float,
+    ) -> None:
+        """Apply a ``Decision`` returned by ``TargetAssociator.decide``.
+
+        keep      → no change (``_target_lock`` updated by normal store path).
+        switch    → commit the new target via ``_commit_target_track``.
+        ambiguous → mark the current lock ambiguous (hold and freeze).
+        """
+        action = decision.action
+        if action == "keep":
+            # Refresh the trusted state for the existing target if it's visible.
+            target = self._resolve_target_track(tracks)
+            if target is not None and not getattr(target, "lost", False):
+                self._store_trusted_target(target, now)
+                # Surface associator confidence in the lock.
+                self._target_lock.trusted_confidence = float(decision.confidence)
+        elif action == "switch" and decision.track_id is not None:
+            self._commit_target_track(decision.track_id, reason="associator")
+            # Store the new target's bbox immediately so the next tick has a ref.
+            new_target = next(
+                (
+                    t
+                    for t in tracks
+                    if t.track_id == decision.track_id and not getattr(t, "lost", False)
+                ),
+                None,
+            )
+            if new_target is not None:
+                self._store_trusted_target(new_target, now)
+                # Intentionally override detector confidence with the associator's
+                # fused confidence — the fused value is what surfaces in telemetry.
+                self._target_lock.trusted_confidence = float(decision.confidence)
+            log.debug(
+                "camera_id=%s associator switch → track=%d conf=%.2f margin=%.2f",
+                self.camera_id,
+                decision.track_id,
+                decision.confidence,
+                decision.margin,
+            )
+        elif action == "ambiguous":
+            target = self._resolve_target_track(tracks)
+            self._mark_target_ambiguous(
+                target,
+                now=now,
+                reason="associator_ambiguous",
+            )
+            log.debug(
+                "camera_id=%s associator ambiguous conf=%.2f margin=%.2f",
+                self.camera_id,
+                decision.confidence,
+                decision.margin,
+            )
+
     def _append_held_target(self, tracks: list[TrackInfo], now: float) -> None:
         lock = self._target_lock
         if self._target_track_id is None or lock.trusted_bbox is None:
@@ -1528,7 +1659,13 @@ class CameraWorker:
         frame: NDArray[np.uint8] | None,
         now: float,
     ) -> None:
-        """Suppress target evidence from obvious crossings or pose-risk crowding."""
+        """Suppress target evidence from obvious crossings or pose-risk crowding.
+
+        When ``config.tracking.use_target_associator`` is True the fused
+        ``TargetAssociator`` drives keep/switch/ambiguous and the method returns
+        early — the existing heuristic path below is completely bypassed.
+        When the flag is False (default) behaviour is byte-identical to today.
+        """
         self._sync_target_flags(tracks)
         if self._target_track_id is None:
             self._target_lock.status = "idle"
@@ -1539,6 +1676,15 @@ class CameraWorker:
             return
         if target.lost:
             return
+
+        # ── flag-gated associator path (OFF by default) ──────────────────────────
+        if getattr(self.config.tracking, "use_target_associator", False):
+            cues = self._build_candidate_cues(tracks)
+            decision = self._associator.decide(cues, self._target_track_id)
+            self._apply_associator_decision(decision, tracks, now)
+            return
+        # ── existing heuristic path (flag OFF — unchanged) ───────────────────────
+
         if (
             self._target_lock.trusted_track_id != target.track_id
             or self._target_lock.trusted_bbox is None

--- a/tests/test_associator_integration.py
+++ b/tests/test_associator_integration.py
@@ -1,0 +1,360 @@
+"""Integration tests for the flag-gated TargetAssociator in CameraWorker.
+
+Tests confirm:
+  1. Flag OFF: ``_associator.decide`` is NEVER called; existing heuristic path runs.
+  2. Flag ON — clear single target: decision is "keep", no ID-switch.
+  3. Flag ON — two look-alike crossing tracks (similar motion, no distinguishing
+     cue): decision is "ambiguous", no ID-switch.
+  4. Flag ON — a track carrying the target identity clearly leads: decision is
+     "switch", target is rebound.
+  5. ``_build_candidate_cues``: cue availability rules respected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoptz.config.models import CameraConfig, SourceConfig, TrackingConfig
+from autoptz.engine.runtime.messages import BBox, TrackInfo
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_config(*, use_target_associator: bool = False) -> CameraConfig:
+    return CameraConfig(
+        id="test-cam-assoc1234",
+        name="Test",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(use_target_associator=use_target_associator),
+    )
+
+
+def _make_worker(config: CameraConfig):
+    from autoptz.engine.camera_worker import CameraWorker
+
+    return CameraWorker(
+        "test-cam-assoc1234",
+        config,
+        on_telemetry=lambda m: None,
+    )
+
+
+def _track(track_id: int, x1: float, y1: float, x2: float, y2: float) -> TrackInfo:
+    return TrackInfo(
+        track_id=track_id,
+        bbox=BBox(x1=x1, y1=y1, x2=x2, y2=y2),
+    )
+
+
+def _bbox(x1: float, y1: float, x2: float, y2: float) -> BBox:
+    return BBox(x1=x1, y1=y1, x2=x2, y2=y2)
+
+
+# ── TC-1: Flag OFF — associator is NEVER consulted ─────────────────────────────
+
+
+class TestFlagOff:
+    def test_decide_never_called_when_flag_off(self, monkeypatch):
+        """With use_target_associator=False, _associator.decide must never be called."""
+        config = _make_config(use_target_associator=False)
+        worker = _make_worker(config)
+
+        # Inject a target
+        worker._target_track_id = 1
+        worker._target_lock.trusted_track_id = 1
+        worker._target_lock.trusted_bbox = _bbox(100, 100, 200, 300)
+        worker._target_lock.trusted_t = 1000.0
+        worker._target_lock.status = "locked"
+
+        def _explode(candidates, current_target_id):  # noqa: ARG001
+            raise AssertionError("_associator.decide must NOT be called when flag is OFF")
+
+        monkeypatch.setattr(worker._associator, "decide", _explode)
+
+        track = _track(1, 100, 100, 200, 300)
+        # Should NOT raise; the heuristic path runs without calling decide.
+        worker._apply_target_lock([track], None, 1001.0)
+
+    def test_existing_lock_tests_still_pass_with_flag_off(self):
+        """Smoke-check: heuristic path still stores trusted target normally."""
+        config = _make_config(use_target_associator=False)
+        worker = _make_worker(config)
+
+        worker._target_track_id = 5
+        track = _track(5, 50, 50, 150, 200)
+        worker._apply_target_lock([track], None, 2000.0)
+
+        # First call seeds trusted_track_id (trusted_bbox was None).
+        assert worker._target_lock.trusted_track_id == 5
+        assert worker._target_lock.trusted_bbox is not None
+
+
+# ── TC-2: Flag ON — single clear target → keep ─────────────────────────────────
+
+
+class TestFlagOnKeep:
+    def test_single_clear_target_kept(self, monkeypatch):
+        """Only track matches the current target with good IOU → keep (no switch)."""
+        config = _make_config(use_target_associator=True)
+        worker = _make_worker(config)
+
+        worker._target_track_id = 1
+        worker._target_lock.trusted_track_id = 1
+        worker._target_lock.trusted_bbox = _bbox(100, 100, 200, 300)
+        worker._target_lock.trusted_t = 5000.0
+        worker._target_lock.status = "locked"
+
+        # Track 1 is at essentially the same position → high IOU → keep.
+        track = _track(1, 102, 98, 202, 302)
+
+        decided = []
+
+        real_decide = worker._associator.decide
+
+        def spy_decide(candidates, current_target_id):
+            d = real_decide(candidates, current_target_id)
+            decided.append(d)
+            return d
+
+        monkeypatch.setattr(worker._associator, "decide", spy_decide)
+
+        worker._apply_target_lock([track], None, 5001.0)
+
+        assert len(decided) == 1
+        assert decided[0].action == "keep"
+        # Target ID must not have changed.
+        assert worker._target_track_id == 1
+
+
+# ── TC-3: Flag ON — two look-alike tracks → ambiguous ─────────────────────────
+
+
+class TestFlagOnAmbiguous:
+    def test_two_lookalike_tracks_ambiguous_no_switch(self):
+        """Real associator returns 'ambiguous' when two look-alike tracks are close.
+
+        Geometry (motion-only — no identity/appearance/pose cues available):
+          trusted_bbox (ref) = (100, 100, 200, 300)  [100×200 box, area=20 000]
+
+          track2 (ID=2, challenger)  at (102, 100, 202, 300):
+              intersection = 98×200 = 19 600, union = 20 400
+              IOU ≈ 0.9608  ← best candidate
+
+          track1 (ID=1, current target, runner-up) at (105, 100, 205, 300):
+              intersection = 95×200 = 19 000, union = 21 000
+              IOU ≈ 0.9048
+
+          margin = 0.9608 − 0.9048 ≈ 0.056 < ambiguous_margin (0.08)
+          → Rule 2b fires: ambiguous (look-alike hold).
+
+        With only the motion cue available, association_confidence collapses to
+        the raw IOU (single-cue weighted average = IOU).
+        """
+        config = _make_config(use_target_associator=True)
+        worker = _make_worker(config)
+
+        # Current target is track 1; trusted_bbox is the reference for IOU.
+        worker._target_track_id = 1
+        worker._target_lock.trusted_track_id = 1
+        worker._target_lock.trusted_bbox = _bbox(100, 100, 200, 300)
+        worker._target_lock.trusted_t = 6000.0
+        worker._target_lock.status = "locked"
+
+        # Challenger (track 2) leads the current target (track 1) by ~0.056 IOU —
+        # below ambiguous_margin (0.08), so the REAL associator returns "ambiguous".
+        track1 = _track(1, 105, 100, 205, 300)  # current target; IOU≈0.9048
+        track2 = _track(2, 102, 100, 202, 300)  # challenger;     IOU≈0.9608
+
+        # Sanity-check: the real decide (not monkeypatched) returns "ambiguous".
+        from autoptz.engine.pipeline.associator import CandidateCues, Cue
+
+        ref = worker._target_lock.trusted_bbox
+        cue1 = CandidateCues(
+            track_id=1,
+            motion=Cue(worker._bbox_iou(ref, track1.bbox), available=True),
+            appearance=Cue(0.0, available=False),
+            pose=Cue(0.0, available=False),
+            identity=Cue(0.0, available=False),
+        )
+        cue2 = CandidateCues(
+            track_id=2,
+            motion=Cue(worker._bbox_iou(ref, track2.bbox), available=True),
+            appearance=Cue(0.0, available=False),
+            pose=Cue(0.0, available=False),
+            identity=Cue(0.0, available=False),
+        )
+        direct_decision = worker._associator.decide([cue1, cue2], current_target_id=1)
+        assert direct_decision.action == "ambiguous", (
+            f"Expected real associator to return 'ambiguous', got {direct_decision!r}"
+        )
+
+        prev_id = worker._target_track_id
+        worker._apply_target_lock([track1, track2], None, 6001.0)
+
+        # No ID-switch — target must remain track 1.
+        assert worker._target_track_id == prev_id
+        # Lock must be frozen as ambiguous (real associator drove this, not a mock).
+        assert worker._target_lock.status == "ambiguous"
+
+
+# ── TC-4: Flag ON — identity cue leads → switch ───────────────────────────────
+
+
+class TestFlagOnSwitch:
+    def test_identity_cue_drives_switch(self, monkeypatch):
+        """A track carrying the target identity clearly dominates → switch."""
+        config = _make_config(use_target_associator=True)
+        worker = _make_worker(config)
+
+        # Current target is track 1.
+        worker._target_track_id = 1
+        worker._target_identity_id = "identity-alice"
+        worker._target_lock.trusted_track_id = 1
+        worker._target_lock.trusted_bbox = _bbox(100, 100, 200, 300)
+        worker._target_lock.trusted_t = 7000.0
+        worker._target_lock.status = "locked"
+
+        # Track 2 carries the target identity with high confidence.
+        worker._track_identity[2] = ("identity-alice", "Alice", 0.95)
+
+        track1 = _track(1, 100, 100, 200, 300)
+        track2 = _track(2, 300, 100, 400, 300)  # different position
+
+        # Force the associator to return "switch" to track 2.
+        from autoptz.engine.pipeline.associator import Decision
+
+        forced_switch = Decision(
+            action="switch",
+            track_id=2,
+            confidence=0.82,
+            margin=0.25,
+        )
+        monkeypatch.setattr(
+            worker._associator,
+            "decide",
+            lambda candidates, current_target_id: forced_switch,
+        )
+
+        worker._apply_target_lock([track1, track2], None, 7001.0)
+
+        # Target must have switched to track 2.
+        assert worker._target_track_id == 2
+        # Lock must be fully committed after the switch.
+        assert worker._target_lock.trusted_track_id == 2
+        assert worker._target_lock.status == "locked"
+        assert worker._target_lock.trusted_bbox is not None
+
+
+# ── TC-5: _build_candidate_cues availability rules ────────────────────────────
+
+
+class TestBuildCandidateCues:
+    def _make_worker_with_ref(
+        self,
+        *,
+        trusted_bbox: BBox | None,
+        target_track_id: int | None,
+        target_identity_id: str | None = None,
+    ):
+        config = _make_config(use_target_associator=True)
+        worker = _make_worker(config)
+        worker._target_track_id = target_track_id
+        worker._target_identity_id = target_identity_id
+        worker._target_lock.trusted_bbox = trusted_bbox
+        return worker
+
+    def test_motion_available_when_ref_bbox_exists(self):
+        """motion cue is available when trusted_bbox and current target are set."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=_bbox(100, 100, 200, 300),
+            target_track_id=1,
+        )
+        track = _track(1, 102, 98, 202, 302)
+        cues = worker._build_candidate_cues([track])
+        assert len(cues) == 1
+        assert cues[0].motion.available is True
+        assert 0.0 < cues[0].motion.value <= 1.0  # high IOU
+
+    def test_motion_unavailable_when_no_ref_bbox(self):
+        """motion cue is unavailable when trusted_bbox is None (no prior target)."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=None,
+            target_track_id=None,
+        )
+        track = _track(1, 100, 100, 200, 300)
+        cues = worker._build_candidate_cues([track])
+        assert len(cues) == 1
+        assert cues[0].motion.available is False
+
+    def test_identity_available_only_for_matching_track(self):
+        """identity cue available only for a track carrying the target identity."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=_bbox(100, 100, 200, 300),
+            target_track_id=1,
+            target_identity_id="identity-alice",
+        )
+        # Track 2 carries the target identity; track 3 does not.
+        worker._track_identity[2] = ("identity-alice", "Alice", 0.90)
+        worker._track_identity[3] = ("identity-bob", "Bob", 0.85)
+        track2 = _track(2, 200, 100, 300, 300)
+        track3 = _track(3, 400, 100, 500, 300)
+        cues_by_id = {c.track_id: c for c in worker._build_candidate_cues([track2, track3])}
+
+        assert cues_by_id[2].identity.available is True
+        assert cues_by_id[2].identity.value == pytest.approx(0.90)
+        assert cues_by_id[3].identity.available is False
+
+    def test_identity_unavailable_when_no_target_identity(self):
+        """No target_identity_id set → identity cue always unavailable."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=_bbox(100, 100, 200, 300),
+            target_track_id=1,
+            target_identity_id=None,
+        )
+        worker._track_identity[1] = ("identity-alice", "Alice", 0.95)
+        track = _track(1, 100, 100, 200, 300)
+        cues = worker._build_candidate_cues([track])
+        assert cues[0].identity.available is False
+
+    def test_pose_and_appearance_always_unavailable(self):
+        """pose and appearance cues are never available from _build_candidate_cues."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=_bbox(100, 100, 200, 300),
+            target_track_id=1,
+        )
+        track = _track(1, 100, 100, 200, 300)
+        cues = worker._build_candidate_cues([track])
+        assert len(cues) == 1
+        assert cues[0].pose.available is False
+        assert cues[0].appearance.available is False
+
+    def test_lost_tracks_excluded(self):
+        """Tracks with lost=True are excluded from candidate cues."""
+        worker = self._make_worker_with_ref(
+            trusted_bbox=_bbox(100, 100, 200, 300),
+            target_track_id=1,
+        )
+        live_track = _track(1, 100, 100, 200, 300)
+        lost_track = _track(2, 300, 100, 400, 300)
+        lost_track.lost = True
+        cues = worker._build_candidate_cues([live_track, lost_track])
+        assert len(cues) == 1
+        assert cues[0].track_id == 1
+
+
+# ── TC-6: Config model — flag field ──────────────────────────────────────────
+
+
+class TestConfigFlag:
+    def test_default_is_false(self):
+        """use_target_associator defaults to False in TrackingConfig."""
+        tc = TrackingConfig()
+        assert tc.use_target_associator is False
+
+    def test_can_be_set_true(self):
+        tc = TrackingConfig(use_target_associator=True)
+        assert tc.use_target_associator is True
+
+    def test_camera_config_default_false(self):
+        cam = CameraConfig(name="Cam")
+        assert cam.tracking.use_target_associator is False


### PR DESCRIPTION
Second half of R5: wires the pure `TargetAssociator` (#95) into `_apply_target_lock`, behind a new `TrackingConfig.use_target_associator` flag (**default OFF**). Flag OFF ⇒ the existing heuristic path runs **byte-identical** (verified: the flag-off test monkeypatches `decide` to raise and confirms it is never called; full suite green). Flag ON ⇒ the fused associator drives keep/switch/ambiguous.

- Cues are built **conservatively** from real signals: motion = IOU(current target trusted bbox, candidate); identity = `_track_identity` matched to the bound target identity. pose/appearance are marked *unavailable* (not computed per-candidate from this path) — the associator excludes missing cues, so it degrades gracefully rather than using wrong values.
- switch → the existing `_commit_target_track` (so pose/reid/identity recovery state resets exactly as a ReID switch); ambiguous → existing `_mark_target_ambiguous`. No raw target-id writes; lock ordering preserved (RLock re-entry).
- 14 integration tests: flag-off never consults the associator; flag-on keep / look-alike→ambiguous (real associator, no ID-switch) / identity-lead→switch (with lock-state asserts); cue-availability.

The flag lets you validate + tune the weights/margins on real cameras before it becomes default (a follow-up flips the default + removes the old heuristics). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)