### PR TITLE
release: 2.2.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to AutoPTZ are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project aims to
 follow [Semantic Versioning](https://semver.org/).
 
+## [2.2.0-rc2] — 2026-06-24
+
+> Pre-release for testing — builds on rc1 with CPU-performance, tracking, and
+> diagnostics work. Please validate on your real cameras and report back before
+> this becomes the stable 2.2.0.
+
+### Added
+
+- **Live GPU-acceleration verdict in the Services panel** — the detector row now
+  shows whether your GPU/accelerator is actually beating the CPU (e.g. *CoreML ·
+  1.24× CPU (accelerated)*), measured once in the background at startup.
+- **OpenVINO auto-install for Intel** — `tools/install.py` now auto-selects the
+  OpenVINO ONNX Runtime wheel on Intel CPU/iGPU Linux machines (faster than the
+  stock CPU provider).
+- **Opt-in fused target-association** — a new `TargetAssociator` fuses motion,
+  ReID, pose, and identity into one confidence-scored keep/switch/hold decision
+  with explicit anti-ID-switch hysteresis. **Off by default**
+  (`tracking.use_target_associator`); enable it to try the new logic and report back.
+- **Batched detector inference** primitive (`detect_batch`) — foundation for a
+  future multi-camera GPU batching path.
+
+### Changed
+
+- **Lower CPU usage and fewer CPU spikes with all subservices running** — face,
+  ReID, and pose no longer fire on the same tick (phase-staggered), and their
+  cadence eases off automatically when the machine is over its frame budget.
+- **CoreML compile-cache** — the CoreML model compiles once per machine and is
+  cached, cutting cold-start and per-camera warmup on Apple Silicon and Intel Macs.
+- **Lighter preview path** — the camera-tile preview is capped at ~20 fps (it's a
+  monitoring view), saving a per-frame resize on higher-fps sources.
+- **Scene-adaptive ReID** — the recovery match threshold tightens automatically
+  when people in frame look alike (reducing wrong re-locks); it never loosens
+  below your configured value.
+
+### Fixed
+
+- CI test reliability: deflaked the macOS app-memory test, the Qt widget-smoke
+  subprocess tests, and the ReID-throttle test.
+
 ## [2.2.0-rc1] — 2026-06-24
 
 > Pre-release for testing — please validate on your real cameras and report back

--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.2.0-rc1"
+__version__ = "2.2.0-rc2"
 
 
 def version() -> str:


### PR DESCRIPTION
Second **pre-release** of the 2.2.0 reliability + performance roadmap, for real-hardware validation before the stable 2.2.0. Bumps `__version__` to `2.2.0-rc2`; on merge, tag `v2.2.0-rc2` triggers the pre-release installer build.

**New since rc1 (all merged, CI-green + multi-agent-reviewed):**
- #92 CPU subservice governor — fewer CPU spikes (phase-stagger) + cadence throttle under load
- #93 preview-rate-cap (~20fps)
- #90 live GPU-acceleration verdict in the Services panel
- #91 OpenVINO auto-install for Intel
- #94 scene-adaptive ReID threshold
- #95/#96 opt-in fused TargetAssociator (off by default)
- #97 batched detect_batch primitive

**Validate especially:** CPU usage/spikes with all subservices running (your priority), and \`python -m autoptz --bench\` / the Services-panel verdict on Intel-Mac+AMD. To try the new tracking logic, set \`tracking.use_target_associator = true\`.

Follow-ups after your validation: P4 coalescing scheduler, wire the associator ReID/pose cues + flip its default, int8 CPU quant, stable Win/Linux device binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)