### PR TITLE
fix(tracking): named-target drift + occlusion chase; perf: ReID on GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ follow [Semantic Versioning](https://semver.org/).
   or CUDA when available instead of always the CPU, cutting the per-frame
   appearance cost (and the GIL stall it caused on Macs). Set
   `AUTOPTZ_REID_DEVICE=cpu` to force the previous behaviour.
+- **Verify/force the CoreML GPU path** — `AUTOPTZ_COREML_UNITS`
+  (`ALL` / `CPUAndGPU` / `CPUOnly`) lets Intel + AMD Macs (e.g. iMac Pro Xeon +
+  Vega 56) check whether CoreML is actually using the discrete GPU or silently
+  falling back to the CPU: run `--bench` with `CPUOnly` and again with `ALL` and
+  compare. Defaults to `ALL`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ follow [Semantic Versioning](https://semver.org/).
   to every core. On Linux/Windows the exact count is honoured; on macOS's GCD
   OpenCV backend (which ignores a positive count) the cap forces single-threaded
   only under heavy multi-camera load.
+- **ReID runs on the GPU** — OSNet appearance ReID now uses the Apple GPU (`mps`)
+  or CUDA when available instead of always the CPU, cutting the per-frame
+  appearance cost (and the GIL stall it caused on Macs). Set
+  `AUTOPTZ_REID_DEVICE=cpu` to force the previous behaviour.
+
+### Fixed
+
+- **Named-target tracking no longer drifts to the wrong person** — a target
+  selected by identity (name), once lost, could be re-bound by appearance ReID to
+  the next visually-similar person, then any track. It now re-binds only to a
+  face-confirmed match of the *same* identity; otherwise it keeps searching.
+- **The camera no longer chases an occluded subject** — when the target is
+  suddenly covered, its box collapses to the visible part (e.g. the legs); the
+  drive loop now coasts on a sudden box-height collapse instead of following the
+  shrinking box down, and resumes when the subject reappears at full size.
 
 ### Removed
 

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1819,6 +1819,10 @@ class CameraWorker:
                     return
             new_id = visible_tracks[result.best_index].track_id
             if new_id != self._target_track_id:
+                if not self._reid_rebind_allows(new_id):
+                    # Named-identity target: body appearance alone must not drift the
+                    # lock onto a different/unknown person — wait for a face match.
+                    return
                 if not self._reid_recovery_confirmed(new_id):
                     return
                 # Now that the candidate is confirmed, blend the matching feature
@@ -1835,6 +1839,20 @@ class CameraWorker:
                     result.best_score,
                 )
                 self._commit_target_track(new_id, reason="reid")
+
+    def _reid_rebind_allows(self, new_id: int) -> bool:
+        """Whether appearance ReID recovery may re-bind the target to *new_id*.
+
+        For a target selected by *identity* (name), body appearance alone must
+        never move the lock onto a different person — re-acquiring a named target
+        requires a face-identity match. So a ReID re-bind is allowed only when the
+        candidate track is face-confirmed as the *same* identity. A manual/clicked
+        target (no identity) keeps the appearance-based re-bind it relies on.
+        """
+        if self._target_identity_id is None:
+            return True
+        entry = self._track_identity.get(new_id)
+        return entry is not None and entry[0] == self._target_identity_id
 
     def _reid_recovery_confirmed(self, track_id: int) -> bool:
         """Return True when the active tracking mode allows rebinding now."""

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -204,6 +204,11 @@ _REID_RECOVERY_CONFIRM_STABLE = 3
 _REID_RECOVERY_CONFIRM_RESPONSIVE = 1
 _REID_RECOVERY_MARGIN = 0.08
 _IDENTITY_TARGET_CONFIRM = 2
+# Occlusion coast: the target box height (frame fraction) must drop below this
+# fraction of its recent *healthy* height to count as a sudden collapse (the
+# subject covered by something) rather than the subject simply walking away.
+_OCCLUSION_COLLAPSE_FRAC = 0.55
+_OCCLUSION_REF_ALPHA = 0.10  # how fast the healthy-height reference tracks a gradual change
 
 # EMA weight for the pose-derived aim point: lower = smoother/laggier.  Light
 # smoothing so noisy keypoint regression doesn't jitter the framing.
@@ -342,6 +347,9 @@ class CameraWorker:
         # target per camera — supersedes an explicit track id when its identity
         # is detected on a live track.
         self._target_identity_id: str | None = config.target.identity_id
+        # Slowly-tracked "healthy" target box height (frame fraction); lets the
+        # drive loop tell a sudden occlusion collapse from a gradual walk-away.
+        self._target_h_ref: float | None = None
 
         self.shm_name = f"cam_{camera_id[:8]}_preview"
 
@@ -1228,10 +1236,17 @@ class CameraWorker:
             and self._tracking_enabled
             and tracking_on
         ):
