### PR TITLE
release: 2.2.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,24 @@ follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0-rc3] — 2026-06-24
+
+> Pre-release for testing — adds **Center Stage** software auto-framing on top of
+> the rc2 CPU-performance and tracking work. Please validate on your real cameras
+> and report back before this becomes the stable 2.2.0.
+
 ### Added
 
 - **Center Stage** — software auto-framing (digital PTZ) for cameras without
   motorised PTZ: a single **Center Stage** toggle in the PTZ panel digitally
-  pans/zooms a crop to follow the selected target, with an optional **Virtual
-  camera output** to publish the framed crop to Zoom/OBS (needs a system
-  virtual-camera driver). The raw PTZ transport selector now lives under PTZ →
-  Advanced, since most users use Center Stage or the auto-probe.
+  crops, zooms, and pans to keep the selected target framed — a head-and-shoulders
+  shot that follows them and holds steady through normal track re-association
+  instead of snapping back to the full frame. Set how tightly it frames with the
+  **Framing** dropdown (Face / Head & shoulders / Upper body / Full body), live.
+  An optional **Virtual camera output** publishes the framed crop to Zoom/OBS
+  (needs a system virtual-camera driver) and disconnects cleanly when turned off.
+  The raw PTZ transport selector now lives under PTZ → Advanced, since most users
+  use Center Stage or the auto-probe.
 
 ### Changed
 

--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.2.0-rc2"
+__version__ = "2.2.0-rc3"
 
 
 def version() -> str:


### PR DESCRIPTION
Cuts **2.2.0-rc3** off `main` (which now includes #100).

## What's in this RC (since rc2)
- **Center Stage** — software auto-framing / digital PTZ for non-PTZ cameras: one toggle that crops, zooms, and pans to keep the selected target framed (head-and-shoulders, holds steady through track re-association), with **Framing**-dropdown tightness (Face / Head & shoulders / Upper body / Full body) and an optional virtual-camera output that disconnects cleanly when off. Raw PTZ transport selector moved to PTZ → Advanced.
- **CPU-spike fixes** — OpenCV thread cap, ReID on GPU (`mps`/CUDA, `AUTOPTZ_REID_DEVICE` override), `AUTOPTZ_COREML_UNITS` knob to verify the GPU path, preview rate cap, ego-motion freshness gate (ping-pong fix).
- **Tracking fixes** — named-target no longer drifts to the wrong person (identity-gated ReID rebind); no longer chases an occluded subject onto the visible remnant (occlusion coast).
- Removed the dead `tracking.face_confirm` toggle; consolidated the unified-pose flag.

## Release mechanics
- `__version__` 2.2.0-rc2 → **2.2.0-rc3** (single source; `pyproject.toml` derives it).
- CHANGELOG `[Unreleased]` rolled into `[2.2.0-rc3]`.
- Tag `v2.2.0-rc3` will be created on the squash-merge commit.

Pre-merge adversarial audit of #100 ran clean (perf/threading 0 findings; engine fixes positively verified). Full suite green locally (1075) and on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)