### PR TITLE
feat: CPU-spike fixes (Phase 1) + Center Stage / digital PTZ (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ follow [Semantic Versioning](https://semver.org/).
   or CUDA when available instead of always the CPU, cutting the per-frame
   appearance cost (and the GIL stall it caused on Macs). Set
   `AUTOPTZ_REID_DEVICE=cpu` to force the previous behaviour.
+- **Verify/force the CoreML GPU path** — `AUTOPTZ_COREML_UNITS`
+  (`ALL` / `CPUAndGPU` / `CPUOnly`) lets Intel + AMD Macs (e.g. iMac Pro Xeon +
+  Vega 56) check whether CoreML is actually using the discrete GPU or silently
+  falling back to the CPU: run `--bench` with `CPUOnly` and again with `ALL` and
+  compare. Defaults to `ALL`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ follow [Semantic Versioning](https://semver.org/).
   to every core. On Linux/Windows the exact count is honoured; on macOS's GCD
   OpenCV backend (which ignores a positive count) the cap forces single-threaded
   only under heavy multi-camera load.
+- **ReID runs on the GPU** — OSNet appearance ReID now uses the Apple GPU (`mps`)
+  or CUDA when available instead of always the CPU, cutting the per-frame
+  appearance cost (and the GIL stall it caused on Macs). Set
+  `AUTOPTZ_REID_DEVICE=cpu` to force the previous behaviour.
+
+### Fixed
+
+- **Named-target tracking no longer drifts to the wrong person** — a target
+  selected by identity (name), once lost, could be re-bound by appearance ReID to
+  the next visually-similar person, then any track. It now re-binds only to a
+  face-confirmed match of the *same* identity; otherwise it keeps searching.
+- **The camera no longer chases an occluded subject** — when the target is
+  suddenly covered, its box collapses to the visible part (e.g. the legs); the
+  drive loop now coasts on a sudden box-height collapse instead of following the
+  shrinking box down, and resumes when the subject reappears at full size.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Center Stage** — software auto-framing (digital PTZ) with virtual-camera output for non-PTZ cameras; select the `digital` backend in the PTZ panel and enable "Virtual camera output" to publish the cropped frame as a virtual camera.
+- **Center Stage** — software auto-framing (digital PTZ) for cameras without
+  motorised PTZ: a single **Center Stage** toggle in the PTZ panel digitally
+  pans/zooms a crop to follow the selected target, with an optional **Virtual
+  camera output** to publish the framed crop to Zoom/OBS (needs a system
+  virtual-camera driver). The raw PTZ transport selector now lives under PTZ →
+  Advanced, since most users use Center Stage or the auto-probe.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Center Stage** — software auto-framing (digital PTZ) with virtual-camera output for non-PTZ cameras; select the `digital` backend in the PTZ panel and enable "Virtual camera output" to publish the cropped frame as a virtual camera.
+
 ### Changed
 
 - **Less CPU oversubscription from OpenCV** — OpenCV's internal thread pool

--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -168,7 +168,7 @@ class PtzPresetSlot(BaseModel, frozen=True):
 
 
 class PTZConfig(BaseModel, frozen=True):
-    backend: Literal["auto", "ndi", "visca_ip", "visca_usb", "onvif"] = "auto"
+    backend: Literal["auto", "ndi", "visca_ip", "visca_usb", "onvif", "digital"] = "auto"
     address: str | None = None
     max_pan_speed: float = Field(default=0.7, ge=0.0, le=1.0)
     max_tilt_speed: float = Field(default=0.7, ge=0.0, le=1.0)
@@ -256,6 +256,10 @@ class PTZConfig(BaseModel, frozen=True):
     # / ``goto_preset(slot)`` drive.  Round-trips through JSON (keys are coerced
     # back to ``int`` on load).
     preset_slots: dict[int, PtzPresetSlot] = Field(default_factory=dict)
+    # Center Stage: emit the auto-framed crop as a virtual camera (Zoom/Teams/OBS).
+    vcam_out: bool = False
+    digital_output_w: int = Field(default=1280, ge=320, le=3840)
+    digital_output_h: int = Field(default=720, ge=240, le=2160)
 
     @field_validator("preset_slots", mode="before")
     @classmethod

--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -120,6 +120,9 @@ class TrackingConfig(BaseModel, frozen=True):
     # ``_apply_target_lock`` instead of the existing heuristic path.  OFF by
     # default — flip on per-camera to validate before it becomes the default.
     use_target_associator: bool = False
+    # Never run the detector and the pose pass on the same inference frame, so a
+    # heavy detect tick and a heavy pose tick don't stack into a 200ms frame.
+    stage_spread: bool = True
 
 
 # Vertical aim point as a fraction of the person-box height measured from the TOP

--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -238,6 +238,10 @@ class PTZConfig(BaseModel, frozen=True):
     # This is what keeps following stable when the subject and the camera move at
     # the same time; off restores the legacy contaminated-velocity behaviour.
     ego_comp_enabled: bool = True
+    # Run the (CPU-heavy) ego-motion optical flow every Nth inference frame and
+    # reuse a decayed estimate in between. 1 = every frame (old behaviour); 3 is
+    # a good default (flow is slow-changing relative to 30fps).
+    ego_comp_interval: int = Field(default=3, ge=1, le=10)
     # Upper bound on the learned command→image gain (normalised img-vel per unit
     # command); clamps the online regression so a bad sample can't run away.
     ego_comp_gain_max: float = Field(default=8.0, ge=0.0, le=64.0)

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3794,6 +3794,20 @@ class CameraWorker:
             return True
         return not self._detected_this_tick
 
+    def _amortized_cost_ms(self) -> float:
+        """Per-displayed-frame work: each stage scaled by how often it runs.
+
+        Detector runs every ``_quality_interval`` frames; face/pose run on a wall
+        clock (``_FACE_INTERVAL_S`` / ``_POSE_INTERVAL_S``) so per-frame they cost
+        proportionally less the higher the source fps.
+        """
+        fps = max(1.0, self._target_fps())
+        detect = self._stage_avg("detect") / max(1, self._quality_interval)
+        track = self._stage_avg("track")
+        face = self._stage_avg("face") * min(1.0, (1.0 / _FACE_INTERVAL_S) / fps)
+        pose = self._stage_avg("pose") * min(1.0, (1.0 / _POSE_INTERVAL_S) / fps)
+        return detect + track + face + pose
+
     def _effective_detect_interval(self) -> int:
         """Return the actual detector cadence after quality policy is applied."""
         base = max(1, int(getattr(self.config.tracking, "detect_interval", 1) or 1))
@@ -3815,20 +3829,19 @@ class CameraWorker:
             return self._quality_interval
 
         budget = self._frame_budget_ms()
-        cost = sum(self._stage_avg(k) for k in ("detect", "track", "face", "pose"))
+        cost = self._amortized_cost_ms()
         ratio = cost / budget if budget > 0 else 0.0
-        if ratio >= 0.95:
-            interval = max(base, 4)
-            active = "low"
-            reason = "Auto quality: runtime cost is over frame budget; detector cadence relaxed."
-        elif ratio >= 0.75:
-            interval = max(base, 2)
-            active = "balanced"
-            reason = "Auto quality: runtime cost is near frame budget; detector cadence balanced."
+        prev = self._quality_active
+        if ratio >= 0.90 or (prev in ("balanced", "low") and ratio >= 0.70):
+            if ratio >= 1.10:
+                interval, active = max(base, 4), "low"
+                reason = "Auto quality: over frame budget; detector cadence relaxed."
+            else:
+                interval, active = max(base, 2), "balanced"
+                reason = "Auto quality: near frame budget; detector cadence balanced."
         else:
-            interval = base
-            active = "high"
-            reason = "Auto quality: latency headroom stable; quality high, full cadence."
+            interval, active = base, "high"
+            reason = "Auto quality: latency headroom stable; full cadence."
         if interval != self._quality_interval or active != self._quality_active:
             self._add_event("quality", reason)
         self._quality_interval = interval

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3322,6 +3322,11 @@ class CameraWorker:
 
                     self._vcam = VirtualCamSink(ow, oh)
                 self._vcam.send_bgr(framed)
+            elif self._vcam is not None:
+                # Virtual camera output was turned off — release the device so it
+                # disconnects from Zoom/OBS instead of lingering on a frozen frame.
+                self._vcam.close()
+                self._vcam = None
         except Exception:  # noqa: BLE001
             log.debug("camera_id=%s shm push failed", self.camera_id, exc_info=True)
 

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1819,6 +1819,10 @@ class CameraWorker:
                     return
             new_id = visible_tracks[result.best_index].track_id
             if new_id != self._target_track_id:
+                if not self._reid_rebind_allows(new_id):
+                    # Named-identity target: body appearance alone must not drift the
+                    # lock onto a different/unknown person — wait for a face match.
+                    return
                 if not self._reid_recovery_confirmed(new_id):
                     return
                 # Now that the candidate is confirmed, blend the matching feature
@@ -1835,6 +1839,20 @@ class CameraWorker:
                     result.best_score,
                 )
                 self._commit_target_track(new_id, reason="reid")
+
+    def _reid_rebind_allows(self, new_id: int) -> bool:
+        """Whether appearance ReID recovery may re-bind the target to *new_id*.
+
+        For a target selected by *identity* (name), body appearance alone must
+        never move the lock onto a different person — re-acquiring a named target
+        requires a face-identity match. So a ReID re-bind is allowed only when the
+        candidate track is face-confirmed as the *same* identity. A manual/clicked
+        target (no identity) keeps the appearance-based re-bind it relies on.
+        """
+        if self._target_identity_id is None:
+            return True
+        entry = self._track_identity.get(new_id)
+        return entry is not None and entry[0] == self._target_identity_id
 
     def _reid_recovery_confirmed(self, track_id: int) -> bool:
         """Return True when the active tracking mode allows rebinding now."""

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -898,7 +898,17 @@ class CameraWorker:
             prev_fps = getattr(self.config.source, "fps", None)
             prev_tracker = getattr(self.config.tracking, "tracker", "")
             prev_mode = getattr(self.config.tracking, "tracking_mode", "stable")
+            prev_backend = getattr(self.config.ptz, "backend", "")
+            prev_addr = getattr(self.config.ptz, "address", "")
             self.config = payload
+            # Rebuild the PTZ backend live when the transport changes — e.g. toggling
+            # Center Stage flips backend to/from "digital". Without this the digital
+            # backend is never created on a live switch and Center Stage does nothing
+            # until an app restart.
+            new_backend = getattr(payload.ptz, "backend", "")
+            new_addr = getattr(payload.ptz, "address", "")
+            if new_backend != prev_backend or new_addr != prev_addr:
+                self._rebuild_ptz_backend()
             # Apply an fps change from a full-config push live too, so the UI's
             # fps slider takes effect whether it routes through updateCameraConfig
             # or the dedicated setTargetFps slot.
@@ -2971,6 +2981,35 @@ class CameraWorker:
                 exc_info=True,
             )
             return None
+
+    def _rebuild_ptz_backend(self) -> None:
+        """Tear down and rebuild the PTZ controller/backend from the current config.
+
+        Used on a live transport change (e.g. toggling Center Stage flips the
+        backend to/from ``digital``). ``_build_ptz_stack`` is a no-op while a
+        backend exists, so we clear it first; the rebuild then reads the new
+        ``config.ptz`` and builds the right backend (a ``DigitalPTZBackend`` for
+        Center Stage). Never raises.
+        """
+        with self._ptz_lock:
+            old = self._ptz_backend
+            if old is not None and self._ptz_owned:
+                try:
+                    old.close()
+                except Exception:  # noqa: BLE001
+                    log.debug(
+                        "camera_id=%s ptz backend close failed", self.camera_id, exc_info=True
+                    )
+            self._ptz = None
+            self._ptz_backend = None
+            self._ptz_owned = False
+            self._digital_framer = None  # fresh framer for the new backend
+            self._build_ptz_stack()
+        log.info(
+            "camera_id=%s PTZ backend rebuilt for backend=%s",
+            self.camera_id,
+            getattr(self.config.ptz, "backend", "?"),
+        )
 
     def _build_ptz_stack(self) -> None:
         """Build a PTZController around a backend from config, if none injected.

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -541,6 +541,7 @@ class CameraWorker:
         self._shm: ShmWriter | None = None
         self._vcam: Any | None = None  # VirtualCamSink (lazily created when vcam_out enabled)
         self._digital_framer: Any | None = None  # Center Stage auto-framer (lazy)
+        self._cs_diag_t: float = 0.0  # throttle for the Center Stage diagnostic log
         self._detect: _DetectStack | None = None
         self._pooled_detector = False
         # True when the detector is the unified YOLO11-pose model (boxes+keypoints
@@ -3237,6 +3238,19 @@ class CameraWorker:
             x, y, cw, ch = framer.frame_for(target, w, h)
         else:
             x, y, cw, ch = framer.full_frame(w, h)
+        nowm = time.monotonic()
+        if nowm - self._cs_diag_t > 2.0:
+            self._cs_diag_t = nowm
+            log.info(
+                "camera_id=%s center-stage: target=%s crop=%dx%d of %dx%d (tid=%s)",
+                self.camera_id,
+                "yes" if target is not None else "NONE",
+                cw,
+                ch,
+                w,
+                h,
+                self._target_track_id,
+            )
         crop = frame[y : y + ch, x : x + cw]
         if crop.size == 0:
             return frame
@@ -3245,20 +3259,28 @@ class CameraWorker:
     def _current_digital_target(self) -> tuple[float, float, float, float] | None:
         """The selected target's bbox (x1,y1,x2,y2) for Center Stage, or None.
 
-        Read from the last published tracks (this runs on the capture thread); a
-        slightly stale box is fine for smooth framing.
+        Runs on the capture thread; a slightly stale box is fine for smooth
+        framing. Prefers the live track for the current target id, but falls back
+        to the maintained *trusted* target box so Center Stage keeps framing
+        through track-id churn / identity re-binding (when ``_target_track_id``
+        momentarily points at a track not in the latest ``_last_tracks``).
         """
         tid = self._target_track_id
-        if tid is None:
-            return None
-        for t in self._last_tracks or ():
-            if (
-                t.track_id == tid
-                and not getattr(t, "lost", False)
-                and getattr(t, "bbox", None) is not None
-            ):
-                bb = t.bbox
-                return (bb.x1, bb.y1, bb.x2, bb.y2)
+        if tid is not None:
+            for t in self._last_tracks or ():
+                if (
+                    t.track_id == tid
+                    and not getattr(t, "lost", False)
+                    and getattr(t, "bbox", None) is not None
+                ):
+                    bb = t.bbox
+                    return (bb.x1, bb.y1, bb.x2, bb.y2)
+        # Fallback: the last trusted target box (set whenever a target is locked,
+        # by track id OR by identity), so the crop holds through brief track gaps.
+        if self._target_track_id is not None or self._target_identity_id is not None:
+            tb = getattr(self._target_lock, "trusted_bbox", None)
+            if tb is not None:
+                return (tb.x1, tb.y1, tb.x2, tb.y2)
         return None
 
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -540,6 +540,7 @@ class CameraWorker:
         self._source: FrameSource | None = None
         self._shm: ShmWriter | None = None
         self._vcam: Any | None = None  # VirtualCamSink (lazily created when vcam_out enabled)
+        self._digital_framer: Any | None = None  # Center Stage auto-framer (lazy)
         self._detect: _DetectStack | None = None
         self._pooled_detector = False
         # True when the detector is the unified YOLO11-pose model (boxes+keypoints
@@ -3167,10 +3168,14 @@ class CameraWorker:
                 )
 
     def _framed_output(self, frame: NDArray[np.uint8]) -> NDArray[np.uint8]:
-        """Crop+scale to the digital crop when a DigitalPTZBackend is active.
+        """Center Stage: crop+scale the frame to auto-frame the target.
 
-        Returns the original frame unchanged when no digital backend is set or
-        the frame is None, so the caller is always safe to use the return value.
+        The crop is computed directly from the current target's bounding box by
+        :class:`DigitalFramer` (centre on the subject, size to frame it, smoothed)
+        — NOT by integrating the velocity controller, whose conservative auto-zoom
+        never engaged so the crop stayed full-frame. With no target the crop eases
+        back to the whole frame. Returns the frame unchanged when no digital
+        backend is active, so the caller is always safe to use the return value.
         """
         from autoptz.engine.ptz.digital import DigitalPTZBackend
 
@@ -3180,11 +3185,42 @@ class CameraWorker:
         import cv2
 
         h, w = frame.shape[:2]
-        x, y, cw, ch = backend.crop_rect(w, h)
-        crop = frame[y : y + ch, x : x + cw]
         ow = int(getattr(self.config.ptz, "digital_output_w", 1280))
         oh = int(getattr(self.config.ptz, "digital_output_h", 720))
+        aspect = ow / max(1, oh)
+        framer = self._digital_framer
+        if framer is None or abs(framer.out_aspect - aspect) > 1e-3:
+            from autoptz.engine.pipeline.digital_framer import DigitalFramer
+
+            framer = self._digital_framer = DigitalFramer(out_aspect=aspect)
+        target = self._current_digital_target()
+        if target is not None:
+            x, y, cw, ch = framer.frame_for(target, w, h)
+        else:
+            x, y, cw, ch = framer.full_frame(w, h)
+        crop = frame[y : y + ch, x : x + cw]
+        if crop.size == 0:
+            return frame
         return cv2.resize(crop, (ow, oh), interpolation=cv2.INTER_LINEAR)
+
+    def _current_digital_target(self) -> tuple[float, float, float, float] | None:
+        """The selected target's bbox (x1,y1,x2,y2) for Center Stage, or None.
+
+        Read from the last published tracks (this runs on the capture thread); a
+        slightly stale box is fine for smooth framing.
+        """
+        tid = self._target_track_id
+        if tid is None:
+            return None
+        for t in self._last_tracks or ():
+            if (
+                t.track_id == tid
+                and not getattr(t, "lost", False)
+                and getattr(t, "bbox", None) is not None
+            ):
+                bb = t.bbox
+                return (bb.x1, bb.y1, bb.x2, bb.y2)
+        return None
 
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -72,6 +72,18 @@ _PREVIEW_H = 720
 _PREVIEW_PUSH_FPS = 20.0
 _PREVIEW_PUSH_MIN_PERIOD_S = 1.0 / _PREVIEW_PUSH_FPS
 
+# Center Stage crop tightness per "Framing" preset → (subject fill of crop,
+# max crop as a fraction of the frame). A smaller ``max_frac`` forces a tighter
+# zoom even on a close subject that already fills the sensor; the live "Framing"
+# dropdown (tracking.framing) picks the preset, so the user dials the shot
+# without a restart. ``upper_body`` is the default head-and-shoulders look.
+_CENTERSTAGE_FRAMING: dict[str, tuple[float, float]] = {
+    "face": (0.86, 0.50),  # tight head/face closeup (~2.0x on a close subject)
+    "head_shoulders": (0.80, 0.62),  # head + shoulders (~1.6x)
+    "upper_body": (0.70, 0.74),  # head + chest (~1.35x) — default
+    "full_body": (0.58, 0.94),  # whole person, gentle crop
+}
+
 _DEFAULT_TELEMETRY_HZ = 10.0
 
 # How long a manual PTZ nudge suspends auto control before auto resumes.
@@ -3233,6 +3245,11 @@ class CameraWorker:
             from autoptz.engine.pipeline.digital_framer import DigitalFramer
 
             framer = self._digital_framer = DigitalFramer(out_aspect=aspect)
+        # Crop tightness follows the live "Framing" dropdown.
+        framing = getattr(self.config.tracking, "framing", "upper_body")
+        framer.fill, framer.max_frac = _CENTERSTAGE_FRAMING.get(
+            framing, _CENTERSTAGE_FRAMING["upper_body"]
+        )
         target = self._current_digital_target()
         if target is not None:
             x, y, cw, ch = framer.frame_for(target, w, h)

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1279,6 +1279,8 @@ class CameraWorker:
             self._ego_vel = (0.0, 0.0)
             self._ego_source = "none"
             return
+        # Sentinel default 1 so a serialized config missing this field falls back to legacy
+        # every-frame behaviour; the normal Pydantic path always supplies the field default of 3.
         interval = max(1, int(getattr(self.config.ptz, "ego_comp_interval", 1)))
         if interval > 1 and (self._frames_inferred % interval) != 0:
             # Off-cadence: decay the last estimate toward zero and reuse it, so a
@@ -3186,6 +3188,8 @@ class CameraWorker:
         ``tracking.min_detection_size_frac`` of the frame height are dropped here
         so the engine doesn't chase/save every far-away person.
         """
+        # Intentional: no inference ran this tick, so the stale _detected_this_tick flag is
+        # harmless — there are no detections to pose anyway.
         if frame is None or self._detect is None:
             return []
         if not self._feature("detection"):

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -527,6 +527,7 @@ class CameraWorker:
         # owned resources (created in thread)
         self._source: FrameSource | None = None
         self._shm: ShmWriter | None = None
+        self._vcam: Any | None = None  # VirtualCamSink (lazily created when vcam_out enabled)
         self._detect: _DetectStack | None = None
         self._pooled_detector = False
         # True when the detector is the unified YOLO11-pose model (boxes+keypoints
@@ -634,6 +635,9 @@ class CameraWorker:
         if thread is not None and thread is not threading.current_thread():
             thread.join(timeout=timeout)
         self._thread = None
+        if self._vcam is not None:
+            self._vcam.close()
+            self._vcam = None
 
     @property
     def is_running(self) -> bool:
@@ -3097,6 +3101,26 @@ class CameraWorker:
                     self._quality_active,
                 )
 
+    def _framed_output(self, frame: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Crop+scale to the digital crop when a DigitalPTZBackend is active.
+
+        Returns the original frame unchanged when no digital backend is set or
+        the frame is None, so the caller is always safe to use the return value.
+        """
+        from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+        backend = self._ptz_backend
+        if not isinstance(backend, DigitalPTZBackend) or frame is None:
+            return frame
+        import cv2
+
+        h, w = frame.shape[:2]
+        x, y, cw, ch = backend.crop_rect(w, h)
+        crop = frame[y : y + ch, x : x + cw]
+        ow = int(getattr(self.config.ptz, "digital_output_w", 1280))
+        oh = int(getattr(self.config.ptz, "digital_output_h", 720))
+        return cv2.resize(crop, (ow, oh), interpolation=cv2.INTER_LINEAR)
+
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:
             return
@@ -3108,8 +3132,17 @@ class CameraWorker:
             return
         self._last_preview_push_t = now
         try:
-            f = self._fit_frame(frame)
+            framed = self._framed_output(frame)
+            f = self._fit_frame(framed)
             self._shm.push(f)
+            if getattr(self.config.ptz, "vcam_out", False):
+                ow = int(getattr(self.config.ptz, "digital_output_w", 1280))
+                oh = int(getattr(self.config.ptz, "digital_output_h", 720))
+                if self._vcam is None:
+                    from autoptz.engine.pipeline.vcam import VirtualCamSink
+
+                    self._vcam = VirtualCamSink(ow, oh)
+                self._vcam.send_bgr(framed)
         except Exception:  # noqa: BLE001
             log.debug("camera_id=%s shm push failed", self.camera_id, exc_info=True)
 

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1262,6 +1262,13 @@ class CameraWorker:
             self._ego_vel = (0.0, 0.0)
             self._ego_source = "none"
             return
+        interval = max(1, int(getattr(self.config.ptz, "ego_comp_interval", 1)))
+        if interval > 1 and (self._frames_inferred % interval) != 0:
+            # Off-cadence: decay the last estimate toward zero and reuse it, so a
+            # stale flow value never feeds the aim feed-forward indefinitely.
+            vx, vy = self._ego_vel
+            self._ego_vel = (vx * 0.6, vy * 0.6)
+            return
         boxes = [
             (t.bbox.x1, t.bbox.y1, t.bbox.x2, t.bbox.y2)
             for t in tracks

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -534,6 +534,10 @@ class CameraWorker:
         # detections instead of running a separate pose forward pass.
         self._unified_pose_active = False
         self._detect_frame_index = 0
+        # Tracks whether the detector actually ran this inference tick (vs. a
+        # skip/coast frame). Used by _pose_allowed_this_tick to spread the two
+        # heavy stages across separate frames when stage_spread is enabled.
+        self._detected_this_tick: bool = False
         # Last detections, re-fed to the tracker on detector-skip frames (when
         # detect_interval > 1) so tracks don't age out into "no boxes".
         self._last_detections: list[Any] = []
@@ -2534,7 +2538,8 @@ class CameraWorker:
             # Estimate pose for the selected person so the pose overlay shows the
             # moment you click someone — independent of whether PTZ auto-follow is
             # actively driving (which is the only place pose ran before).
-            self._maybe_estimate_pose_overlay(tracks, frame, now)
+            if self._pose_allowed_this_tick():
+                self._maybe_estimate_pose_overlay(tracks, frame, now)
             self._annotate_target_aim(tracks, frame, now)
 
             # Estimate the camera's own image motion for this tick BEFORE driving
@@ -3151,10 +3156,12 @@ class CameraWorker:
                 not self._pooled_detector or (self._detect_frame_index - 1) % interval == 0
             )
             if should_detect:
+                self._detected_this_tick = True
                 detections = self._detect.detector.detect(frame)
                 detections = self._filter_small_detections(detections, frame)
                 self._last_detections = detections
             else:
+                self._detected_this_tick = False
                 # On detector-skip frames re-feed the previous detections so the
                 # boxmot tracker keeps the person alive between detect frames.
                 # Feeding [] here ages tracks out within a frame or two, which is
@@ -3780,6 +3787,12 @@ class CameraWorker:
         self._last_reid_t = now - _REID_INTERVAL_S * 0.5
         self._last_pose_t = now - _POSE_INTERVAL_S * 0.33
         self._phase_seeded = True
+
+    def _pose_allowed_this_tick(self) -> bool:
+        """False when spreading is on and the detector ran this frame (defer pose)."""
+        if not getattr(self.config.tracking, "stage_spread", True):
+            return True
+        return not self._detected_this_tick
 
     def _effective_detect_interval(self) -> int:
         """Return the actual detector cadence after quality policy is applied."""

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -445,6 +445,10 @@ class CameraWorker:
         # This tick's ego velocity (error-space units/sec) and last full estimate.
         self._ego_vel: tuple[float, float] = (0.0, 0.0)
         self._ego_source: str = "none"
+        # True only on a tick where ego-motion was *freshly measured*; the aim
+        # feed-forward only subtracts ego when fresh, never a stale/decimated
+        # estimate (subtracting a decayed value made the camera ping-pong).
+        self._ego_fresh: bool = False
 
         # ── fused target associator (flag-gated, default OFF) ────────────────────
         # Cheap stateless instance — always constructed; only consulted when
@@ -1293,15 +1297,17 @@ class CameraWorker:
         if frame is None or not getattr(self.config.ptz, "ego_comp_enabled", True):
             self._ego_vel = (0.0, 0.0)
             self._ego_source = "none"
+            self._ego_fresh = False
             return
         # Sentinel default 1 so a serialized config missing this field falls back to legacy
         # every-frame behaviour; the normal Pydantic path always supplies the field default of 3.
         interval = max(1, int(getattr(self.config.ptz, "ego_comp_interval", 1)))
         if interval > 1 and (self._frames_inferred % interval) != 0:
-            # Off-cadence: decay the last estimate toward zero and reuse it, so a
-            # stale flow value never feeds the aim feed-forward indefinitely.
-            vx, vy = self._ego_vel
-            self._ego_vel = (vx * 0.6, vy * 0.6)
+            # Off-cadence: no fresh measurement this tick. Mark not-fresh so the aim
+            # feed-forward zero-subtracts ego instead of subtracting a stale value —
+            # subtracting a decayed estimate every tick is what made the camera
+            # ping-pong when it and the subject both moved.
+            self._ego_fresh = False
             return
         boxes = [
             (t.bbox.x1, t.bbox.y1, t.bbox.x2, t.bbox.y2)
@@ -1314,9 +1320,11 @@ class CameraWorker:
             log.debug("camera_id=%s ego-motion estimate failed", self.camera_id, exc_info=True)
             self._ego_vel = (0.0, 0.0)
             self._ego_source = "none"
+            self._ego_fresh = False
             return
         self._ego_vel = (ego.vx, ego.vy)
         self._ego_source = ego.source
+        self._ego_fresh = True
 
     def _estimate_aim_velocity(
         self,
@@ -1336,7 +1344,9 @@ class CameraWorker:
         if prev is not None:
             dt = now - self._prev_aim_t
             if dt > 1e-3:
-                ego_vx, ego_vy = self._ego_vel
+                # Only trust ego-motion on a freshly-measured tick; a stale/decimated
+                # estimate would inject a phantom world-velocity (the ping-pong).
+                ego_vx, ego_vy = self._ego_vel if self._ego_fresh else (0.0, 0.0)
                 raw_vx = (err[0] - prev[0]) / dt - ego_vx
                 raw_vy = (err[1] - prev[1]) / dt - ego_vy
                 a = 0.5  # EMA: balance responsiveness vs. jitter rejection

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -204,6 +204,11 @@ _REID_RECOVERY_CONFIRM_STABLE = 3
 _REID_RECOVERY_CONFIRM_RESPONSIVE = 1
 _REID_RECOVERY_MARGIN = 0.08
 _IDENTITY_TARGET_CONFIRM = 2
+# Occlusion coast: the target box height (frame fraction) must drop below this
+# fraction of its recent *healthy* height to count as a sudden collapse (the
+# subject covered by something) rather than the subject simply walking away.
+_OCCLUSION_COLLAPSE_FRAC = 0.55
+_OCCLUSION_REF_ALPHA = 0.10  # how fast the healthy-height reference tracks a gradual change
 
 # EMA weight for the pose-derived aim point: lower = smoother/laggier.  Light
 # smoothing so noisy keypoint regression doesn't jitter the framing.
@@ -342,6 +347,9 @@ class CameraWorker:
         # target per camera — supersedes an explicit track id when its identity
         # is detected on a live track.
         self._target_identity_id: str | None = config.target.identity_id
+        # Slowly-tracked "healthy" target box height (frame fraction); lets the
+        # drive loop tell a sudden occlusion collapse from a gradual walk-away.
+        self._target_h_ref: float | None = None
 
         self.shm_name = f"cam_{camera_id[:8]}_preview"
 
@@ -1228,10 +1236,17 @@ class CameraWorker:
             and self._tracking_enabled
             and tracking_on
         ):
+            fh = max(1, int(frame.shape[0]))
+            box_h_frac = (float(target.bbox.y2) - float(target.bbox.y1)) / fh
+            occluded = self._target_box_collapsed(box_h_frac)
             err, height = self._track_error(target, frame, now, tracks=tracks)
             vel = self._estimate_aim_velocity(err, now)
             try:
-                pan, tilt, zoom = ctrl.step(err, vel, height, track_active=True, t=now)
+                # A box that suddenly collapsed (occlusion → only a partial body
+                # visible) is not a trustworthy aim — coast (track_active=False) so
+                # the controller holds instead of chasing it onto the legs/last-known
+                # partial position, and resumes when the subject reappears in full.
+                pan, tilt, zoom = ctrl.step(err, vel, height, track_active=not occluded, t=now)
                 self._ptz_last_cmd = (pan, tilt, zoom)
                 self._log_ptz_cmd("auto", pan, tilt, zoom)
             except Exception:  # noqa: BLE001
@@ -1353,6 +1368,7 @@ class CameraWorker:
         with self._appearance_lock:
             if track_id != self._target_track_id:
                 self._reset_pose_aim()
+                self._target_h_ref = None
                 self._target_lock = _TargetLockState(status="pending", reason=reason)
                 self._reid_recover_candidate = None
                 self._identity_recover_candidate = None
@@ -1363,6 +1379,25 @@ class CameraWorker:
                 if reset_reid:
                     self._reset_reid()
             self._target_track_id = track_id
+
+    def _target_box_collapsed(self, height_frac: float) -> bool:
+        """True when the target box height suddenly collapsed vs its recent healthy
+        size — the occlusion signature (the subject covered by something leaves only
+        a partial box, e.g. just the legs). A gradual shrink (the subject walking
+        away) updates the reference and is NOT flagged, because the slow reference
+        keeps pace; a sudden drop IS flagged, because the reference hasn't caught up.
+        The caller coasts the PTZ instead of chasing the box down to the last-known
+        partial position.
+        """
+        h = max(0.0, float(height_frac))
+        ref = self._target_h_ref
+        if ref is None or ref <= 0.0:
+            self._target_h_ref = h
+            return False
+        if h < ref * _OCCLUSION_COLLAPSE_FRAC:
+            return True  # leave the reference intact so a full-size reappearance recovers
+        self._target_h_ref = ref + _OCCLUSION_REF_ALPHA * (h - ref)
+        return False
 
     @staticmethod
     def _bbox_area(bb: BBox) -> float:

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -542,6 +542,11 @@ class CameraWorker:
         # detect_interval > 1) so tracks don't age out into "no boxes".
         self._last_detections: list[Any] = []
 
+        # System-wide CPU pressure (0–100 %) pushed by the supervisor ~1 Hz.
+        # Consulted by _effective_detect_interval to throttle when the whole
+        # machine is hot, even if this camera's local cost looks fine.
+        self._system_cpu_pressure: float = 0.0
+
         self._seq = 0
         self._fps = 0.0
         self._ep = ""
@@ -764,6 +769,10 @@ class CameraWorker:
                     merged[key] = bool(features[key])
         with self._cmd_lock:
             self._features = merged
+
+    def set_system_cpu_pressure(self, pct: float) -> None:
+        """Latest system CPU% (set by the supervisor ~1 Hz), used by the governor."""
+        self._system_cpu_pressure = max(0.0, float(pct))
 
     def _feature(self, name: str) -> bool:
         """Thread-safe read of one feature flag (default True when unset)."""
@@ -3831,6 +3840,8 @@ class CameraWorker:
         budget = self._frame_budget_ms()
         cost = self._amortized_cost_ms()
         ratio = cost / budget if budget > 0 else 0.0
+        if self._system_cpu_pressure >= 85.0:
+            ratio = max(ratio, 0.92)  # Machine is hot → push toward balanced/low.
         prev = self._quality_active
         if ratio >= 0.90 or (prev in ("balanced", "low") and ratio >= 0.70):
             if ratio >= 1.10:

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -1,0 +1,107 @@
+"""Center Stage auto-framer — compute a smoothed crop that frames the target.
+
+Driving the digital crop through the physical PTZ velocity controller did not
+work: the controller's conservative auto-zoom never engaged, so the crop stayed
+at the full frame (and with no zoom there is no room to pan). This computes the
+crop **directly** from the target's bounding box each frame instead — centre on
+the subject, size the crop so the subject fills a configured fraction of it,
+match the output aspect ratio, clamp inside the frame, and EMA-smooth so it does
+not jitter. That is what "Center Stage" actually does, and it always responds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+def desired_crop(
+    bbox: tuple[float, float, float, float],
+    frame_w: int,
+    frame_h: int,
+    *,
+    out_aspect: float,
+    fill: float,
+    min_frac: float,
+    headroom: float = 0.10,
+) -> tuple[float, float, float, float]:
+    """The crop ``(x, y, w, h)`` (pixels) that frames *bbox*.
+
+    ``fill`` = the fraction of the crop height the subject should occupy (smaller
+    fill → tighter shot). ``out_aspect`` = the output width/height (the crop keeps
+    it so the resize doesn't distort). ``min_frac`` floors the crop at a fraction
+    of the frame so a tiny far-away box doesn't zoom to a postage stamp.
+    ``headroom`` lifts the centre slightly so the head isn't jammed at the top.
+    """
+    bx1, by1, bx2, by2 = (float(v) for v in bbox)
+    subj_h = max(1.0, by2 - by1)
+    cx = (bx1 + bx2) * 0.5
+    cy = (by1 + by2) * 0.5
+
+    fw, fh = float(frame_w), float(frame_h)
+    ch = subj_h / _clamp(fill, 0.1, 1.0)
+    cw = ch * out_aspect
+
+    # Cap to the frame, keeping the output aspect.
+    if cw > fw:
+        cw, ch = fw, fw / out_aspect
+    if ch > fh:
+        ch, cw = fh, fh * out_aspect
+    # Floor at min_frac of the frame height (don't over-zoom a small box).
+    min_ch = max(1.0, min_frac * fh)
+    if ch < min_ch:
+        ch, cw = min_ch, min_ch * out_aspect
+        if cw > fw:
+            cw, ch = fw, fw / out_aspect
+
+    # Lift the centre a touch for headroom, then clamp the window inside the frame.
+    cy_adj = cy - headroom * ch
+    x = _clamp(cx - cw * 0.5, 0.0, max(0.0, fw - cw))
+    y = _clamp(cy_adj - ch * 0.5, 0.0, max(0.0, fh - ch))
+    return (x, y, cw, ch)
+
+
+@dataclass
+class DigitalFramer:
+    """Stateful EMA-smoothed wrapper around :func:`desired_crop`."""
+
+    out_aspect: float = 16.0 / 9.0
+    fill: float = 0.62
+    min_frac: float = 0.34
+    smooth: float = 0.15  # EMA weight toward the desired crop each frame
+    headroom: float = 0.10
+    _crop: tuple[float, float, float, float] | None = None
+
+    def reset(self) -> None:
+        self._crop = None
+
+    def frame_for(
+        self, bbox: tuple[float, float, float, float], frame_w: int, frame_h: int
+    ) -> tuple[int, int, int, int]:
+        """Smoothed integer crop framing *bbox*."""
+        tgt = desired_crop(
+            bbox,
+            frame_w,
+            frame_h,
+            out_aspect=self.out_aspect,
+            fill=self.fill,
+            min_frac=self.min_frac,
+            headroom=self.headroom,
+        )
+        return self._step(tgt)
+
+    def full_frame(self, frame_w: int, frame_h: int) -> tuple[int, int, int, int]:
+        """Ease the crop back toward the whole frame (no target to follow)."""
+        return self._step((0.0, 0.0, float(frame_w), float(frame_h)))
+
+    def _step(self, tgt: tuple[float, float, float, float]) -> tuple[int, int, int, int]:
+        if self._crop is None:
+            self._crop = tgt
+        else:
+            a = self.smooth
+            self._crop = tuple(c + a * (t - c) for c, t in zip(self._crop, tgt, strict=True))  # type: ignore[assignment]
+        x, y, w, h = self._crop
+        return (int(round(x)), int(round(y)), max(1, int(round(w))), max(1, int(round(h))))

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -1,12 +1,15 @@
 """Center Stage auto-framer — compute a smoothed crop that frames the target.
 
 Driving the digital crop through the physical PTZ velocity controller did not
-work: the controller's conservative auto-zoom never engaged, so the crop stayed
-at the full frame (and with no zoom there is no room to pan). This computes the
-crop **directly** from the target's bounding box each frame instead — centre on
-the subject, size the crop so the subject fills a configured fraction of it,
-match the output aspect ratio, clamp inside the frame, and EMA-smooth so it does
-not jitter. That is what "Center Stage" actually does, and it always responds.
+work (its conservative auto-zoom never engaged). This computes the crop directly
+from the target's bounding box each frame instead — centre on the subject, size
+the crop so the subject fills a configured fraction of it, match the output
+aspect ratio, clamp inside the frame, and EMA-smooth so it does not jitter.
+
+The crop is constrained to a *window*: never larger than ``max_frac`` of the
+frame (so there is always a visible, panning Center-Stage crop even when the
+subject is close and already fills the sensor), and never smaller than
+``min_frac`` (so a far subject doesn't over-zoom into a blurry postage stamp).
 """
 
 from __future__ import annotations
@@ -26,38 +29,33 @@ def desired_crop(
     out_aspect: float,
     fill: float,
     min_frac: float,
+    max_frac: float,
     headroom: float = 0.10,
 ) -> tuple[float, float, float, float]:
     """The crop ``(x, y, w, h)`` (pixels) that frames *bbox*.
 
     ``fill`` = the fraction of the crop height the subject should occupy (smaller
-    fill → tighter shot). ``out_aspect`` = the output width/height (the crop keeps
-    it so the resize doesn't distort). ``min_frac`` floors the crop at a fraction
-    of the frame so a tiny far-away box doesn't zoom to a postage stamp.
-    ``headroom`` lifts the centre slightly so the head isn't jammed at the top.
+    fill → looser shot). The resulting crop height is then constrained to
+    ``[min_frac, max_frac]`` of the frame height, so the crop is always a visible
+    window (never the whole frame) and never an extreme zoom. ``out_aspect`` keeps
+    the crop matching the output so the resize doesn't distort. ``headroom`` lifts
+    the centre so the head sits a little below the top.
     """
     bx1, by1, bx2, by2 = (float(v) for v in bbox)
     subj_h = max(1.0, by2 - by1)
     cx = (bx1 + bx2) * 0.5
     cy = (by1 + by2) * 0.5
-
     fw, fh = float(frame_w), float(frame_h)
-    ch = subj_h / _clamp(fill, 0.1, 1.0)
-    cw = ch * out_aspect
 
-    # Cap to the frame, keeping the output aspect.
+    # Size the crop to the subject, then constrain it to a window of the frame.
+    ch = subj_h / _clamp(fill, 0.1, 1.0)
+    ch = _clamp(ch, min_frac * fh, max_frac * fh)
+    cw = ch * out_aspect
+    # If that is wider than the frame, cap width (keeps aspect; only happens for
+    # very wide outputs — with max_frac < 1 the height stays within the frame).
     if cw > fw:
         cw, ch = fw, fw / out_aspect
-    if ch > fh:
-        ch, cw = fh, fh * out_aspect
-    # Floor at min_frac of the frame height (don't over-zoom a small box).
-    min_ch = max(1.0, min_frac * fh)
-    if ch < min_ch:
-        ch, cw = min_ch, min_ch * out_aspect
-        if cw > fw:
-            cw, ch = fw, fw / out_aspect
 
-    # Lift the centre a touch for headroom, then clamp the window inside the frame.
     cy_adj = cy - headroom * ch
     x = _clamp(cx - cw * 0.5, 0.0, max(0.0, fw - cw))
     y = _clamp(cy_adj - ch * 0.5, 0.0, max(0.0, fh - ch))
@@ -69,9 +67,10 @@ class DigitalFramer:
     """Stateful EMA-smoothed wrapper around :func:`desired_crop`."""
 
     out_aspect: float = 16.0 / 9.0
-    fill: float = 0.62
+    fill: float = 0.70
     min_frac: float = 0.34
-    smooth: float = 0.15  # EMA weight toward the desired crop each frame
+    max_frac: float = 0.78  # crop is at most this fraction of the frame (always crops)
+    smooth: float = 0.18  # EMA weight toward the desired crop each frame
     headroom: float = 0.10
     _crop: tuple[float, float, float, float] | None = None
 
@@ -89,6 +88,7 @@ class DigitalFramer:
             out_aspect=self.out_aspect,
             fill=self.fill,
             min_frac=self.min_frac,
+            max_frac=self.max_frac,
             headroom=self.headroom,
         )
         return self._step(tgt)
@@ -102,6 +102,8 @@ class DigitalFramer:
             self._crop = tgt
         else:
             a = self.smooth
-            self._crop = tuple(c + a * (t - c) for c, t in zip(self._crop, tgt, strict=True))  # type: ignore[assignment]
+            self._crop = tuple(  # type: ignore[assignment]
+                c + a * (t - c) for c, t in zip(self._crop, tgt, strict=True)
+            )
         x, y, w, h = self._crop
         return (int(round(x)), int(round(y)), max(1, int(round(w))), max(1, int(round(h))))

--- a/autoptz/engine/pipeline/reid.py
+++ b/autoptz/engine/pipeline/reid.py
@@ -112,6 +112,39 @@ class ReIDResult:
     scores: list[float] = field(default_factory=list)
 
 
+def _pick_device(*, has_mps: bool, has_cuda: bool) -> str:
+    """Device priority for OSNet ReID: Apple GPU (mps) → CUDA → CPU."""
+    if has_mps:
+        return "mps"
+    if has_cuda:
+        return "cuda"
+    return "cpu"
+
+
+def _best_reid_device() -> str:
+    """Best available torch device for ReID, or "cpu" if torch is unavailable.
+
+    Keeps the appearance pass off the CPU on Macs (Apple ``mps``) and CUDA boxes —
+    it is otherwise a major per-frame cost that also stalls the inference thread
+    through the GIL. Set ``AUTOPTZ_REID_DEVICE=cpu`` to force it back (e.g. if an
+    OSNet op misbehaves on mps).
+    """
+    import os  # noqa: PLC0415
+
+    forced = os.environ.get("AUTOPTZ_REID_DEVICE", "").strip().lower()
+    if forced in ("cpu", "mps", "cuda"):
+        return forced
+    try:
+        import torch  # noqa: PLC0415
+
+        return _pick_device(
+            has_mps=bool(torch.backends.mps.is_available() and torch.backends.mps.is_built()),
+            has_cuda=bool(torch.cuda.is_available()),
+        )
+    except Exception:  # noqa: BLE001 — no torch / probe failure → CPU
+        return "cpu"
+
+
 class BodyReID:
     """OSNet appearance embeddings + hysteresis recovery matching.
 
@@ -129,7 +162,7 @@ class BodyReID:
         self,
         weights: Path | None = None,
         *,
-        device: str = "cpu",
+        device: str | None = None,
         threshold_hi: float = 0.70,
         threshold_lo: float = 0.45,
         _backend: Any | None = None,
@@ -145,22 +178,44 @@ class BodyReID:
         if _backend is None:
             self._try_init(weights, device)
 
-    def _try_init(self, weights: Path | None, device: str) -> None:
+    def _try_init(self, weights: Path | None, device: str | None) -> None:
         global _WARNED_UNAVAILABLE
         name = weights or Path("osnet_x0_25_msmt17.pt")
-        # BoxMOT ≥ 11 exposes a single ``boxmot.reid.ReID`` entry point with a
-        # ``__call__(frame, boxes=...)`` feature extractor.  Older releases used
-        # ``boxmot.appearance.reid_auto_backend.ReidAutoBackend`` whose ``.model``
-        # had ``get_features(xyxys, frame)``.  Try the new API first, then fall
-        # back, so both major versions work; either path degrades gracefully.
+        device = device or _best_reid_device()
+        # Try the resolved (GPU) device first; if it can't initialise (an op a
+        # given backend doesn't support on mps, etc.) fall back to CPU before
+        # finally degrading to motion-only.
+        if self._init_on_device(name, device):
+            return
+        if device != "cpu" and self._init_on_device(name, "cpu"):
+            log.info("BodyReID: %s device init failed; using CPU", device)
+            return
+        self._backend = None
+        self._available = False
+        if not _WARNED_UNAVAILABLE:
+            _WARNED_UNAVAILABLE = True
+            log.warning(
+                "boxmot OSNet ReID unavailable; appearance recovery disabled "
+                "(motion-only tracking still works).",
+                exc_info=True,
+            )
+
+    def _init_on_device(self, name: Path, device: str) -> bool:
+        """Build the OSNet backend on *device*; True on success, False to fall back.
+
+        BoxMOT ≥ 11 exposes ``boxmot.reid.ReID`` (``__call__(frame, boxes=...)``);
+        older releases used ``boxmot.appearance.reid_auto_backend.ReidAutoBackend``
+        whose ``.model`` had ``get_features(xyxys, frame)``. Try the new API first,
+        then the legacy one, so both major versions work.
+        """
         try:
             from boxmot.reid import ReID  # noqa: PLC0415
 
             self._backend = ReID(weights=name, device=device, half=False)
             self._new_api = True
             self._available = True
-            log.info("BodyReID ready (OSNet %s, boxmot.reid API)", name)
-            return
+            log.info("BodyReID ready (OSNet %s on %s, boxmot.reid API)", name, device)
+            return True
         except Exception:  # noqa: BLE001 — fall through to the legacy API
             pass
         try:
@@ -168,24 +223,13 @@ class BodyReID:
                 ReidAutoBackend,
             )
 
-            self._backend = ReidAutoBackend(
-                weights=name,
-                device=device,
-                half=False,
-            ).model
+            self._backend = ReidAutoBackend(weights=name, device=device, half=False).model
             self._new_api = False
             self._available = True
-            log.info("BodyReID ready (OSNet %s, legacy API)", name)
+            log.info("BodyReID ready (OSNet %s on %s, legacy API)", name, device)
+            return True
         except Exception:  # noqa: BLE001 — missing dep/weights/network must not raise
-            self._backend = None
-            self._available = False
-            if not _WARNED_UNAVAILABLE:
-                _WARNED_UNAVAILABLE = True
-                log.warning(
-                    "boxmot OSNet ReID unavailable; appearance recovery disabled "
-                    "(motion-only tracking still works).",
-                    exc_info=True,
-                )
+            return False
 
     @property
     def available(self) -> bool:

--- a/autoptz/engine/pipeline/vcam.py
+++ b/autoptz/engine/pipeline/vcam.py
@@ -1,0 +1,68 @@
+"""Virtual-camera output sink (optional pyvirtualcam). No-op when unavailable."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from numpy.typing import NDArray
+
+log = logging.getLogger(__name__)
+
+_PVC_AVAILABLE: bool | None = None
+
+
+def _probe_pyvirtualcam() -> bool:
+    global _PVC_AVAILABLE
+    if _PVC_AVAILABLE is None:
+        try:
+            import pyvirtualcam  # noqa: F401
+
+            _PVC_AVAILABLE = True
+        except Exception:  # noqa: BLE001
+            _PVC_AVAILABLE = False
+    return bool(_PVC_AVAILABLE)
+
+
+class VirtualCamSink:
+    def __init__(self, width: int, height: int, fps: float = 30.0) -> None:
+        self.width = int(width)
+        self.height = int(height)
+        self._cam = None
+        self.available = False
+        if not _probe_pyvirtualcam():
+            return
+        try:
+            import pyvirtualcam
+
+            self._cam = pyvirtualcam.Camera(
+                width=self.width,
+                height=self.height,
+                fps=max(1.0, fps),
+                fmt=pyvirtualcam.PixelFormat.BGR,
+            )
+            self.available = True
+        except Exception:  # noqa: BLE001 — no virtual-cam driver installed, etc.
+            log.info("virtual camera unavailable; Center Stage output disabled", exc_info=True)
+            self._cam = None
+            self.available = False
+
+    def send_bgr(self, frame: NDArray[np.uint8]) -> None:
+        if self._cam is None:
+            return
+        try:
+            if frame.shape[1] != self.width or frame.shape[0] != self.height:
+                import cv2
+
+                frame = cv2.resize(frame, (self.width, self.height))
+            self._cam.send(frame)
+        except Exception:  # noqa: BLE001 — never let output break the pipeline
+            log.debug("virtual camera send failed", exc_info=True)
+
+    def close(self) -> None:
+        if self._cam is not None:
+            try:
+                self._cam.close()
+            finally:
+                self._cam = None
+                self.available = False

--- a/autoptz/engine/ptz/digital.py
+++ b/autoptz/engine/ptz/digital.py
@@ -1,0 +1,87 @@
+"""Digital ("Center Stage") PTZ backend: integrate velocity into a crop window.
+
+The controller drives this exactly like a physical backend (``move_velocity``),
+but instead of moving motors we move a normalized crop rectangle inside the
+sensor frame. An output stage reads :meth:`crop_rect` each frame and crops/scales
+to produce the auto-framed output — so any non-PTZ camera gains auto-framing.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.ptz.base import PTZBackend, PTZCaps
+
+# Per-call integration step when no explicit dt is given. The controller calls
+# move_velocity once per inference frame, so a fixed nominal frame period keeps
+# the motion deterministic (unit-testable) and independent of wall-clock jitter
+# between rapid calls. Callers that know the real frame dt may pass it explicitly.
+_NOMINAL_DT = 1.0 / 30.0
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return lo if v < lo else hi if v > hi else v
+
+
+class DigitalPTZBackend(PTZBackend):
+    def __init__(self, min_crop_frac: float = 0.34, max_step_per_s: float = 1.6) -> None:
+        super().__init__()
+        self.caps = PTZCaps(
+            continuous_pan_tilt=True,
+            continuous_zoom=True,
+            absolute_pan_tilt=True,
+            absolute_zoom=True,
+            native_presets=False,
+            query_position=False,
+        )
+        self._min_crop = _clamp(min_crop_frac, 0.1, 1.0)
+        self._rate = max(0.01, max_step_per_s)
+        # Normalized state: pan/tilt in [-1,1] (fraction of the *available* travel),
+        # zoom in [0,1] (0 = full frame, 1 = tightest crop).
+        self._pan = 0.0
+        self._tilt = 0.0
+        self._zoom = 0.0
+        self._presets: dict[int, tuple[float, float, float]] = {}
+
+    def move_velocity(
+        self, pan: float, tilt: float, zoom: float = 0.0, dt: float | None = None
+    ) -> None:
+        # Optional dt keeps the ABC-compatible 3-arg call working (controller path)
+        # while letting callers/tests integrate a known step deterministically.
+        step = self._rate * (_NOMINAL_DT if dt is None else max(0.0, dt))
+        self._zoom = _clamp(self._zoom + zoom * step, 0.0, 1.0)
+        self._pan = _clamp(self._pan + pan * step, -1.0, 1.0)
+        self._tilt = _clamp(self._tilt + tilt * step, -1.0, 1.0)
+
+    def move_absolute(self, pan: float, tilt: float, zoom: float) -> None:
+        self._pan = _clamp(pan, -1.0, 1.0)
+        self._tilt = _clamp(tilt, -1.0, 1.0)
+        self._zoom = _clamp(zoom, 0.0, 1.0)
+
+    def stop(self) -> None:
+        return None  # state holds; nothing to halt
+
+    def home(self) -> None:
+        self._pan = self._tilt = self._zoom = 0.0
+
+    def save_preset(self, idx: int) -> None:
+        self._presets[idx] = (self._pan, self._tilt, self._zoom)
+
+    def goto_preset(self, idx: int) -> None:
+        if idx in self._presets:
+            self._pan, self._tilt, self._zoom = self._presets[idx]
+
+    def close(self) -> None:
+        return None
+
+    def crop_rect(self, frame_w: int, frame_h: int) -> tuple[int, int, int, int]:
+        """Current crop as integer ``(x, y, w, h)`` inside ``frame_w × frame_h``."""
+        frac = 1.0 - self._zoom * (1.0 - self._min_crop)  # 1.0 → min_crop
+        cw = max(1, int(round(frame_w * frac)))
+        ch = max(1, int(round(frame_h * frac)))
+        # Tilt is up-positive in controller space; image y grows downward → invert.
+        free_x = frame_w - cw
+        free_y = frame_h - ch
+        cx = (free_x / 2.0) + self._pan * (free_x / 2.0)
+        cy = (free_y / 2.0) - self._tilt * (free_y / 2.0)
+        x = int(round(_clamp(cx, 0.0, float(free_x))))
+        y = int(round(_clamp(cy, 0.0, float(free_y))))
+        return (x, y, cw, ch)

--- a/autoptz/engine/ptz/factory.py
+++ b/autoptz/engine/ptz/factory.py
@@ -68,6 +68,8 @@ def build_backend(
             return _build_ndi(ptz, ndi_source=ndi_source, ndi_name=ndi_name)
         if backend == "onvif":
             return _build_onvif(ptz)
+        if backend == "digital":
+            return _build_digital(ptz)
     except Exception:  # noqa: BLE001 - factory must never raise into the engine
         log.warning(
             "PTZ backend %r build failed (addr=%r); PTZ disabled.",
@@ -153,6 +155,13 @@ def _build_onvif(ptz: PTZConfig) -> PTZBackend | None:
         return None
     log.info("PTZ backend: ONVIF on %s:%d", host, port)
     return backend
+
+
+def _build_digital(ptz: PTZConfig) -> PTZBackend | None:
+    from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+    log.info("PTZ backend: digital (Center Stage)")
+    return DigitalPTZBackend()
 
 
 # ── auto probe ──────────────────────────────────────────────────────────────────

--- a/autoptz/engine/runtime/inference.py
+++ b/autoptz/engine/runtime/inference.py
@@ -199,17 +199,39 @@ def effective_precision(ep: EP | str, prefs: HardwarePrefs | None = None) -> str
     return "fp16" if (ep in _ACCELERATED_EPS and _wants_fp16(prefs)) else "fp32"
 
 
+_VALID_COREML_UNITS = ("ALL", "CPUAndGPU", "CPUOnly", "CPUAndNeuralEngine")
+
+
+def _coreml_compute_units() -> str:
+    """CoreML compute-unit target. Defaults to ``ALL`` (CoreML picks the fastest
+    unit per op; on Intel Macs ``ALL`` includes the discrete AMD GPU via Metal).
+
+    Override with ``AUTOPTZ_COREML_UNITS`` to diagnose or force the path on
+    Intel + AMD (e.g. iMac Pro Xeon + Vega) Macs — ``CPUOnly`` to *measure* whether
+    the GPU is helping at all (compare two ``--bench`` runs), or ``CPUAndGPU`` to
+    pin the discrete GPU if ``ALL`` is silently choosing the CPU. Invalid values
+    fall back to ``ALL``.
+    """
+    import os  # noqa: PLC0415
+
+    val = os.environ.get("AUTOPTZ_COREML_UNITS", "").strip().lower()
+    for v in _VALID_COREML_UNITS:
+        if val == v.lower():
+            return v
+    return "ALL"
+
+
 def _provider_options(ep: EP, prefs: HardwarePrefs | None) -> dict[str, object]:
     """Per-EP acceleration options. Empty dict = provider defaults."""
     if ep is EP.COREML:
         # MLProgram routes to the Apple Neural Engine / GPU (incl. AMD on Intel
-        # Macs via Metal); ALL lets CoreML pick the fastest unit per op.
-        # ModelCacheDirectory persists the compiled MLProgram so the slow first
-        # compile is one-time per machine, not paid on every session build
-        # (acute with many camera workers / process-per-camera).
+        # Macs via Metal); the compute-unit target is tunable (AUTOPTZ_COREML_UNITS)
+        # so an Intel+AMD Mac can verify/force the GPU path. ModelCacheDirectory
+        # persists the compiled MLProgram so the slow first compile is one-time per
+        # machine, not paid on every session build (acute with process-per-camera).
         return {
             "ModelFormat": "MLProgram",
-            "MLComputeUnits": "ALL",
+            "MLComputeUnits": _coreml_compute_units(),
             "ModelCacheDirectory": _coreml_cache_dir(),
         }
     if ep is EP.TENSORRT:

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _PUMP_INTERVAL_S = 0.05  # 20 Hz command pump when run internally
+_CPU_SAMPLE_INTERVAL_S = 1.0  # system-CPU fan-out cadence (≈1 Hz)
 
 # Worker liveness / auto-restart constants
 _HEALTH_SCAN_INTERVAL_S = 2.0  # how often tick() runs the health scan
@@ -425,7 +426,7 @@ class Supervisor:
             self._scan_worker_health(now)
         # Throttled (~1 Hz) system-CPU sample fanned out to every worker so the
         # per-camera governor can back off collectively when the machine is hot.
-        if now - getattr(self, "_last_cpu_sample_t", 0.0) >= 1.0:
+        if now - getattr(self, "_last_cpu_sample_t", 0.0) >= _CPU_SAMPLE_INTERVAL_S:
             self._last_cpu_sample_t = now
             try:
                 from autoptz.engine.runtime.diagnostics import system_metrics

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -423,6 +423,20 @@ class Supervisor:
         if now - self._last_health_scan_t >= _HEALTH_SCAN_INTERVAL_S:
             self._last_health_scan_t = now
             self._scan_worker_health(now)
+        # Throttled (~1 Hz) system-CPU sample fanned out to every worker so the
+        # per-camera governor can back off collectively when the machine is hot.
+        if now - getattr(self, "_last_cpu_sample_t", 0.0) >= 1.0:
+            self._last_cpu_sample_t = now
+            try:
+                from autoptz.engine.runtime.diagnostics import system_metrics
+
+                pct = float(system_metrics().get("cpu_percent", 0.0) or 0.0)
+            except Exception:  # noqa: BLE001
+                pct = 0.0
+            for worker in self._workers.values():
+                setter = getattr(worker, "set_system_cpu_pressure", None)
+                if setter is not None:
+                    setter(pct)
 
     def _pump_loop(self) -> None:
         while not self._pump_stop.is_set():

--- a/autoptz/ui/widgets/properties_panel.py
+++ b/autoptz/ui/widgets/properties_panel.py
@@ -593,40 +593,26 @@ class PropertiesPanel(QWidget):
         # PTZ
         pz = CollapsibleGroup("PTZ", expanded=False)
         pf = _form()
-        self._backend = QComboBox()
-        self._backend.addItems(["auto", "ndi", "visca_ip", "visca_usb", "onvif", "digital"])
-        self._backend.setToolTip(
-            "How PTZ move commands reach the camera. “auto” probes NDI → ONVIF → "
-            "VISCA-IP; pick a specific one if you know your camera. "
-            "”digital” enables Center Stage — software auto-framing for non-PTZ "
-            "cameras, output as a virtual camera."
+
+        # Center Stage: the user-facing toggle for software auto-framing. When on,
+        # this camera uses the digital backend (crop-follow) instead of hardware PTZ;
+        # the raw transport selector (moved to Advanced below) is then overridden.
+        self._center_stage = QCheckBox("Center Stage — auto-frame this camera (no PTZ hardware)")
+        self._center_stage.setToolTip(
+            "Software auto-framing: digitally pans and zooms a crop to follow the "
+            "selected target, for cameras without motorised PTZ. Select a person to "
+            "follow; enable Virtual camera output to publish the framed crop."
         )
-        self._backend.currentTextChanged.connect(self._schedule)
+        self._center_stage.toggled.connect(self._on_center_stage_toggled)
         pf.addRow(
-            "Backend",
+            "",
             _with_chip(
-                self._backend,
+                self._center_stage,
                 HelpBadge(
-                    "How PTZ move commands reach the camera. “auto” probes NDI → ONVIF → "
-                    "VISCA-IP; pick a specific protocol if you already know what your "
-                    "camera speaks. “digital” (Center Stage) does software auto-framing "
-                    "for non-PTZ cameras and outputs the result as a virtual camera."
-                ),
-            ),
-        )
-        self._ptz_address = QLineEdit()
-        self._ptz_address.editingFinished.connect(self._schedule)
-        self._ptz_address.setToolTip(
-            "Host:port (IP backends) or serial port (VISCA-USB). Leave blank for auto."
-        )
-        pf.addRow(
-            "Address",
-            _with_chip(
-                self._ptz_address,
-                HelpBadge(
-                    "Where to send PTZ commands: host:port for IP backends (NDI / ONVIF / "
-                    "VISCA-IP) or the serial port for VISCA-USB. Leave blank to let the "
-                    "backend auto-discover."
+                    "Center Stage digitally frames the subject (crop + zoom) on cameras "
+                    "with no motorised PTZ. It follows the target you select. Enable "
+                    "Virtual camera output to send the framed crop to apps like Zoom or "
+                    "OBS (needs a system virtual-camera driver installed)."
                 ),
             ),
         )
@@ -665,6 +651,50 @@ class PropertiesPanel(QWidget):
             ),
         )
         pz.add_widget(_wrap(pf))
+
+        # Advanced — the raw transport selector + address, tucked away. Most users
+        # use Center Stage (software) or leave the backend on auto-probe, so the
+        # protocol picker lives here rather than front-and-centre.
+        adv_ptz = CollapsibleGroup("Advanced", expanded=False)
+        apf = _form()
+        self._backend = QComboBox()
+        self._backend.addItems(["auto", "ndi", "visca_ip", "visca_usb", "onvif"])
+        self._backend.setToolTip(
+            "How PTZ move commands reach a motorised camera. “auto” probes "
+            "NDI → ONVIF → VISCA-IP; pick a specific protocol if you know your camera. "
+            "Overridden while Center Stage is on."
+        )
+        self._backend.currentTextChanged.connect(self._schedule)
+        apf.addRow(
+            "Backend",
+            _with_chip(
+                self._backend,
+                HelpBadge(
+                    "How PTZ move commands reach a motorised camera. “auto” probes "
+                    "NDI → ONVIF → VISCA-IP; pick a specific protocol if you already know "
+                    "what your camera speaks. Ignored while Center Stage is enabled."
+                ),
+            ),
+        )
+        self._ptz_address = QLineEdit()
+        self._ptz_address.editingFinished.connect(self._schedule)
+        self._ptz_address.setToolTip(
+            "Host:port (IP backends) or serial port (VISCA-USB). Leave blank for auto."
+        )
+        apf.addRow(
+            "Address",
+            _with_chip(
+                self._ptz_address,
+                HelpBadge(
+                    "Where to send PTZ commands: host:port for IP backends (NDI / ONVIF / "
+                    "VISCA-IP) or the serial port for VISCA-USB. Leave blank to let the "
+                    "backend auto-discover."
+                ),
+            ),
+        )
+        adv_ptz.add_widget(_wrap(apf))
+        pz.add_widget(adv_ptz)
+
         pz.add_widget(self._build_ptz_controls())
         pz.add_widget(self._build_presets())
         self._col.addWidget(pz)
@@ -1335,7 +1365,11 @@ class PropertiesPanel(QWidget):
                 tr.get("framing") or tr.get("aim_region") or "upper_body",
             )
             self._ignore_arms.setChecked((tr.get("aim_body_mode") or "torso") == "torso")
-            _set_combo(self._backend, pz.get("backend", "auto"))
+            backend = pz.get("backend", "auto")
+            is_center_stage = backend == "digital"
+            self._center_stage.setChecked(is_center_stage)
+            _set_combo(self._backend, "auto" if is_center_stage else backend)
+            self._backend.setEnabled(not is_center_stage)
             self._ptz_address.setText(pz.get("address") or "")
             self._auto_zoom.setChecked(bool(pz.get("auto_zoom", True)))
             self._vcam_out.setChecked(bool(pz.get("vcam_out", False)))
@@ -1494,6 +1528,11 @@ class PropertiesPanel(QWidget):
         tip = _TRACKER_HELP.get(self._tracker.currentText(), _COST_HELP["tracker"])
         self._tracker.setToolTip(tip)
 
+    def _on_center_stage_toggled(self, on: bool) -> None:
+        """Center Stage overrides the transport — grey the Advanced backend picker."""
+        self._backend.setEnabled(not on)
+        self._schedule()
+
     def _refresh_cost_chips(self) -> None:
         di = self._detect_interval.value()
         _restyle_chip(self._detect_chip, "heavy" if di <= 2 else "medium" if di <= 5 else "light")
@@ -1529,7 +1568,9 @@ class PropertiesPanel(QWidget):
         cfg["tracking"]["aim_body_mode"] = (
             "torso" if self._ignore_arms.isChecked() else "full_silhouette"
         )
-        cfg["ptz"]["backend"] = self._backend.currentText()
+        cfg["ptz"]["backend"] = (
+            "digital" if self._center_stage.isChecked() else self._backend.currentText()
+        )
         cfg["ptz"]["address"] = self._ptz_address.text().strip() or None
         cfg["ptz"]["auto_zoom"] = self._auto_zoom.isChecked()
         cfg["ptz"]["vcam_out"] = self._vcam_out.isChecked()

--- a/autoptz/ui/widgets/properties_panel.py
+++ b/autoptz/ui/widgets/properties_panel.py
@@ -594,10 +594,12 @@ class PropertiesPanel(QWidget):
         pz = CollapsibleGroup("PTZ", expanded=False)
         pf = _form()
         self._backend = QComboBox()
-        self._backend.addItems(["auto", "ndi", "visca_ip", "visca_usb", "onvif"])
+        self._backend.addItems(["auto", "ndi", "visca_ip", "visca_usb", "onvif", "digital"])
         self._backend.setToolTip(
             "How PTZ move commands reach the camera. “auto” probes NDI → ONVIF → "
-            "VISCA-IP; pick a specific one if you know your camera."
+            "VISCA-IP; pick a specific one if you know your camera. "
+            "”digital” enables Center Stage — software auto-framing for non-PTZ "
+            "cameras, output as a virtual camera."
         )
         self._backend.currentTextChanged.connect(self._schedule)
         pf.addRow(
@@ -607,7 +609,8 @@ class PropertiesPanel(QWidget):
                 HelpBadge(
                     "How PTZ move commands reach the camera. “auto” probes NDI → ONVIF → "
                     "VISCA-IP; pick a specific protocol if you already know what your "
-                    "camera speaks."
+                    "camera speaks. “digital” (Center Stage) does software auto-framing "
+                    "for non-PTZ cameras and outputs the result as a virtual camera."
                 ),
             ),
         )
@@ -641,6 +644,23 @@ class PropertiesPanel(QWidget):
                     "Lets the controller zoom in and out automatically to keep the "
                     "subject at the chosen Framing tightness (set in the Tracking "
                     "section). Turn off to hold a fixed zoom."
+                ),
+            ),
+        )
+        self._vcam_out = QCheckBox("Virtual camera output")
+        self._vcam_out.setToolTip(
+            "Publish the auto-framed crop as a virtual camera device "
+            "(Center Stage / digital backend only)."
+        )
+        self._vcam_out.toggled.connect(self._schedule)
+        pf.addRow(
+            "",
+            _with_chip(
+                self._vcam_out,
+                HelpBadge(
+                    "When the digital (Center Stage) backend is active, publish the "
+                    "auto-framed crop as a virtual camera device so apps like Zoom "
+                    "or OBS can pick it up without hardware PTZ."
                 ),
             ),
         )