+            fh = max(1, int(frame.shape[0]))
+            box_h_frac = (float(target.bbox.y2) - float(target.bbox.y1)) / fh
+            occluded = self._target_box_collapsed(box_h_frac)
             err, height = self._track_error(target, frame, now, tracks=tracks)
             vel = self._estimate_aim_velocity(err, now)
             try:
-                pan, tilt, zoom = ctrl.step(err, vel, height, track_active=True, t=now)
+                # A box that suddenly collapsed (occlusion → only a partial body
+                # visible) is not a trustworthy aim — coast (track_active=False) so
+                # the controller holds instead of chasing it onto the legs/last-known
+                # partial position, and resumes when the subject reappears in full.
+                pan, tilt, zoom = ctrl.step(err, vel, height, track_active=not occluded, t=now)
                 self._ptz_last_cmd = (pan, tilt, zoom)
                 self._log_ptz_cmd("auto", pan, tilt, zoom)
             except Exception:  # noqa: BLE001
@@ -1353,6 +1368,7 @@ class CameraWorker:
         with self._appearance_lock:
             if track_id != self._target_track_id:
                 self._reset_pose_aim()
+                self._target_h_ref = None
                 self._target_lock = _TargetLockState(status="pending", reason=reason)
                 self._reid_recover_candidate = None
                 self._identity_recover_candidate = None
@@ -1363,6 +1379,25 @@ class CameraWorker:
                 if reset_reid:
                     self._reset_reid()
             self._target_track_id = track_id
+
+    def _target_box_collapsed(self, height_frac: float) -> bool:
+        """True when the target box height suddenly collapsed vs its recent healthy
+        size — the occlusion signature (the subject covered by something leaves only
+        a partial box, e.g. just the legs). A gradual shrink (the subject walking
+        away) updates the reference and is NOT flagged, because the slow reference
+        keeps pace; a sudden drop IS flagged, because the reference hasn't caught up.
+        The caller coasts the PTZ instead of chasing the box down to the last-known
+        partial position.
+        """
+        h = max(0.0, float(height_frac))
+        ref = self._target_h_ref
+        if ref is None or ref <= 0.0:
+            self._target_h_ref = h
+            return False
+        if h < ref * _OCCLUSION_COLLAPSE_FRAC:
+            return True  # leave the reference intact so a full-size reappearance recovers
+        self._target_h_ref = ref + _OCCLUSION_REF_ALPHA * (h - ref)
+        return False
 
     @staticmethod
     def _bbox_area(bb: BBox) -> float:

--- a/autoptz/engine/pipeline/reid.py
+++ b/autoptz/engine/pipeline/reid.py
@@ -112,6 +112,39 @@ class ReIDResult:
     scores: list[float] = field(default_factory=list)
 
 
