### PR TITLE
refactor(flags): remove dead face_confirm, consolidate unified_pose, cap OpenCV threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to AutoPTZ are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project aims to
 follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Less CPU oversubscription from OpenCV** — OpenCV's internal thread pool
+  (resize/letterbox and the per-frame ego-motion optical flow) is now capped to
+  the same per-camera budget as the ONNX Runtime sessions instead of defaulting
+  to every core. On Linux/Windows the exact count is honoured; on macOS's GCD
+  OpenCV backend (which ignores a positive count) the cap forces single-threaded
+  only under heavy multi-camera load.
+
+### Removed
+
+- Removed the per-camera **"Confirm with face recognition"** toggle
+  (`tracking.face_confirm`). It was never wired to engine behaviour — face
+  recognition is controlled by the global **Face recognition** module switch
+  (Services) — so the checkbox only persisted and displayed itself. Existing
+  configs that still carry the key load fine (it is ignored).
+
+### Internal
+
+- Consolidated the `AUTOPTZ_UNIFIED_POSE` env flag into a single resolver
+  (`autoptz.engine.runtime.flags.env_unified_pose`); the inference pool and the
+  worker stacks now share one source of truth instead of two duplicate readers.
+
 ## [2.2.0-rc2] — 2026-06-24
 
 > Pre-release for testing — builds on rc1 with CPU-performance, tracking, and

--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -92,7 +92,6 @@ class TrackingConfig(BaseModel, frozen=True):
     reid_threshold_hi: float = Field(default=0.60, ge=0.0, le=1.0)
     reid_threshold_lo: float = Field(default=0.35, ge=0.0, le=1.0)
     coast_window_ms: int = Field(default=300, ge=0)