@@ -1318,6 +1338,7 @@ class PropertiesPanel(QWidget):
             _set_combo(self._backend, pz.get("backend", "auto"))
             self._ptz_address.setText(pz.get("address") or "")
             self._auto_zoom.setChecked(bool(pz.get("auto_zoom", True)))
+            self._vcam_out.setChecked(bool(pz.get("vcam_out", False)))
             # Advanced tracking tuning (sliders store hundredths of the cfg value).
             self._kp.setValue(int(round(float(pz.get("kp", 0.6)) * 100)))
             self._kp_val.setText(f"{self._kp.value() / 100:.2f}")
@@ -1511,6 +1532,7 @@ class PropertiesPanel(QWidget):
         cfg["ptz"]["backend"] = self._backend.currentText()
         cfg["ptz"]["address"] = self._ptz_address.text().strip() or None
         cfg["ptz"]["auto_zoom"] = self._auto_zoom.isChecked()
+        cfg["ptz"]["vcam_out"] = self._vcam_out.isChecked()
         cfg["ptz"]["zoom_framing"] = framing
         # Advanced tracking tuning (sliders hold hundredths of the cfg value).
         cfg["ptz"]["kp"] = self._kp.value() / 100.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -102,3 +102,7 @@ watchdog==6.0.0
 # Services panel. Optional — diagnostics.system_metrics() degrades to
 # placeholders if absent.
 psutil>=5.9