+def _pick_device(*, has_mps: bool, has_cuda: bool) -> str:
+    """Device priority for OSNet ReID: Apple GPU (mps) → CUDA → CPU."""
+    if has_mps:
+        return "mps"
+    if has_cuda:
+        return "cuda"
+    return "cpu"
+
+
+def _best_reid_device() -> str:
+    """Best available torch device for ReID, or "cpu" if torch is unavailable.
+
+    Keeps the appearance pass off the CPU on Macs (Apple ``mps``) and CUDA boxes —
+    it is otherwise a major per-frame cost that also stalls the inference thread
+    through the GIL. Set ``AUTOPTZ_REID_DEVICE=cpu`` to force it back (e.g. if an
+    OSNet op misbehaves on mps).
+    """
+    import os  # noqa: PLC0415
+
+    forced = os.environ.get("AUTOPTZ_REID_DEVICE", "").strip().lower()
+    if forced in ("cpu", "mps", "cuda"):
+        return forced
+    try:
+        import torch  # noqa: PLC0415
+
+        return _pick_device(
+            has_mps=bool(torch.backends.mps.is_available() and torch.backends.mps.is_built()),
+            has_cuda=bool(torch.cuda.is_available()),
+        )
+    except Exception:  # noqa: BLE001 — no torch / probe failure → CPU
+        return "cpu"
+
+
 class BodyReID:
     """OSNet appearance embeddings + hysteresis recovery matching.
 
@@ -129,7 +162,7 @@ class BodyReID:
         self,
         weights: Path | None = None,
         *,
-        device: str = "cpu",
+        device: str | None = None,
         threshold_hi: float = 0.70,
         threshold_lo: float = 0.45,
         _backend: Any | None = None,
@@ -145,22 +178,44 @@ class BodyReID:
         if _backend is None:
             self._try_init(weights, device)
 
-    def _try_init(self, weights: Path | None, device: str) -> None:
+    def _try_init(self, weights: Path | None, device: str | None) -> None:
         global _WARNED_UNAVAILABLE
         name = weights or Path("osnet_x0_25_msmt17.pt")
-        # BoxMOT ≥ 11 exposes a single ``boxmot.reid.ReID`` entry point with a
-        # ``__call__(frame, boxes=...)`` feature extractor.  Older releases used
-        # ``boxmot.appearance.reid_auto_backend.ReidAutoBackend`` whose ``.model``
-        # had ``get_features(xyxys, frame)``.  Try the new API first, then fall
-        # back, so both major versions work; either path degrades gracefully.
+        device = device or _best_reid_device()
+        # Try the resolved (GPU) device first; if it can't initialise (an op a
+        # given backend doesn't support on mps, etc.) fall back to CPU before
+        # finally degrading to motion-only.
+        if self._init_on_device(name, device):
+            return
+        if device != "cpu" and self._init_on_device(name, "cpu"):
+            log.info("BodyReID: %s device init failed; using CPU", device)
+            return
+        self._backend = None
+        self._available = False
+        if not _WARNED_UNAVAILABLE:
+            _WARNED_UNAVAILABLE = True
+            log.warning(
+                "boxmot OSNet ReID unavailable; appearance recovery disabled "
+                "(motion-only tracking still works).",
+                exc_info=True,
+            )
+
+    def _init_on_device(self, name: Path, device: str) -> bool:
+        """Build the OSNet backend on *device*; True on success, False to fall back.
+
+        BoxMOT ≥ 11 exposes ``boxmot.reid.ReID`` (``__call__(frame, boxes=...)``);
+        older releases used ``boxmot.appearance.reid_auto_backend.ReidAutoBackend``
+        whose ``.model`` had ``get_features(xyxys, frame)``. Try the new API first,
+        then the legacy one, so both major versions work.
+        """
         try:
             from boxmot.reid import ReID  # noqa: PLC0415
 
             self._backend = ReID(weights=name, device=device, half=False)
             self._new_api = True
             self._available = True
-            log.info("BodyReID ready (OSNet %s, boxmot.reid API)", name)
-            return
+            log.info("BodyReID ready (OSNet %s on %s, boxmot.reid API)", name, device)
+            return True
         except Exception:  # noqa: BLE001 — fall through to the legacy API
             pass
         try:
@@ -168,24 +223,13 @@ class BodyReID:
                 ReidAutoBackend,
             )
 
-            self._backend = ReidAutoBackend(
-                weights=name,
-                device=device,
-                half=False,
-            ).model
+            self._backend = ReidAutoBackend(weights=name, device=device, half=False).model
             self._new_api = False
             self._available = True
-            log.info("BodyReID ready (OSNet %s, legacy API)", name)
+            log.info("BodyReID ready (OSNet %s on %s, legacy API)", name, device)
+            return True
         except Exception:  # noqa: BLE001 — missing dep/weights/network must not raise
-            self._backend = None
-            self._available = False
-            if not _WARNED_UNAVAILABLE:
-                _WARNED_UNAVAILABLE = True
-                log.warning(
-                    "boxmot OSNet ReID unavailable; appearance recovery disabled "
-                    "(motion-only tracking still works).",
-                    exc_info=True,
-                )
+            return False
 
     @property
     def available(self) -> bool:

--- a/autoptz/engine/runtime/inference.py
+++ b/autoptz/engine/runtime/inference.py
@@ -199,17 +199,39 @@ def effective_precision(ep: EP | str, prefs: HardwarePrefs | None = None) -> str
     return "fp16" if (ep in _ACCELERATED_EPS and _wants_fp16(prefs)) else "fp32"
 
 
+_VALID_COREML_UNITS = ("ALL", "CPUAndGPU", "CPUOnly", "CPUAndNeuralEngine")
+
+
+def _coreml_compute_units() -> str:
+    """CoreML compute-unit target. Defaults to ``ALL`` (CoreML picks the fastest
+    unit per op; on Intel Macs ``ALL`` includes the discrete AMD GPU via Metal).
+
+    Override with ``AUTOPTZ_COREML_UNITS`` to diagnose or force the path on
+    Intel + AMD (e.g. iMac Pro Xeon + Vega) Macs — ``CPUOnly`` to *measure* whether
+    the GPU is helping at all (compare two ``--bench`` runs), or ``CPUAndGPU`` to
+    pin the discrete GPU if ``ALL`` is silently choosing the CPU. Invalid values
+    fall back to ``ALL``.
+    """
+    import os  # noqa: PLC0415
+
+    val = os.environ.get("AUTOPTZ_COREML_UNITS", "").strip().lower()
+    for v in _VALID_COREML_UNITS:
+        if val == v.lower():
+            return v
+    return "ALL"
+
+
 def _provider_options(ep: EP, prefs: HardwarePrefs | None) -> dict[str, object]:
     """Per-EP acceleration options. Empty dict = provider defaults."""
     if ep is EP.COREML:
         # MLProgram routes to the Apple Neural Engine / GPU (incl. AMD on Intel
-        # Macs via Metal); ALL lets CoreML pick the fastest unit per op.
-        # ModelCacheDirectory persists the compiled MLProgram so the slow first
-        # compile is one-time per machine, not paid on every session build
-        # (acute with many camera workers / process-per-camera).
+        # Macs via Metal); the compute-unit target is tunable (AUTOPTZ_COREML_UNITS)
+        # so an Intel+AMD Mac can verify/force the GPU path. ModelCacheDirectory
+        # persists the compiled MLProgram so the slow first compile is one-time per
+        # machine, not paid on every session build (acute with process-per-camera).
         return {
             "ModelFormat": "MLProgram",
-            "MLComputeUnits": "ALL",
+            "MLComputeUnits": _coreml_compute_units(),
             "ModelCacheDirectory": _coreml_cache_dir(),
         }
     if ep is EP.TENSORRT:

--- a/tests/test_coreml_units.py
+++ b/tests/test_coreml_units.py
@@ -1,0 +1,27 @@
+"""CoreML compute-unit selection (AUTOPTZ_COREML_UNITS).
+
+Lets an Intel + AMD Mac (e.g. iMac Pro Xeon + Vega) verify/force whether CoreML
+uses the discrete GPU or silently falls back to the CPU.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.runtime.inference import _coreml_compute_units
+
+
+class TestCoreMLComputeUnits:
+    def test_default_is_all(self, monkeypatch):
+        monkeypatch.delenv("AUTOPTZ_COREML_UNITS", raising=False)
+        assert _coreml_compute_units() == "ALL"
+
+    def test_explicit_cpu_only(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "CPUOnly")
+        assert _coreml_compute_units() == "CPUOnly"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "cpuandgpu")
+        assert _coreml_compute_units() == "CPUAndGPU"
+
+    def test_invalid_falls_back_to_all(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_COREML_UNITS", "turbo")
+        assert _coreml_compute_units() == "ALL"

--- a/tests/test_reid_device.py
+++ b/tests/test_reid_device.py
@@ -1,0 +1,38 @@
+"""ReID device auto-selection.
+
+OSNet ReID was pinned to ``device="cpu"`` — a major per-frame cost on Macs that
+also stalled the inference thread via the GIL. It should prefer the platform GPU
+(Apple ``mps`` / CUDA) and fall back to CPU, so the appearance pass gets off the
+CPU where possible.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.pipeline.reid import _best_reid_device, _pick_device
+
+
+class TestPickDevice:
+    def test_prefers_mps(self):
+        assert _pick_device(has_mps=True, has_cuda=False) == "mps"
+
+    def test_prefers_cuda_when_no_mps(self):
+        assert _pick_device(has_mps=False, has_cuda=True) == "cuda"
+
+    def test_mps_wins_over_cuda(self):
+        assert _pick_device(has_mps=True, has_cuda=True) == "mps"
+
+    def test_cpu_when_nothing(self):
+        assert _pick_device(has_mps=False, has_cuda=False) == "cpu"
+
+
+class TestBestReidDevice:
+    def test_returns_a_valid_device(self):
+        assert _best_reid_device() in {"mps", "cuda", "cpu"}
+
+    def test_env_override_forces_device(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_REID_DEVICE", "cpu")
+        assert _best_reid_device() == "cpu"
+
+    def test_env_override_ignores_garbage(self, monkeypatch):
+        monkeypatch.setenv("AUTOPTZ_REID_DEVICE", "banana")
+        assert _best_reid_device() in {"mps", "cuda", "cpu"}

--- a/tests/test_target_lock.py
+++ b/tests/test_target_lock.py
@@ -1,0 +1,47 @@
+"""Target-lock correctness tests.
+
+Bug D — a target selected by *identity* (name) must never be re-bound to a
+different person by the appearance-only ReID recovery path. ReID may hold/refresh
+the current track, but re-acquiring a *named* target requires a face-identity
+match, not body appearance — otherwise the camera drifts onto the next
+visually-similar person, then the next unknown track.
+"""
+
+from __future__ import annotations
+
+from autoptz.config.models import CameraConfig, SourceConfig, TrackingConfig
+
+
+def _worker(identity_id: str | None = None):
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(
+        id="cam-lock-00000001",
+        name="t",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(tracking_mode="stable"),
+    )
+    w = CameraWorker("cam-lock-00000001", cfg, on_telemetry=lambda m: None)
+    w._target_identity_id = identity_id
+    return w
+
+
+class TestReidRebindIdentityGate:
+    def test_named_target_allows_rebind_only_to_same_identity(self):
+        w = _worker(identity_id="A")
+        w._track_identity = {5: ("A", "Alice", 0.9), 7: ("B", "Bob", 0.8)}
+        assert w._reid_rebind_allows(5) is True  # same identity → allowed
+        assert w._reid_rebind_allows(7) is False  # different known person → blocked
+
+    def test_named_target_blocks_rebind_to_unknown_track(self):
+        w = _worker(identity_id="A")
+        w._track_identity = {}
+        # Unknown track (no confirmed identity) → blocked; wait for a face match.
+        assert w._reid_rebind_allows(9) is False
+
+    def test_manual_target_allows_appearance_rebind(self):
+        w = _worker(identity_id=None)
+        w._track_identity = {7: ("B", "Bob", 0.8)}
+        # No identity target (clicked/manual): appearance re-bind is the intended behaviour.
+        assert w._reid_rebind_allows(7) is True
+        assert w._reid_rebind_allows(9) is True

--- a/tests/test_target_lock.py
+++ b/tests/test_target_lock.py
@@ -45,3 +45,31 @@ class TestReidRebindIdentityGate:
         # No identity target (clicked/manual): appearance re-bind is the intended behaviour.
         assert w._reid_rebind_allows(7) is True
         assert w._reid_rebind_allows(9) is True
+
+
+class TestTargetBoxCollapsed:
+    """Bug C — a target box that suddenly collapses (occlusion → only legs/partial
+    visible) must be flagged so the camera coasts instead of chasing the shrinking
+    box down to the last-known partial position. A gradual shrink (the subject
+    walking away) must NOT be flagged."""
+
+    def test_first_call_sets_reference_not_collapsed(self):
+        w = _worker()
+        assert w._target_box_collapsed(0.5) is False
+        assert w._target_h_ref == 0.5
+
+    def test_gradual_shrink_not_flagged_and_tracks_reference(self):
+        w = _worker()
+        w._target_box_collapsed(0.5)
+        for h in (0.47, 0.44, 0.41, 0.38):
+            assert w._target_box_collapsed(h) is False
+        # The healthy-height reference followed the gradual change downward.
+        assert w._target_h_ref < 0.5
+
+    def test_sudden_collapse_is_flagged_and_recovers(self):
+        w = _worker()
+        w._target_box_collapsed(0.5)
+        assert w._target_box_collapsed(0.2) is True  # sudden drop below the reference
+        # Reference is left intact on collapse, so the subject reappearing at full
+        # size is immediately trusted again.
+        assert w._target_box_collapsed(0.5) is False


### PR DESCRIPTION
Three root-cause fixes from a systematic debugging pass on the user's report (each TDD'd, full suite green). These are pre-existing issues on `main`/rc2, independent of PR #100.

## Fixes
1. **Named-target drift (identity lock)** — when a target selected by *name* was lost, the appearance-only ReID recovery re-bound the lock to whoever's *body* matched best → it drifted onto the next visually-similar person, then any track. A named-identity target now re-binds via ReID **only to a face-confirmed match of the same identity** (`_reid_rebind_allows`); otherwise it stays searching. Manual/clicked targets keep appearance re-bind.
2. **Occlusion chase** — when the subject was covered, the box collapsed to the visible part (legs) but stayed non-`lost`, so the PTZ chased it down to the last-known partial position. The drive loop now tracks a slow "healthy height" reference and **coasts on a sudden collapse** (occlusion) while a gradual shrink (walking away) keeps following — distinguished so normal following is unaffected.
3. **Perf: ReID on GPU** — OSNet ReID was pinned to `device="cpu"` (a major per-frame cost on the M4 Pro that also stalled the inference thread via the GIL). It now auto-selects **mps/CUDA** with a CPU fallback; `AUTOPTZ_REID_DEVICE` overrides.

## Why these
Measured on an M4 Pro: detector = 11ms (CoreML, accelerated). The 148ms with all services on is **face (forced CPU) + ReID (CPU)** — #3 gets ReID onto the GPU. #1/#2 are the "loses my person / chases the wrong box" report.

## Tests
New `tests/test_target_lock.py`, `tests/test_reid_device.py`. Full suite **1046 passing**, ruff clean.

## Validate on real cameras before merge
- Select a person by name; have them occluded/leave → camera should **hold/search**, not grab someone else or chase legs.
- Confirm ReID still works on `mps` and the per-frame budget drops (set `AUTOPTZ_REID_DEVICE=cpu` to compare / if mps misbehaves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)