-    face_confirm: bool = False
     quality_floor: Literal["auto", "high", "balanced", "low"] = "auto"
     # "Framing" preset — the single user-facing control for how the shot is composed.
     # It sets the vertical aim point (how high up the person box the camera centres:

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -4144,7 +4144,7 @@ class CameraWorker:
             RuntimeServiceInfo(
                 key="face",
                 name="Face",
-                configured="on" if getattr(tracking, "face_confirm", False) else "off",
+                configured="on" if self._feature("face_recognition") else "off",
                 enabled=self._feature("face_recognition"),
                 active=bool(self._feature("face_recognition") and self._face is not None),
                 state=self._stage_status(

--- a/autoptz/engine/pipeline/pool.py
+++ b/autoptz/engine/pipeline/pool.py
@@ -37,17 +37,12 @@ per-worker fallback for tests/fakes that do not inject a pool.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-
-def _env_unified_pose() -> bool:
-    """Process-wide opt-in for the unified (one-backbone) pose detector."""
-    return os.environ.get("AUTOPTZ_UNIFIED_POSE", "").strip().lower() in ("1", "true", "yes", "on")
-
+from autoptz.engine.runtime.flags import env_unified_pose
 
 if TYPE_CHECKING:
     import numpy as np
@@ -159,7 +154,7 @@ class InferencePool:
         # When set, the detector slot is a unified YOLO11-pose model that emits
         # boxes AND keypoints in one pass (the separate pose estimator is then
         # unused).  Env var wins so it's togglable without touching config.
-        self._unified_pose = bool(unified_pose) or _env_unified_pose()
+        self._unified_pose = bool(unified_pose) or env_unified_pose()
 
         self._detector: Any | None = None
         self._detector_built = False

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -123,6 +123,12 @@ def run_camera_process(
     except Exception:  # noqa: BLE001
         pass
 
+    # Re-apply the OpenCV thread cap in this child (it inherited AUTOPTZ_CV2_THREADS
+    # from the parent but not the in-process cv2.setNumThreads call).
+    from autoptz.engine.runtime.flags import apply_opencv_thread_cap
+
+    apply_opencv_thread_cap()
+
     worker = None
     try:
         from autoptz.engine.camera_worker import CameraWorker

--- a/autoptz/engine/runtime/flags.py
+++ b/autoptz/engine/runtime/flags.py
@@ -1,0 +1,62 @@
+"""Process-wide feature-flag env resolvers — the single source of truth.
+
+These ``AUTOPTZ_*`` switches are read from more than one layer (the inference
+pool, the worker stacks, the supervisor), so the parsing of "what counts as on"
+lives here once instead of being re-implemented per call site.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Strings that count as "on" for a boolean env flag.
+_TRUE_VALUES = ("1", "true", "yes", "on")
+
+
+def _env_true(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUE_VALUES
+
+
+def env_unified_pose() -> bool:
+    """Process-wide opt-in for the unified (one-backbone) pose detector.
+
+    Honoured in addition to the per-camera ``tracking.unified_pose`` config flag.
+    """
+    return _env_true("AUTOPTZ_UNIFIED_POSE")
+
+
+def apply_opencv_thread_cap(threads: int | None = None) -> None:
+    """Cap OpenCV's internal thread pool (resize/letterbox + optical flow).
+
+    OpenCV defaults to *all* cores, so with several camera threads each firing
+    cv2 work it oversubscribes the CPU — a real source of frame-time/CPU spikes.
+    ``threads`` defaults to the ``AUTOPTZ_CV2_THREADS`` budget the supervisor
+    publishes (so a spawned camera child can re-apply it in its own process).
+
+    **Backend nuance:** with the TBB/OpenMP backends (typical on Linux/Windows)
+    ``setNumThreads(n)`` honours *n*.  With the GCD/Concurrency backend (the macOS
+    opencv-python wheels) a positive count is **ignored** and only ``0`` (force
+    single-threaded) takes effect — so when we want a tight single-thread cap and
+    the backend kept more, we fall back to disabling OpenCV's internal threading.
+    Best-effort and must never raise into startup.
+    """
+    if threads is None:
+        raw = os.environ.get("AUTOPTZ_CV2_THREADS", "").strip()
+        if not raw:
+            return
+        try:
+            threads = max(1, int(raw))
+        except ValueError:
+            return
+    try:
+        import cv2
+
+        threads = max(1, int(threads))
+        cv2.setNumThreads(threads)
+        # GCD/Concurrency backends ignore a positive count; if we asked to squeeze
+        # down to a single thread but it kept more, force OpenCV single-threaded so
+        # per-camera cv2 work can't fan across every core under heavy multi-cam load.
+        if threads <= 1 and cv2.getNumThreads() > 1:
+            cv2.setNumThreads(0)
+    except Exception:  # noqa: BLE001 — a thread-cap hint must never block startup
+        pass

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -822,6 +822,7 @@ class Supervisor:
         import os
 
         from autoptz.config.models import HardwarePrefs
+        from autoptz.engine.runtime.flags import apply_opencv_thread_cap
 
         try:
             raw = self._store.get_setting("hardware", {}) if self._store is not None else {}
@@ -846,8 +847,17 @@ class Supervisor:
             threads = max(1, usable // max(1, camera_count))
         os.environ["AUTOPTZ_ORT_INTRA_THREADS"] = str(threads)
 
+        # OpenCV keeps its OWN thread pool for resize/letterbox and the per-frame
+        # optical flow (ego-motion), defaulting to *all* cores. With several camera
+        # threads each firing cv2 work that oversubscribes the CPU and is a real
+        # source of the frame-time/CPU spikes — ORT alone was capped, OpenCV was not.
+        # Cap it to the same per-camera budget. Published too so a process-per-camera
+        # child (which doesn't run this code) can re-apply it in-process.
+        os.environ["AUTOPTZ_CV2_THREADS"] = str(threads)
+        apply_opencv_thread_cap(threads)
+
         log.info(
-            "hardware prefs → env | force_ep=%s precision=%s intra_threads=%s "
+            "hardware prefs → env | force_ep=%s precision=%s intra_threads=%s (ORT+OpenCV) "
             "(cores=%s, cameras=%s)",
             hw.force_ep or "auto",
             hw.precision,

--- a/autoptz/engine/worker/stacks.py
+++ b/autoptz/engine/worker/stacks.py
@@ -229,11 +229,9 @@ def _log_detector_ready_once(model_path: str, ep: str) -> None:
 
 def _want_unified_pose(config: CameraConfig) -> bool:
     """True iff this camera wants the unified pose detector (config or env)."""
-    import os
+    from autoptz.engine.runtime.flags import env_unified_pose
 
-    if getattr(config.tracking, "unified_pose", False):
-        return True
-    return os.environ.get("AUTOPTZ_UNIFIED_POSE", "").strip().lower() in ("1", "true", "yes", "on")
+    return bool(getattr(config.tracking, "unified_pose", False)) or env_unified_pose()
 
 
 def _build_detect_stack(config: CameraConfig) -> _DetectStack | None:

--- a/autoptz/ui/widgets/properties_panel.py
+++ b/autoptz/ui/widgets/properties_panel.py
@@ -91,7 +91,6 @@ _COST_HELP = {
     "tracker": "\n".join(_TRACKER_HELP.values()),
     "reid": "Appearance re-identification recovers a target after occlusion — "
     "accurate but the most expensive option (runs an extra model).",
-    "face_confirm": "Confirms identity with face recognition — moderate extra cost.",
 }
 
 
@@ -586,18 +585,8 @@ class PropertiesPanel(QWidget):
         )
         # ReID is no longer a per-camera checkbox: it's the global "reid" feature
         # (Services) combined with the per-camera Mode above ("Stable" uses it).
-        self._face = QCheckBox("Confirm with face recognition")
-        self._face.toggled.connect(self._schedule)
-        self._face_chip = CostChip("medium")
-        self._face_chip.setToolTip(_COST_HELP["face_confirm"])
-        tf.addRow(
-            "",
-            _with_chip(
-                self._face,
-                self._face_chip,
-                HelpBadge(_COST_HELP["face_confirm"]),
-            ),
-        )
+        # Face recognition likewise has no per-camera toggle — it's the global
+        # "face_recognition" feature (Services), gated per the selected target.
         tr.add_widget(_wrap(tf))
         self._col.addWidget(tr)
 
@@ -1326,7 +1315,6 @@ class PropertiesPanel(QWidget):
                 tr.get("framing") or tr.get("aim_region") or "upper_body",
             )
             self._ignore_arms.setChecked((tr.get("aim_body_mode") or "torso") == "torso")
-            self._face.setChecked(bool(tr.get("face_confirm", False)))
             _set_combo(self._backend, pz.get("backend", "auto"))
             self._ptz_address.setText(pz.get("address") or "")
             self._auto_zoom.setChecked(bool(pz.get("auto_zoom", True)))
@@ -1491,7 +1479,6 @@ class PropertiesPanel(QWidget):
         _restyle_chip(
             self._tracker_chip, "light" if self._tracker.currentText() == "bytetrack" else "medium"
         )
-        self._face_chip.setVisible(self._face.isChecked())
 
     def _push(self) -> None:
         if not self._camera_id or not self._cfg:
@@ -1521,7 +1508,6 @@ class PropertiesPanel(QWidget):
         cfg["tracking"]["aim_body_mode"] = (
             "torso" if self._ignore_arms.isChecked() else "full_silhouette"
         )
-        cfg["tracking"]["face_confirm"] = self._face.isChecked()
         cfg["ptz"]["backend"] = self._backend.currentText()
         cfg["ptz"]["address"] = self._ptz_address.text().strip() or None
         cfg["ptz"]["auto_zoom"] = self._auto_zoom.isChecked()

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,64 @@
+"""Tests for the consolidated feature-flag env resolvers (autoptz.engine.runtime.flags)."""
+
+from __future__ import annotations
+
+import cv2
+import pytest
+
+from autoptz.engine.runtime.flags import apply_opencv_thread_cap, env_unified_pose
+
+
+@pytest.fixture(autouse=True)
+def _restore_cv2_threads():
+    """Save/restore the process-global OpenCV thread count around each test."""
+    prev = cv2.getNumThreads()
+    yield
+    cv2.setNumThreads(prev)
+
+
+class TestEnvUnifiedPose:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+    def test_truthy(self, monkeypatch, value):
+        monkeypatch.setenv("AUTOPTZ_UNIFIED_POSE", value)
+        assert env_unified_pose() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+    def test_falsy(self, monkeypatch, value):
+        monkeypatch.setenv("AUTOPTZ_UNIFIED_POSE", value)
+        assert env_unified_pose() is False
+
+    def test_unset_is_false(self, monkeypatch):
+        monkeypatch.delenv("AUTOPTZ_UNIFIED_POSE", raising=False)
+        assert env_unified_pose() is False
+
+
+class TestApplyOpenCVThreadCap:
+    def test_cap_to_one_is_single_threaded(self):
+        """Portable contract: capping to 1 makes OpenCV single-threaded.
+
+        Honoured directly by TBB/OpenMP; reached via setNumThreads(0) on the
+        macOS GCD backend (which ignores a positive count).
+        """
+        apply_opencv_thread_cap(1)
+        assert cv2.getNumThreads() <= 1
+
+    def test_reads_env_when_no_arg(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_CV2_THREADS", "1")
+        apply_opencv_thread_cap()
+        assert cv2.getNumThreads() <= 1
+
+    def test_noop_when_env_unset_and_no_arg(self, monkeypatch):
+        monkeypatch.delenv("AUTOPTZ_CV2_THREADS", raising=False)
+        before = cv2.getNumThreads()
+        apply_opencv_thread_cap()  # no arg, no env → leave the current setting alone
+        assert cv2.getNumThreads() == before
+
+    def test_bad_env_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_CV2_THREADS", "not-a-number")
+        before = cv2.getNumThreads()
+        apply_opencv_thread_cap()
+        assert cv2.getNumThreads() == before
+
+    def test_does_not_raise_on_multi_thread_target(self):
+        """A multi-thread target must never raise, whatever the backend does with it."""
+        apply_opencv_thread_cap(4)


### PR DESCRIPTION
Flip-switch architecture cleanup + a real CPU-oversubscription fix.

## Changes
- **Remove dead `face_confirm` knob** — the per-camera "Confirm with face recognition" toggle never gated engine behaviour (face is controlled by the global `face_recognition` module switch). Removed the config field, UI checkbox, and telemetry use; telemetry `configured` now reflects the actual feature flag. Old configs ignore the stale key (no `extra=forbid`).
- **Consolidate `unified_pose`** — single resolver `autoptz.engine.runtime.flags.env_unified_pose`; the inference pool and worker stacks share one source of truth instead of two duplicate env readers.
- **Cap OpenCV threads** — `cv2.setNumThreads` was never called, so OpenCV (resize/letterbox + the per-frame ego optical-flow) fanned across all cores while the ORT sessions were already capped. New `flags.apply_opencv_thread_cap` caps it to the same per-camera budget, applied in the supervisor and re-applied in the process-per-camera child. **macOS-GCD-aware:** that backend ignores a positive count (only `0` works), so the cap forces single-threaded only under heavy multi-camera load; TBB/OpenMP backends honour the exact count.

## Tests
- New `tests/test_flags.py` (18 cases; OpenCV-backend-portable contract).
- Full suite green locally (1033 passed), ruff check + format clean.

## Notes
- Behaviour change: OpenCV thread cap. Conservative (caps to the existing per-camera budget). On a few-camera macOS setup it's effectively a no-op (GCD); the real macOS lever for optical-flow cost is ego-flow decimation (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)