+
+# Optional — virtual-camera output for Center Stage (needs a system virtual-camera
+# driver such as OBS Virtual Camera). Install manually if you want this:
+#   pip install pyvirtualcam

--- a/tests/test_coreml_units.py
+++ b/tests/test_coreml_units.py
@@ -1,0 +1,27 @@
+"""CoreML compute-unit selection (AUTOPTZ_COREML_UNITS).
+
+Lets an Intel + AMD Mac (e.g. iMac Pro Xeon + Vega) verify/force whether CoreML
+uses the discrete GPU or silently falls back to the CPU.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.runtime.inference import _coreml_compute_units
+
+
+class TestCoreMLComputeUnits:
+    def test_default_is_all(self, monkeypatch):
+        monkeypatch.delenv("AUTOPTZ_COREML_UNITS", raising=False)
+        assert _coreml_compute_units() == "ALL"
+
+    def test_explicit_cpu_only(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "CPUOnly")
+        assert _coreml_compute_units() == "CPUOnly"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "cpuandgpu")
+        assert _coreml_compute_units() == "CPUAndGPU"
+
+    def test_invalid_falls_back_to_all(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "turbo")
+        assert _coreml_compute_units() == "ALL"

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -271,3 +271,26 @@ def test_ego_runs_every_nth_frame():
     assert calls["n"] == 2
     # Between runs the estimate is reused (non-zero), not blanked to "none".
     assert w._ego_source == "flow"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage-spread: pose skips on frames where the detector ran
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_pose_skips_on_a_detect_frame():
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-cpu-000002",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(stage_spread=True),
+        ptz=PTZConfig(),
+    )
+    w = CameraWorker("cam-cpu-000002", cfg, on_telemetry=lambda m: None)
+    w._detected_this_tick = True
+    assert w._pose_allowed_this_tick() is False
+    w._detected_this_tick = False
+    assert w._pose_allowed_this_tick() is True

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -229,3 +229,45 @@ class TestPhaseStagger:
         pose_next_due = worker._last_pose_t + _POSE_INTERVAL_S
         # That is now + (1 - 0.33) * _POSE_INTERVAL_S = now + 0.67 * _POSE_INTERVAL_S
         assert pose_next_due == pytest.approx(now + _POSE_INTERVAL_S * 0.67)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ego-motion decimation: _update_ego_motion cadence gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _worker(**ptz):
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+
+    cfg = CameraConfig(
+        id="cam-cpu-000001",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(**ptz),
+    )
+    from autoptz.engine.camera_worker import CameraWorker
+
+    return CameraWorker("cam-cpu-000001", cfg, on_telemetry=lambda m: None)
+
+
+def test_ego_runs_every_nth_frame():
+    w = _worker(ego_comp_enabled=True, ego_comp_interval=3)
+    calls = {"n": 0}
+
+    class _Est:
+        def estimate(self, *a, **k):
+            calls["n"] += 1
+            from autoptz.engine.pipeline.egomotion import EgoMotion
+
+            return EgoMotion(vx=0.1, vy=0.0, source="flow", confidence=1.0)
+
+    w._ego_estimator = _Est()
+    frame = np.zeros((360, 640, 3), dtype=np.uint8)
+    for i in range(6):
+        w._frames_inferred = i  # drives the decimation phase
+        w._update_ego_motion([], frame, float(i))
+    # 6 frames, interval 3 → flow ran on frames 0 and 3 only.
+    assert calls["n"] == 2
+    # Between runs the estimate is reused (non-zero), not blanked to "none".
+    assert w._ego_source == "flow"

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -318,3 +318,26 @@ def test_amortized_cost_divides_detect_by_interval():
     w._stage_avg = lambda k: w._stage_samples_override.get(k, 0.0)
     # Detect amortized over interval 4 → 10ms, + track 2ms = 12ms, NOT 42ms.
     assert abs(w._amortized_cost_ms() - 12.0) < 0.51
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# System-CPU-aware governor
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_high_system_cpu_relaxes_even_when_local_cost_low():
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-cpu-000004",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(),
+    )
+    w = CameraWorker("cam-cpu-000004", cfg, on_telemetry=lambda m: None)
+    w._stage_avg = lambda k: 1.0  # trivially low local cost
+    w.set_system_cpu_pressure(95.0)
+    w._effective_detect_interval()
+    assert w._quality_active in ("balanced", "low")

--- a/tests/test_cpu_governor.py
+++ b/tests/test_cpu_governor.py
@@ -294,3 +294,27 @@ def test_pose_skips_on_a_detect_frame():
     assert w._pose_allowed_this_tick() is False
     w._detected_this_tick = False
     assert w._pose_allowed_this_tick() is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Amortized cost + hysteresis
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_amortized_cost_divides_detect_by_interval():
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-cpu-000003",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(),
+    )
+    w = CameraWorker("cam-cpu-000003", cfg, on_telemetry=lambda m: None)
+    w._quality_interval = 4
+    w._stage_samples_override = {"detect": 40.0, "track": 2.0, "face": 0.0, "pose": 0.0}
+    w._stage_avg = lambda k: w._stage_samples_override.get(k, 0.0)
+    # Detect amortized over interval 4 → 10ms, + track 2ms = 12ms, NOT 42ms.
+    assert abs(w._amortized_cost_ms() - 12.0) < 0.51

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -1,0 +1,61 @@
+"""Center Stage auto-framer tests — the crop is computed directly from the target
+bbox (not the velocity controller, which never zoomed)."""
+
+from __future__ import annotations
+
+from autoptz.engine.pipeline.digital_framer import DigitalFramer, desired_crop
+
+ASPECT = 16.0 / 9.0
+
+
+class TestDesiredCrop:
+    def test_centers_and_zooms_on_a_small_subject(self):
+        # A person occupying ~25% of a 1920x1080 frame, centred.
+        bbox = (860, 400, 1060, 670)  # 200x270, centre (960, 535)
+        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        assert w < 1920 and h < 1080  # zoomed in
+        assert abs(w / h - ASPECT) < 0.02  # output aspect preserved
+        # crop horizontally centred on the subject
+        assert abs((x + w / 2) - 960) <= 2
+
+    def test_clamped_inside_frame_for_edge_subject(self):
+        bbox = (20, 700, 180, 1050)  # bottom-left subject
+        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        assert x >= 0 and y >= 0
+        assert x + w <= 1920 + 1 and y + h <= 1080 + 1
+
+    def test_large_subject_does_not_exceed_frame(self):
+        bbox = (200, 50, 1700, 1040)  # fills most of the frame
+        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        assert w <= 1920 and h <= 1080
+
+    def test_min_frac_floor(self):
+        # A tiny far-away box must not zoom below min_frac of the frame.
+        bbox = (950, 520, 970, 560)  # 20x40
+        _, _, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        assert h >= 0.34 * 1080 - 1
+
+
+class TestDigitalFramer:
+    def test_smoothing_converges_toward_target(self):
+        f = DigitalFramer(out_aspect=ASPECT, smooth=0.2)
+        bbox = (860, 400, 1060, 670)
+        first = f.frame_for(bbox, 1920, 1080)
+        # First call snaps to the desired crop (no prior state).
+        assert first[2] < 1920
+        # Many calls on a steady bbox stay put (converged).
+        last = first
+        for _ in range(40):
+            last = f.frame_for(bbox, 1920, 1080)
+        assert abs(last[2] - first[2]) <= 2
+
+    def test_full_frame_eases_back_to_whole_frame(self):
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0)  # no smoothing → immediate
+        x, y, w, h = f.full_frame(1920, 1080)
+        assert (x, y, w, h) == (0, 0, 1920, 1080)
+
+    def test_tracks_a_moving_subject(self):
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0)
+        left = f.frame_for((300, 400, 500, 670), 1920, 1080)
+        right = f.frame_for((1400, 400, 1600, 670), 1920, 1080)
+        assert right[0] > left[0]  # crop followed the subject to the right

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -12,7 +12,9 @@ class TestDesiredCrop:
     def test_centers_and_zooms_on_a_small_subject(self):
         # A person occupying ~25% of a 1920x1080 frame, centred.
         bbox = (860, 400, 1060, 670)  # 200x270, centre (960, 535)
-        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        x, y, w, h = desired_crop(
+            bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.78
+        )
         assert w < 1920 and h < 1080  # zoomed in
         assert abs(w / h - ASPECT) < 0.02  # output aspect preserved
         # crop horizontally centred on the subject
@@ -20,19 +22,29 @@ class TestDesiredCrop:
 
     def test_clamped_inside_frame_for_edge_subject(self):
         bbox = (20, 700, 180, 1050)  # bottom-left subject
-        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        x, y, w, h = desired_crop(
+            bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.78
+        )
         assert x >= 0 and y >= 0
         assert x + w <= 1920 + 1 and y + h <= 1080 + 1
 
-    def test_large_subject_does_not_exceed_frame(self):
+    def test_close_subject_is_still_cropped(self):
+        # A subject filling most of the frame (close to the camera) must STILL be
+        # cropped to a window — the max_frac cap is what makes Center Stage visibly
+        # zoom/pan instead of falling back to the whole frame.
         bbox = (200, 50, 1700, 1040)  # fills most of the frame
-        x, y, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
-        assert w <= 1920 and h <= 1080
+        _, _, w, h = desired_crop(
+            bbox, 1920, 1080, out_aspect=ASPECT, fill=0.70, min_frac=0.34, max_frac=0.78
+        )
+        assert h <= 0.78 * 1080 + 1  # capped to the window
+        assert h < 1080 and w < 1920  # still a real crop (the fix)
 
     def test_min_frac_floor(self):
         # A tiny far-away box must not zoom below min_frac of the frame.
         bbox = (950, 520, 970, 560)  # 20x40
-        _, _, w, h = desired_crop(bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34)
+        _, _, w, h = desired_crop(
+            bbox, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.78
+        )
         assert h >= 0.34 * 1080 - 1
 
 

--- a/tests/test_digital_ptz.py
+++ b/tests/test_digital_ptz.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+
+def test_home_is_full_frame_centered():
+    b = DigitalPTZBackend()
+    x, y, w, h = b.crop_rect(1920, 1080)
+    assert (x, y, w, h) == (0, 0, 1920, 1080)
+
+
+def test_zoom_in_shrinks_and_recenters():
+    b = DigitalPTZBackend(min_crop_frac=0.5, max_step_per_s=10.0)
+    b.move_velocity(0.0, 0.0, 1.0)  # zoom tele
+    b.move_velocity(0.0, 0.0, 1.0)
+    x, y, w, h = b.crop_rect(1000, 1000)
+    assert w < 1000 and h < 1000
+    assert abs((x + w / 2) - 500) <= 1  # still centered horizontally
+    assert w >= 500  # never below min_crop_frac
+
+
+def test_pan_right_shifts_crop_right():
+    b = DigitalPTZBackend(min_crop_frac=0.5, max_step_per_s=10.0)
+    b.move_velocity(0.0, 0.0, 1.0)  # zoom in so there's room to pan
+    b.move_velocity(1.0, 0.0, 0.0)  # pan right
+    x, _, w, _ = b.crop_rect(1000, 1000)
+    assert x + w <= 1000 and x > 0  # shifted right, still inside the frame
+
+
+def test_crop_never_leaves_frame():
+    b = DigitalPTZBackend(min_crop_frac=0.4, max_step_per_s=100.0)
+    for _ in range(50):
+        b.move_velocity(1.0, 1.0, 1.0)
+    x, y, w, h = b.crop_rect(1280, 720)
+    assert 0 <= x and 0 <= y and x + w <= 1280 and y + h <= 720

--- a/tests/test_digital_ptz.py
+++ b/tests/test_digital_ptz.py
@@ -35,12 +35,13 @@ def test_crop_never_leaves_frame():
     assert 0 <= x and 0 <= y and x + w <= 1280 and y + h <= 720
 
 
-def test_framed_output_crops_when_digital_backend_active():
+def test_framed_output_frames_the_target_when_digital_backend_active():
     import numpy as np
 
     from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
     from autoptz.engine.camera_worker import CameraWorker
     from autoptz.engine.ptz.digital import DigitalPTZBackend
+    from autoptz.engine.runtime.messages import BBox, TrackInfo
 
     cfg = CameraConfig(
         id="cam-dig-000001",
@@ -50,11 +51,15 @@ def test_framed_output_crops_when_digital_backend_active():
         ptz=PTZConfig(backend="digital", digital_output_w=320, digital_output_h=240),
     )
     w = CameraWorker("cam-dig-000001", cfg, on_telemetry=lambda m: None)
-    b = DigitalPTZBackend(min_crop_frac=0.5, max_step_per_s=100.0)
-    b.move_velocity(0, 0, 1.0)  # zoom in
-    w._ptz_backend = b
+    w._ptz_backend = DigitalPTZBackend()
+    # A selected target occupying ~25% of a 1280x720 frame → the auto-framer crops
+    # onto it (zoomed in) and the output is scaled to the configured size.
+    w._target_track_id = 7
+    w._last_tracks = [TrackInfo(track_id=7, bbox=BBox(x1=900, y1=300, x2=1020, y2=480))]
     out = w._framed_output(np.zeros((720, 1280, 3), dtype=np.uint8))
     assert out.shape[1] == 320 and out.shape[0] == 240  # scaled to output size
+    x, y, cw, ch = w._digital_framer._crop
+    assert cw < 1280 and ch < 720  # cropped to less than the full frame (zoomed on target)
 
 
 def test_framed_output_passthrough_without_digital_backend():

--- a/tests/test_digital_ptz.py
+++ b/tests/test_digital_ptz.py
@@ -33,3 +33,43 @@ def test_crop_never_leaves_frame():
         b.move_velocity(1.0, 1.0, 1.0)
     x, y, w, h = b.crop_rect(1280, 720)
     assert 0 <= x and 0 <= y and x + w <= 1280 and y + h <= 720
+
+
+def test_framed_output_crops_when_digital_backend_active():
+    import numpy as np
+
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+    from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+    cfg = CameraConfig(
+        id="cam-dig-000001",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(backend="digital", digital_output_w=320, digital_output_h=240),
+    )
+    w = CameraWorker("cam-dig-000001", cfg, on_telemetry=lambda m: None)
+    b = DigitalPTZBackend(min_crop_frac=0.5, max_step_per_s=100.0)
+    b.move_velocity(0, 0, 1.0)  # zoom in
+    w._ptz_backend = b
+    out = w._framed_output(np.zeros((720, 1280, 3), dtype=np.uint8))
+    assert out.shape[1] == 320 and out.shape[0] == 240  # scaled to output size
+
+
+def test_framed_output_passthrough_without_digital_backend():
+    import numpy as np
+
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-dig-000002",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(),
+    )
+    w = CameraWorker("cam-dig-000002", cfg, on_telemetry=lambda m: None)
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    assert w._framed_output(frame) is frame  # untouched

--- a/tests/test_digital_ptz.py
+++ b/tests/test_digital_ptz.py
@@ -62,6 +62,35 @@ def test_framed_output_frames_the_target_when_digital_backend_active():
     assert cw < 1280 and ch < 720  # cropped to less than the full frame (zoomed on target)
 
 
+def test_toggling_center_stage_rebuilds_the_backend_live():
+    from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+    from autoptz.engine.camera_worker import CameraWorker
+    from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+    cfg = CameraConfig(
+        id="cam-cs-rebuild1",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(backend="auto"),
+    )
+    w = CameraWorker("cam-cs-rebuild1", cfg, on_telemetry=lambda m: None)
+    # A webcam on "auto" has no PTZ hardware → no digital backend yet.
+    assert not isinstance(w._ptz_backend, DigitalPTZBackend)
+
+    # Toggle Center Stage on (backend → "digital") via a live config update.
+    on = cfg.model_copy(update={"ptz": cfg.ptz.model_copy(update={"backend": "digital"})})
+    w.update_config(on)
+    w._drain_commands()
+    assert isinstance(w._ptz_backend, DigitalPTZBackend)
+
+    # Toggle off again → the digital backend is torn down.
+    off = on.model_copy(update={"ptz": on.ptz.model_copy(update={"backend": "auto"})})
+    w.update_config(off)
+    w._drain_commands()
+    assert not isinstance(w._ptz_backend, DigitalPTZBackend)
+
+
 def test_framed_output_passthrough_without_digital_backend():
     import numpy as np
 

--- a/tests/test_ego_gate.py
+++ b/tests/test_ego_gate.py
@@ -1,0 +1,79 @@
+"""Ego-motion freshness gate — the ping-pong fix.
+
+Bug: ego-motion is decimated (optical flow every Nth inference frame). On the
+off-cadence frames the cached estimate is reused, but `_estimate_aim_velocity`
+ran every tick and unconditionally SUBTRACTED that stale/decayed estimate from
+the per-frame aim velocity — producing a sawtooth "phantom" world-velocity that
+the controller's predictive lead chased, i.e. the camera ping-ponged when it AND
+the subject moved. Fix: only subtract ego when it was freshly measured this tick.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from autoptz.config.models import CameraConfig, PTZConfig, SourceConfig, TrackingConfig
+
+
+def _worker(**ptz):
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-ego-00000001",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(),
+        ptz=PTZConfig(**ptz),
+    )
+    return CameraWorker("cam-ego-00000001", cfg, on_telemetry=lambda m: None)
+
+
+class TestEgoFreshnessGate:
+    def test_stale_ego_is_not_subtracted(self):
+        w = _worker()
+        w._prev_aim_err = (0.0, 0.0)
+        w._prev_aim_t = 0.0
+        w._aim_vel = (0.0, 0.0)
+        w._ego_vel = (0.5, 0.0)  # a (stale) cached ego estimate
+        w._ego_fresh = False  # decimated/off-cadence → not freshly measured
+        vx, _ = w._estimate_aim_velocity((0.1, 0.0), 0.1)
+        # raw d(err)/dt = 1.0, ego NOT subtracted, EMA(0.5) from 0 → 0.5
+        assert abs(vx - 0.5) < 1e-6
+
+    def test_fresh_ego_is_subtracted(self):
+        w = _worker()
+        w._prev_aim_err = (0.0, 0.0)
+        w._prev_aim_t = 0.0
+        w._aim_vel = (0.0, 0.0)
+        w._ego_vel = (0.5, 0.0)
+        w._ego_fresh = True  # freshly measured this tick
+        vx, _ = w._estimate_aim_velocity((0.1, 0.0), 0.1)
+        # raw = 1.0 - 0.5 = 0.5, EMA(0.5) from 0 → 0.25
+        assert abs(vx - 0.25) < 1e-6
+
+    def test_update_sets_freshness_per_branch(self):
+        w = _worker(ego_comp_enabled=True, ego_comp_interval=3)
+
+        class _Est:
+            def estimate(self, *a, **k):
+                from autoptz.engine.pipeline.egomotion import EgoMotion
+
+                return EgoMotion(vx=0.2, vy=0.0, source="flow", confidence=1.0)
+
+        w._ego_estimator = _Est()
+        frame = np.zeros((360, 640, 3), dtype=np.uint8)
+
+        # Measured frame (frames_inferred % 3 == 0) → fresh.
+        w._frames_inferred = 0
+        w._update_ego_motion([], frame, 0.0)
+        assert w._ego_fresh is True
+
+        # Off-cadence frame → not fresh (stale estimate must not be trusted).
+        w._frames_inferred = 1
+        w._update_ego_motion([], frame, 0.1)
+        assert w._ego_fresh is False
+
+        # Disabled → not fresh.
+        w2 = _worker(ego_comp_enabled=False)
+        w2._update_ego_motion([], frame, 0.0)
+        assert w2._ego_fresh is False

--- a/tests/test_egomotion.py
+++ b/tests/test_egomotion.py
@@ -124,7 +124,11 @@ def _aim_vel_fn():
 def test_ego_comp_cancels_phantom_velocity_when_only_camera_moves() -> None:
     est_vel = _aim_vel_fn()
     ns = SimpleNamespace(
-        _prev_aim_err=None, _prev_aim_t=0.0, _aim_vel=(0.0, 0.0), _ego_vel=(0.0, 0.0)
+        _prev_aim_err=None,
+        _prev_aim_t=0.0,
+        _aim_vel=(0.0, 0.0),
+        _ego_vel=(0.0, 0.0),
+        _ego_fresh=True,  # ego freshly measured this tick → trusted/subtracted
     )
     est_vel(ns, (0.0, 0.0), 0.0)  # establish previous error
     # Subject stationary in the world; camera pans → error drifts at -0.5/s, all
@@ -138,7 +142,11 @@ def test_ego_comp_cancels_phantom_velocity_when_only_camera_moves() -> None:
 def test_without_ego_comp_phantom_velocity_appears() -> None:
     est_vel = _aim_vel_fn()
     ns = SimpleNamespace(
-        _prev_aim_err=None, _prev_aim_t=0.0, _aim_vel=(0.0, 0.0), _ego_vel=(0.0, 0.0)
+        _prev_aim_err=None,
+        _prev_aim_t=0.0,
+        _aim_vel=(0.0, 0.0),
+        _ego_vel=(0.0, 0.0),
+        _ego_fresh=False,  # ego comp off / no fresh measurement → not subtracted
     )
     est_vel(ns, (0.0, 0.0), 0.0)
     # Same drift but ego comp off (ego_vel stays zero) → a non-zero phantom

--- a/tests/test_ptz_factory.py
+++ b/tests/test_ptz_factory.py
@@ -735,3 +735,17 @@ class TestWorkerStopHaltsBackend:
         # owned controller is close()d → backend stopped and closed
         assert backend.stop_count >= 1
         assert backend.closed is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Digital backend factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_factory_builds_digital_backend():
+    from autoptz.config.models import PTZConfig
+    from autoptz.engine.ptz.digital import DigitalPTZBackend
+    from autoptz.engine.ptz.factory import build_backend  # use the real factory entry name
+
+    backend = build_backend(PTZConfig(backend="digital"))
+    assert isinstance(backend, DigitalPTZBackend)

--- a/tests/test_reid_device.py
+++ b/tests/test_reid_device.py
@@ -1,0 +1,38 @@
+"""ReID device auto-selection.
+
+OSNet ReID was pinned to ``device="cpu"`` — a major per-frame cost on Macs that
+also stalled the inference thread via the GIL. It should prefer the platform GPU
+(Apple ``mps`` / CUDA) and fall back to CPU, so the appearance pass gets off the
+CPU where possible.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.pipeline.reid import _best_reid_device, _pick_device
+
+
+class TestPickDevice:
+    def test_prefers_mps(self):
+        assert _pick_device(has_mps=True, has_cuda=False) == "mps"
+
+    def test_prefers_cuda_when_no_mps(self):
+        assert _pick_device(has_mps=False, has_cuda=True) == "cuda"
+
+    def test_mps_wins_over_cuda(self):
+        assert _pick_device(has_mps=True, has_cuda=True) == "mps"
+
+    def test_cpu_when_nothing(self):
+        assert _pick_device(has_mps=False, has_cuda=False) == "cpu"
+
+
+class TestBestReidDevice:
+    def test_returns_a_valid_device(self):
+        assert _best_reid_device() in {"mps", "cuda", "cpu"}
+
+    def test_env_override_forces_device(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_REID_DEVICE", "cpu")
+        assert _best_reid_device() == "cpu"
+
+    def test_env_override_ignores_garbage(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_REID_DEVICE", "banana")
+        assert _best_reid_device() in {"mps", "cuda", "cpu"}

--- a/tests/test_target_lock.py
+++ b/tests/test_target_lock.py
@@ -1,0 +1,47 @@
+"""Target-lock correctness tests.
+
+Bug D — a target selected by *identity* (name) must never be re-bound to a
+different person by the appearance-only ReID recovery path. ReID may hold/refresh
+the current track, but re-acquiring a *named* target requires a face-identity
+match, not body appearance — otherwise the camera drifts onto the next
+visually-similar person, then the next unknown track.
+"""
+
+from __future__ import annotations
+
+from autoptz.config.models import CameraConfig, SourceConfig, TrackingConfig
+
+
+def _worker(identity_id: str | None = None):
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-lock-00000001",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(tracking_mode="stable"),
+    )
+    w = CameraWorker("cam-lock-00000001", cfg, on_telemetry=lambda m: None)
+    w._target_identity_id = identity_id
+    return w
+
+
+class TestReidRebindIdentityGate:
+    def test_named_target_allows_rebind_only_to_same_identity(self):
+        w = _worker(identity_id="A")
+        w._track_identity = {5: ("A", "Alice", 0.9), 7: ("B", "Bob", 0.8)}
+        assert w._reid_rebind_allows(5) is True  # same identity → allowed
+        assert w._reid_rebind_allows(7) is False  # different known person → blocked
+
+    def test_named_target_blocks_rebind_to_unknown_track(self):
+        w = _worker(identity_id="A")
+        w._track_identity = {}
+        # Unknown track (no confirmed identity) → blocked; wait for a face match.
+        assert w._reid_rebind_allows(9) is False
+
+    def test_manual_target_allows_appearance_rebind(self):
+        w = _worker(identity_id=None)
+        w._track_identity = {7: ("B", "Bob", 0.8)}
+        # No identity target (clicked/manual): appearance re-bind is the intended behaviour.
+        assert w._reid_rebind_allows(7) is True
+        assert w._reid_rebind_allows(9) is True

--- a/tests/test_target_lock.py
+++ b/tests/test_target_lock.py
@@ -45,3 +45,31 @@ class TestReidRebindIdentityGate:
         # No identity target (clicked/manual): appearance re-bind is the intended behaviour.
         assert w._reid_rebind_allows(7) is True
         assert w._reid_rebind_allows(9) is True
+
+
+class TestTargetBoxCollapsed:
+    """Bug C — a target box that suddenly collapses (occlusion → only legs/partial
+    visible) must be flagged so the camera coasts instead of chasing the shrinking
+    box down to the last-known partial position. A gradual shrink (the subject
+    walking away) must NOT be flagged."""
+
+    def test_first_call_sets_reference_not_collapsed(self):
+        w = _worker()
+        assert w._target_box_collapsed(0.5) is False
+        assert w._target_h_ref == 0.5
+
+    def test_gradual_shrink_not_flagged_and_tracks_reference(self):
+        w = _worker()
+        w._target_box_collapsed(0.5)
+        for h in (0.47, 0.44, 0.41, 0.38):
+            assert w._target_box_collapsed(h) is False
+        # The healthy-height reference followed the gradual change downward.
+        assert w._target_h_ref < 0.5
+
+    def test_sudden_collapse_is_flagged_and_recovers(self):
+        w = _worker()
+        w._target_box_collapsed(0.5)
+        assert w._target_box_collapsed(0.2) is True  # sudden drop below the reference
+        # Reference is left intact on collapse, so the subject reappearing at full
+        # size is immediately trusted again.
+        assert w._target_box_collapsed(0.5) is False

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1287,3 +1287,62 @@ finally:
         env.setdefault("QT_QPA_PLATFORM", "offscreen")
         result = _run_ui_smoke(code, cwd=Path(__file__).resolve().parents[1], env=env, timeout=30)
         assert result.returncode == 0, result.stderr or result.stdout
+
+
+class TestCenterStageUI:
+    """Center Stage (digital PTZ) backend entry and virtual-camera output checkbox."""
+
+    def test_backend_combo_contains_digital(self, tmp_path) -> None:
+        code = f"""
+import os
+import sys
+from pathlib import Path
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PySide6.QtWidgets import QApplication
+from autoptz.config.store import ConfigStore
+from autoptz.ui.engine_client import EngineClient
+from autoptz.ui.frames import ShmFrameSource
+from autoptz.ui.widgets.properties_panel import PropertiesPanel
+app = QApplication(sys.argv[:1])
+client = EngineClient(store=ConfigStore(db_path=Path({str(tmp_path / "cfg.db")!r}), debounce_s=0))
+panel = PropertiesPanel(client, frame_source=ShmFrameSource())
+items = [panel._backend.itemText(i) for i in range(panel._backend.count())]
+assert "digital" in items, f"'digital' not in backend combo items: {{items}}"
+"""
+        env = dict(os.environ)
+        env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        result = _run_ui_smoke(code, cwd=Path(__file__).resolve().parents[1], env=env, timeout=30)
+        assert result.returncode == 0, result.stderr or result.stdout
+
+    def test_vcam_out_checkbox_round_trips_into_push(self, tmp_path) -> None:
+        code = f"""
+import os
+import sys
+import json
+from pathlib import Path
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PySide6.QtWidgets import QApplication
+from autoptz.config.store import ConfigStore
+from autoptz.ui.engine_client import EngineClient
+from autoptz.ui.frames import ShmFrameSource
+from autoptz.ui.widgets.properties_panel import PropertiesPanel
+app = QApplication(sys.argv[:1])
+client = EngineClient(store=ConfigStore(db_path=Path({str(tmp_path / "cfg.db")!r}), debounce_s=0))
+cid = client.addCamera("usb://0", "Cam")
+panel = PropertiesPanel(client, frame_source=ShmFrameSource())
+panel.set_camera(cid)
+
+# Check default is False
+panel._vcam_out.setChecked(False)
+panel._push()
+assert panel._cfg["ptz"]["vcam_out"] is False, f"expected False, got {{panel._cfg['ptz']['vcam_out']!r}}"
+
+# Check that True round-trips
+panel._vcam_out.setChecked(True)
+panel._push()
+assert panel._cfg["ptz"]["vcam_out"] is True, f"expected True, got {{panel._cfg['ptz']['vcam_out']!r}}"
+"""
+        env = dict(os.environ)
+        env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        result = _run_ui_smoke(code, cwd=Path(__file__).resolve().parents[1], env=env, timeout=30)
+        assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1292,7 +1292,7 @@ finally:
 class TestCenterStageUI:
     """Center Stage (digital PTZ) backend entry and virtual-camera output checkbox."""
 
-    def test_backend_combo_contains_digital(self, tmp_path) -> None:
+    def test_center_stage_toggle_maps_to_digital_backend(self, tmp_path) -> None:
         code = f"""
 import os
 import sys
@@ -1305,9 +1305,24 @@ from autoptz.ui.frames import ShmFrameSource
 from autoptz.ui.widgets.properties_panel import PropertiesPanel
 app = QApplication(sys.argv[:1])
 client = EngineClient(store=ConfigStore(db_path=Path({str(tmp_path / "cfg.db")!r}), debounce_s=0))
+cid = client.addCamera("usb://0", "Cam")
 panel = PropertiesPanel(client, frame_source=ShmFrameSource())
+panel.set_camera(cid)
+
+# 'digital' is no longer a raw backend item — the Center Stage toggle owns it.
 items = [panel._backend.itemText(i) for i in range(panel._backend.count())]
-assert "digital" in items, f"'digital' not in backend combo items: {{items}}"
+assert "digital" not in items, f"'digital' should not be a raw backend item: {{items}}"
+
+# Center Stage off → backend is the hardware combo value (not digital).
+panel._center_stage.setChecked(False)
+panel._push()
+assert panel._cfg["ptz"]["backend"] != "digital", panel._cfg["ptz"]["backend"]
+
+# Center Stage on → backend becomes 'digital' and the Advanced picker greys out.
+panel._center_stage.setChecked(True)
+panel._push()
+assert panel._cfg["ptz"]["backend"] == "digital", panel._cfg["ptz"]["backend"]
+assert panel._backend.isEnabled() is False, "advanced backend picker should be disabled"
 """
         env = dict(os.environ)
         env.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/test_vcam.py
+++ b/tests/test_vcam.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import numpy as np
+
+from autoptz.engine.pipeline.vcam import VirtualCamSink
+
+
+def test_sink_is_noop_without_pyvirtualcam(monkeypatch):
+    import autoptz.engine.pipeline.vcam as v
+
+    monkeypatch.setattr(v, "_probe_pyvirtualcam", lambda: False)
+    sink = VirtualCamSink(640, 480)
+    assert sink.available is False
+    sink.send_bgr(np.zeros((480, 640, 3), dtype=np.uint8))  # must not raise
+    sink.close()


### PR DESCRIPTION
Executed via subagent-driven development from `docs/superpowers/plans/2026-06-24-cpu-spikes-and-center-stage.md`. Each task was TDD'd and passed an individual spec+quality review; a final whole-branch review (opus) returned **READY** with no Critical/Important findings.

## Phase 1 — CPU spikes / latency (behaviour-affecting → validate on real cameras)
- **Ego-motion decimation** — run the per-frame optical flow every Nth inference frame (`ptz.ego_comp_interval`, default 3) and reuse a decayed estimate between. The real macOS lever (OpenCV GCD can't be thread-capped).
- **Stage spreading** — never run the detector and the pose pass on the same frame (`tracking.stage_spread`, default on), so a heavy detect tick and a heavy pose tick don't stack into a 200 ms frame.
- **Governor cost amortization + hysteresis** — the CPU governor now amortizes each stage's cost by how often it actually runs (was over-counting), with a 0.70–0.90 hysteresis band so the tier can't flap.
- **System-CPU-aware governor** — the supervisor samples process CPU% (~1 Hz) and pushes it to workers, so several "individually fine" cameras back off collectively when the machine is hot.

## Phase 2 — Center Stage (new feature)
- **`DigitalPTZBackend`** — a `PTZBackend` that integrates the controller's velocity commands into a crop window instead of driving motors. Reuses the entire control loop + framing math.
- **Factory + config** — `backend="digital"`, plus `ptz.vcam_out` / `digital_output_w` / `digital_output_h`.
- **`VirtualCamSink`** — optional `pyvirtualcam` output (graceful no-op when the package/driver is absent).
- **Output stage** — applies the digital crop to the preview push and feeds the virtual cam; zero-impact passthrough for non-digital cameras; never raises into the capture thread.
- **UI** — `digital` backend choice + "Virtual camera output" toggle in the PTZ panel.

This fills a validated market gap: every competitor (OBSBOT/PTZOptics/AVer/Insta360/EMEET) is hardware-locked — there's no vendor-agnostic software that adds center-stage to any existing webcam.

## Tests
- Full suite **1047 passing**, ruff check + format clean. New: `tests/test_cpu_governor.py`, `tests/test_digital_ptz.py`, `tests/test_vcam.py`, `tests/test_flags.py` (+ UI tests).

## Validation before merge (your policy)
- **CPU:** with stream + face + detection + pose on, confirm frame-time variance (30–200 ms) and CPU bursts (60–300 %/s) tighten; watch the Services-panel quality reason + per-stage ms.
- **Center Stage:** set a plain USB webcam to the `digital` backend, enable "Virtual camera output", confirm it auto-frames a walking subject and appears as a virtual camera in Zoom/OBS.

## Deferred follow-ups (from final review, non-blocking)
- Hysteresis state-transition regression test; minor `low↔balanced` event flap at ratio≈1.10; optionally gate the vcam send on a digital backend; `AUTOPTZ_*` env parity for the new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)