### PR TITLE
fix: Windows face-save diagnosability + offline pack, PTZ pan-jitter, safe-zone centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Safe zone now centers the subject (was: froze them at the oval edge).** The
+  PTZ controller's framing setpoint is the safe-zone **center**, not the frame
+  center: a subject inside the zone is now gently eased toward the middle (Center
+  Stage-style) instead of being held wherever they happened to enter the oval. A
+  **frame-edge guard** keeps a wide zone from ever stranding the subject at the
+  screen edge, and a configured **square** zone now respects its corners (the
+  `Roundness` control) instead of always behaving like an ellipse.
+- **Smoother PTZ tracking while the camera pans.** Ego-motion compensation is now
+  window-matched, so the controller no longer injects the camera's own pan speed
+  into its feed-forward on the frames between ego measurements (the main cause of
+  hunting). A brief target loss now resumes from the pre-loss speed instead of
+  cold-restarting the motion ramp (the "find" lurch). Note: this fixes the
+  control-loop side of the jitter; a detector/tracker dropping the box during very
+  fast pans is a separate item still under investigation.
+- **Windows face recognition failures are now diagnosable, and the model can ship
+  offline.** A failed insightface/model load no longer fails silently — the
+  Services panel reports the real reason (and "model not downloaded" when the
+  `buffalo_l` weights are absent) instead of a misleading "ok". The face pack is
+  now provisioned via `python -m tools.fetch_models` and bundled into installers,
+  so a fresh **offline** machine can enroll faces. (If face recognition is failing
+  for a non-network reason — e.g. a dependency/ABI break — the Services panel now
+  surfaces it so it can be fixed directly.)
+
 ## [2.2.0-rc3] — 2026-06-24
 
 > Pre-release for testing — adds **Center Stage** software auto-framing on top of

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1362,14 +1362,30 @@ class CameraWorker:
         (``self._ego_vel``, also error-space units/sec) leaves the subject's
         *world* motion, so the controller's velocity feed-forward stops chasing
         the camera's own pan/tilt (the hunting/oscillation fix).
+
+        **Window matching (the jitter fix):** ego-motion is measured only once per
+        ``ego_comp_interval`` frames and spans that whole window.  The per-tick
+        d(error)/dt spans a single frame, so subtracting the ego estimate only
+        cancels cleanly when the two cover the SAME interval.  We therefore only
+        recompute the velocity on a freshly-measured (``_ego_fresh``) tick — where
+        the error delta has accrued over the same window — and HOLD the last value
+        between fresh ticks.  Previously the off-cadence ticks zero-subtracted ego
+        and injected the full camera-pan velocity into the feed-forward on 2 of
+        every 3 frames, which is what made the camera hunt during pans.
         """
+        # With ego comp ENABLED, skip the off-cadence ticks (hold last velocity)
+        # so the error delta and the ego estimate always span the same window.
+        # With ego comp OFF there is no multi-frame estimate to match, so compute
+        # every tick as before (no ego is subtracted regardless).
+        ego_on = bool(getattr(self.config.ptz, "ego_comp_enabled", True))
+        if ego_on and not self._ego_fresh:
+            return self._aim_vel
+
         vx = vy = 0.0
         prev = self._prev_aim_err
         if prev is not None:
             dt = now - self._prev_aim_t
             if dt > 1e-3:
-                # Only trust ego-motion on a freshly-measured tick; a stale/decimated
-                # estimate would inject a phantom world-velocity (the ping-pong).
                 ego_vx, ego_vy = self._ego_vel if self._ego_fresh else (0.0, 0.0)
                 raw_vx = (err[0] - prev[0]) / dt - ego_vx
                 raw_vy = (err[1] - prev[1]) / dt - ego_vy

--- a/autoptz/engine/identity/service.py
+++ b/autoptz/engine/identity/service.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import logging
 import threading
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -174,8 +174,12 @@ class IdentityService:
     ) -> IdentityRecord:
         """Add a new *labeled* identity (persisted).  ``embedding`` may be None."""
         embeddings = [embedding_to_bytes(embedding)] if embedding is not None else []
+        # Pass ``id`` only when supplied (else IdentityRecord's default factory
+        # generates one).  Typed ``dict[str, Any]`` so the ** unpack doesn't make
+        # mypy infer every field as ``str``.
+        id_kwargs: dict[str, Any] = {"id": identity_id} if identity_id else {}
         rec = IdentityRecord(
-            **({"id": identity_id} if identity_id else {}),
+            **id_kwargs,
             name=name,
             embeddings=embeddings,
             thumbnail=thumbnail,

--- a/autoptz/engine/pipeline/identify.py
+++ b/autoptz/engine/pipeline/identify.py
@@ -92,7 +92,7 @@ class FaceObservation:
         inter_ocular = ((rx - lx) ** 2 + (ry - ly) ** 2) ** 0.5
         if inter_ocular <= 1e-3:
             return None
-        return abs(nx - eye_mid_x) / inter_ocular
+        return float(abs(nx - eye_mid_x) / inter_ocular)
 
 
 @dataclass(frozen=True)

--- a/autoptz/engine/pipeline/identify.py
+++ b/autoptz/engine/pipeline/identify.py
@@ -138,14 +138,44 @@ def cosine(a: NDArray[np.floating], b: NDArray[np.floating]) -> float:
 # ── face model provisioning ────────────────────────────────────────────────────
 
 
-def insightface_root() -> str:
-    """Resolve the insightface model storage root (``$INSIGHTFACE_HOME`` or ``~/.insightface``).
+def _insightface_pack_present(root: Path) -> bool:
+    """True if *root* holds an insightface model pack (``root/models/*/*.onnx``)."""
+    models = root / "models"
+    try:
+        return models.is_dir() and any(models.glob("*/*.onnx"))
+    except OSError:
+        return False
 
-    Threaded into ``FaceAnalysis(root=...)`` so a bundled or relocated model cache
-    is honoured — the offline-Windows provisioning path.  Kept consistent with the
-    weight check in :func:`autoptz.engine.runtime.diagnostics.face_status`.
+
+def insightface_root() -> str:
+    """Resolve the insightface model storage root.
+
+    Priority: ``$INSIGHTFACE_HOME`` (explicit override) → a pack **bundled inside
+    the app** (``<bundled models>/insightface`` — what release installers ship and
+    ``tools.fetch_models`` writes) → the **user model cache**
+    (``<app-data models>/insightface``, populated by a dev's ``fetch_models``) →
+    ``~/.insightface`` (insightface's own default, where it auto-downloads when
+    online).  Threaded into ``FaceAnalysis(root=...)`` so an **offline packaged
+    app finds its weights with no download** — the real fix for "faces never save
+    on Windows".  Kept consistent with :func:`face_status` in
+    :mod:`autoptz.engine.runtime.diagnostics`.
     """
-    return os.environ.get("INSIGHTFACE_HOME") or str(Path.home() / ".insightface")
+    env = os.environ.get("INSIGHTFACE_HOME")
+    if env:
+        return env
+    try:
+        from autoptz.engine.runtime.models import (  # noqa: PLC0415
+            _models_cache_dir,
+            bundled_models_dir,
+        )
+
+        for base in (bundled_models_dir(), _models_cache_dir()):
+            candidate = Path(base) / "insightface"
+            if _insightface_pack_present(candidate):
+                return str(candidate)
+    except Exception:  # noqa: BLE001 — resolution must never raise into the model load
+        pass
+    return str(Path.home() / ".insightface")
 
 
 def ensure_face_model(root: str | None = None, model_name: str = "buffalo_l") -> str | None:

--- a/autoptz/engine/pipeline/identify.py
+++ b/autoptz/engine/pipeline/identify.py
@@ -25,7 +25,9 @@ This module owns *embedding + matching*; gallery storage/CRUD lives in
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -133,6 +135,45 @@ def cosine(a: NDArray[np.floating], b: NDArray[np.floating]) -> float:
     return float(np.dot(na, nb))
 
 
+# ── face model provisioning ────────────────────────────────────────────────────
+
+
+def insightface_root() -> str:
+    """Resolve the insightface model storage root (``$INSIGHTFACE_HOME`` or ``~/.insightface``).
+
+    Threaded into ``FaceAnalysis(root=...)`` so a bundled or relocated model cache
+    is honoured — the offline-Windows provisioning path.  Kept consistent with the
+    weight check in :func:`autoptz.engine.runtime.diagnostics.face_status`.
+    """
+    return os.environ.get("INSIGHTFACE_HOME") or str(Path.home() / ".insightface")
+
+
+def ensure_face_model(root: str | None = None, model_name: str = "buffalo_l") -> str | None:
+    """Pre-download the insightface model pack into *root* for offline use.
+
+    Constructing :class:`FaceAnalysis` triggers insightface's own download of the
+    pack (needs network) into ``<root>/models/<model_name>``; once cached, later
+    OFFLINE runs load it without network — the fix for "faces never save on an
+    offline first-run" (run ``python -m tools.fetch_models`` once while online).
+    Returns ``None`` on success, or a human-readable error string (never raises).
+    """
+    try:
+        from insightface.app import FaceAnalysis  # noqa: PLC0415
+
+        from autoptz.engine.runtime.inference import EP  # noqa: PLC0415
+
+        app = FaceAnalysis(
+            name=model_name,
+            root=root or insightface_root(),
+            providers=[EP.CPU.value],
+            allowed_modules=["detection", "recognition"],
+        )
+        app.prepare(ctx_id=-1, det_size=(640, 640))
+        return None
+    except Exception as exc:  # noqa: BLE001 — provisioning must never crash the caller
+        return f"{type(exc).__name__}: {exc}"
+
+
 # ── face recogniser ──────────────────────────────────────────────────────────────
 
 
@@ -161,6 +202,11 @@ class FaceRecognizer:
         self._det_size = det_size
         self._app: Any | None = _app
         self._available = _app is not None
+        # Human-readable reason the model failed to load (``None`` when healthy).
+        # Surfaced so a silent insightface/model failure (the "faces never save"
+        # symptom, common on offline Windows first-run) becomes diagnosable in
+        # the Services panel / logs instead of vanishing into a swallowed except.
+        self.last_error: str | None = None
         if _app is None:
             self._try_init()
 
@@ -194,24 +240,32 @@ class FaceRecognizer:
             # and load time.
             app = FaceAnalysis(
                 name=self._model_name,
+                root=insightface_root(),
                 providers=providers,
                 allowed_modules=["detection", "recognition"],
             )
             app.prepare(ctx_id=ctx_id, det_size=(self._det_size, self._det_size))
             self._app = app
             self._available = True
+            self.last_error = None
             log.info(
                 "FaceRecognizer ready (insightface %s, ep=CPU, modules=detection+recognition)",
                 self._model_name,
             )
-        except Exception:  # noqa: BLE001 — missing dep/model/network must not raise
+        except Exception as exc:  # noqa: BLE001 — missing dep/model/network must not raise
             self._app = None
             self._available = False
+            # Capture the concrete reason (ImportError / model-not-found / ORT EP /
+            # the NumPy-2 C-ext break) so the Services panel and logs can show
+            # *why* face recognition is off instead of failing silently.
+            self.last_error = f"{type(exc).__name__}: {exc}"
             if not _WARNED_UNAVAILABLE:
                 _WARNED_UNAVAILABLE = True
                 log.warning(
-                    "insightface unavailable (missing package, model, or network); "
-                    "face recognition disabled — manual click-to-track still works.",
+                    "insightface unavailable for model %r (%s); face recognition "
+                    "disabled — manual click-to-track still works.",
+                    self._model_name,
+                    self.last_error,
                     exc_info=True,
                 )
 

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -64,6 +64,16 @@ _ACCEL_LEAD_MAX = 0.3  # hard cap on the acceleration-term contribution to the a
 # this fraction *beyond* the box edge before following resumes — kills the
 # start/stop chatter when they hover right on the boundary.
 _HOLD_HYSTERESIS = 0.25
+# Safe-zone CENTERING: the inner no-move deadband as a fraction of the zone's
+# half-extent.  Inside it the camera holds (anti-jitter); beyond it the subject
+# is eased back toward the zone centre (Center-Stage feel) instead of being
+# frozen wherever they entered the oval.  Smaller → tighter centring.
+_FRAMING_DEADBAND = 0.35
+# Frame-edge guard: once the subject's measured error reaches this fraction of
+# the half-frame (≈ near the screen edge), correct on the full offset toward the
+# zone centre regardless of zone size — a big safe zone must never let the
+# subject sit at/over the frame edge.
+_EDGE_GUARD = 0.9
 
 
 # ── one-euro filter ───────────────────────────────────────────────────────────
@@ -134,6 +144,37 @@ def _clamp(x: float, lo: float, hi: float) -> float:
 def _shape(x: float) -> float:
     """Non-linear response curve: ease-in (gentle near zero, full speed at ±1)."""
     return math.copysign(abs(x) ** _POWER, x) if x != 0.0 else 0.0
+
+
+def _zone_norm(dx: float, dy: float, hw: float, hh: float, roundness: float) -> float:
+    """Normalized distance from a zone centre; ``<= 1.0`` means inside the zone.
+
+    Blends an ellipse (``roundness=1`` → ``(dx/hw)²+(dy/hh)²``) and a rectangle
+    (``roundness=0`` → ``max((dx/hw)², (dy/hh)²)``) so a configured "square" zone
+    actually contains its corners instead of being treated as an ellipse.  Both
+    forms equal 1.0 on the axis-aligned edge, so the boundary semantics are stable
+    across ``roundness``.
+    """
+    hw = max(1e-6, hw)
+    hh = max(1e-6, hh)
+    nx = (dx / hw) ** 2
+    ny = (dy / hh) ** 2
+    r = _clamp(roundness, 0.0, 1.0)
+    return r * (nx + ny) + (1.0 - r) * max(nx, ny)
+
+
+def _soft_deadband(d: float, dead: float) -> float:
+    """Zero within ``±dead``; beyond it, the excess (sign-preserving).
+
+    Feeding this to the PD makes the steady state ``|error| ≤ dead`` — the subject
+    settles *within* the deadband of the setpoint (i.e. centred), rather than the
+    PD holding wherever they happened to enter a wide region.
+    """
+    if dead <= 0.0:
+        return d
+    if abs(d) <= dead:
+        return 0.0
+    return math.copysign(abs(d) - dead, d)
 
 
 def _slew(prev: float, target: float, max_step: float) -> float:
@@ -516,20 +557,21 @@ class PTZController:
         ex, ey = p.error
         vx, vy = p.velocity
 
-        # 0. HOLD — while the subject is actually inside the framing region (its
-        #    *measured* position, not a velocity-predicted one), hold the camera
-        #    still: zero the error AND the feed-forward velocity so a parked
-        #    subject can't trigger micro-moves from velocity/aim noise.  Hysteresis
-        #    (see ``_update_hold``) stops it chattering at the edge.
+        # 0. FRAMING — remap the measured error onto the framing setpoint.  With a
+        #    safe zone this drives the subject toward the ZONE CENTRE (eased, with
+        #    an inner deadband + frame-edge guard) instead of freezing them
+        #    anywhere inside the oval; without one it's the legacy per-axis dead
+        #    zone around the frame centre.  ``holding`` (subject settled in the
+        #    deadband) zeroes the feed-forward velocity too so a parked subject
+        #    can't trigger micro-moves.  See ``_framing_error``.
         #
-        # 1. Only while *following* (outside the region) do we project the aim
+        # 1. Only while *following* (outside the deadband) do we project the aim
         #    forward by the lead time (+ measured loop latency when
         #    ``lead_time_auto``), so the camera leads real motion without nudging a
         #    stationary subject.  The velocity is ego-corrected, so this leads the
         #    subject's world motion, not the camera's own pan.
-        holding = self._update_hold(ex, ey, cfg)
+        ex, ey, holding = self._framing_error(ex, ey, cfg)
         if holding:
-            ex = ey = 0.0
             vx = vy = 0.0
         else:
             lead = float(getattr(cfg, "lead_time_s", 0.0))
@@ -640,29 +682,73 @@ class PTZController:
 
         return pan_cmd, tilt_cmd
 
-    def _update_hold(self, ex: float, ey: float, cfg: Any) -> bool:
-        """Return whether to HOLD (subject inside the framing region), with hysteresis.
+    def _framing_error(self, ex: float, ey: float, cfg: Any) -> tuple[float, float, bool]:
+        """Map measured (frame-centre) error → control error toward the setpoint.
 
-        Uses the *measured* error.  For the framing box (safe-zone) the region is an
-        ellipse matching the on-screen oval; otherwise it's the per-axis dead-zone.
-        Once holding, the subject must travel ``_HOLD_HYSTERESIS`` beyond the edge
-        to resume following — so hovering on the boundary doesn't start/stop chatter.
+        Returns ``(control_ex, control_ey, holding)``.  The PD drives the control
+        error to zero, so the *setpoint* is wherever the control error is zero:
+
+        - **Safe zone ON** → setpoint is the zone CENTRE.  An inner deadband
+          (``_FRAMING_DEADBAND`` of the zone) holds the camera still (anti-jitter);
+          beyond it the subject is eased back toward the centre via a soft deadband
+          (the Center-Stage feel — no freezing at the oval edge).  A frame-edge
+          guard (``_EDGE_GUARD``) abandons the deadband near the screen edge so a
+          *wide* zone can never strand the subject off-frame.  ``roundness`` shapes
+          the zone between ellipse and rectangle so a "square" respects its corners.
+        - **Safe zone OFF** → legacy per-axis dead-zone around the frame centre
+          (hold inside, full error outside), unchanged.
+
+        Hold uses the *measured* error and a hysteresis band so hovering on the
+        boundary doesn't start/stop chatter.
         """
-        if getattr(cfg, "safe_zone_enabled", False):
-            cx = float(getattr(cfg, "safe_zone_x", 0.0))
-            cy = float(getattr(cfg, "safe_zone_y", 0.0))
-            hw = max(1e-3, float(getattr(cfg, "safe_zone_w", 0.15)))
-            hh = max(1e-3, float(getattr(cfg, "safe_zone_h", 0.22)))
-            # Elliptical distance (1.0 == on the oval edge), matching the overlay.
-            dist = ((ex - cx) / hw) ** 2 + ((ey - cy) / hh) ** 2
-            inside = dist <= 1.0
-            outside = dist > (1.0 + _HOLD_HYSTERESIS) ** 2
-        else:
-            dzx = max(1e-6, float(getattr(cfg, "deadzone_x", 0.0)))
-            dzy = max(1e-6, float(getattr(cfg, "deadzone_y", 0.0)))
-            inside = abs(ex) <= dzx and abs(ey) <= dzy
-            m = 1.0 + _HOLD_HYSTERESIS
-            outside = abs(ex) > dzx * m or abs(ey) > dzy * m
+        if not getattr(cfg, "safe_zone_enabled", False):
+            holding = self._update_hold(ex, ey, cfg)
+            return (0.0, 0.0, True) if holding else (ex, ey, False)
+
+        cx = float(getattr(cfg, "safe_zone_x", 0.0))
+        cy = float(getattr(cfg, "safe_zone_y", 0.0))
+        hw = max(1e-3, float(getattr(cfg, "safe_zone_w", 0.15)))
+        hh = max(1e-3, float(getattr(cfg, "safe_zone_h", 0.22)))
+        roundness = float(getattr(cfg, "safe_zone_roundness", 1.0))
+        dx = ex - cx
+        dy = ey - cy
+
+        # Frame-edge guard: near the screen edge, drop the deadband/hold and drive
+        # on the full offset toward the zone centre (a wide zone must not let the
+        # subject sit at the edge).
+        if abs(ex) >= _EDGE_GUARD or abs(ey) >= _EDGE_GUARD:
+            self._holding = False
+            return dx, dy, False
+
+        dbx = _FRAMING_DEADBAND * hw
+        dby = _FRAMING_DEADBAND * hh
+        # Latch ON inside the inner deadband; release only past the OUTER zone edge
+        # (×(1+hyst)) — a wide quiet band, then ease all the way to centre.
+        inside_db = _zone_norm(dx, dy, dbx, dby, roundness) <= 1.0
+        outside_zone = _zone_norm(dx, dy, hw, hh, roundness) > (1.0 + _HOLD_HYSTERESIS) ** 2
+        if self._holding:
+            if outside_zone:
+                self._holding = False
+        elif inside_db:
+            self._holding = True
+        if self._holding:
+            return 0.0, 0.0, True
+
+        return _soft_deadband(dx, dbx), _soft_deadband(dy, dby), False
+
+    def _update_hold(self, ex: float, ey: float, cfg: Any) -> bool:
+        """Return whether to HOLD inside the per-axis dead-zone, with hysteresis.
+
+        Used only when the safe zone is OFF (the safe-zone case is handled by
+        :meth:`_framing_error`).  Once holding, the subject must travel
+        ``_HOLD_HYSTERESIS`` beyond the dead-zone edge to resume following — so
+        hovering on the boundary doesn't start/stop chatter.
+        """
+        dzx = max(1e-6, float(getattr(cfg, "deadzone_x", 0.0)))
+        dzy = max(1e-6, float(getattr(cfg, "deadzone_y", 0.0)))
+        inside = abs(ex) <= dzx and abs(ey) <= dzy
+        m = 1.0 + _HOLD_HYSTERESIS
+        outside = abs(ex) > dzx * m or abs(ey) > dzy * m
 
         if self._holding:
             if outside:

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -487,6 +487,15 @@ class PTZController:
         # ── state transitions ─────────────────────────────────────────────────
         if p.track_active:
             if self._state != ControllerState.TRACKING:
+                # WARM re-acquire when the target was lost only BRIEFLY (still in
+                # the coast window): it's ~where it was, so keep the slew-limiter
+                # speed (and hold latch) so motion resumes from the pre-loss speed
+                # instead of re-ramping from a dead stop — that cold restart of the
+                # slew is the visible "find" lurch in the find/lose/find cycle
+                # during pans.  Everything else still resets (below), so there's no
+                # stale wind-up or filter/derivative artifact.
+                warm = self._state == ControllerState.COASTING
+
                 # (re-)acquired target: reset filters (and re-apply smoothing in
                 # case the tuning changed while we were searching)
                 self._filt_ex.reset()
@@ -504,11 +513,15 @@ class PTZController:
                 self._prev_pan_sign = 0
                 self._prev_tilt_sign = 0
                 self._flip_score = 0.0
-                self._slew_pan = 0.0
-                self._slew_tilt = 0.0
-                self._holding = False
                 self._zoom_height_ema = None
                 self._zoom_cmd = 0.0
+                if not warm:
+                    # COLD acquire (fresh target, or recovery after a long loss via
+                    # SEARCHING where the subject may be anywhere): also stop the
+                    # slew limiter and release the hold so motion ramps from rest.
+                    self._slew_pan = 0.0
+                    self._slew_tilt = 0.0
+                    self._holding = False
                 self._state = ControllerState.TRACKING
         else:
             if self._state == ControllerState.TRACKING:

--- a/autoptz/engine/runtime/diagnostics.py
+++ b/autoptz/engine/runtime/diagnostics.py
@@ -106,16 +106,40 @@ def reid_status() -> dict[str, str]:
     )
 
 
+def _insightface_models_dir() -> Path:
+    """Where insightface stores model packs (``$INSIGHTFACE_HOME`` or ``~/.insightface``)."""
+    base = os.environ.get("INSIGHTFACE_HOME") or (Path.home() / ".insightface")
+    return Path(base) / "models"
+
+
 def face_status() -> dict[str, str]:
-    """Face recognition (insightface SCRFD + ArcFace) availability."""
-    if _module_present("insightface"):
-        return _entry("face", "Face recognition", "ok", "insightface SCRFD + ArcFace")
-    return _entry(
-        "face",
-        "Face recognition",
-        "off",
-        "insightface not installed · manual click-to-track still works",
-    )
+    """Face recognition (insightface SCRFD + ArcFace) availability.
+
+    Reports on the *weights*, not just the package: an offline first-run (common
+    on Windows) has insightface installed but no ``buffalo_l`` pack, so the
+    models never load and faces silently fail to enroll/save.  That case is
+    surfaced as ``warn`` ("model not downloaded") instead of the old misleading
+    ``ok`` so the operator knows why faces aren't working.
+    """
+    if not _module_present("insightface"):
+        return _entry(
+            "face",
+            "Face recognition",
+            "off",
+            "insightface not installed · manual click-to-track still works",
+        )
+    model = os.environ.get("AUTOPTZ_FACE_MODEL", "buffalo_l")
+    model_dir = _insightface_models_dir() / model
+    has_weights = model_dir.is_dir() and any(model_dir.glob("*.onnx"))
+    if not has_weights:
+        return _entry(
+            "face",
+            "Face recognition",
+            "warn",
+            f"insightface installed but model {model!r} not downloaded "
+            "(needs network on first run) · manual click-to-track still works",
+        )
+    return _entry("face", "Face recognition", "ok", "insightface SCRFD + ArcFace")
 
 
 def pose_status() -> dict[str, str]:

--- a/autoptz/engine/runtime/diagnostics.py
+++ b/autoptz/engine/runtime/diagnostics.py
@@ -106,12 +106,6 @@ def reid_status() -> dict[str, str]:
     )
 
 
-def _insightface_models_dir() -> Path:
-    """Where insightface stores model packs (``$INSIGHTFACE_HOME`` or ``~/.insightface``)."""
-    base = os.environ.get("INSIGHTFACE_HOME") or (Path.home() / ".insightface")
-    return Path(base) / "models"
-
-
 def face_status() -> dict[str, str]:
     """Face recognition (insightface SCRFD + ArcFace) availability.
 
@@ -119,7 +113,9 @@ def face_status() -> dict[str, str]:
     on Windows) has insightface installed but no ``buffalo_l`` pack, so the
     models never load and faces silently fail to enroll/save.  That case is
     surfaced as ``warn`` ("model not downloaded") instead of the old misleading
-    ``ok`` so the operator knows why faces aren't working.
+    ``ok`` so the operator knows why faces aren't working.  Resolves the model
+    root via :func:`autoptz.engine.pipeline.identify.insightface_root` so it
+    checks the SAME place the recogniser loads from (bundled / cache / home).
     """
     if not _module_present("insightface"):
         return _entry(
@@ -128,8 +124,10 @@ def face_status() -> dict[str, str]:
             "off",
             "insightface not installed · manual click-to-track still works",
         )
+    from autoptz.engine.pipeline.identify import insightface_root  # noqa: PLC0415
+
     model = os.environ.get("AUTOPTZ_FACE_MODEL", "buffalo_l")
-    model_dir = _insightface_models_dir() / model
+    model_dir = Path(insightface_root()) / "models" / model
     has_weights = model_dir.is_dir() and any(model_dir.glob("*.onnx"))
     if not has_weights:
         return _entry(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -90,6 +90,41 @@ class TestTrackerStatusNonBlocking:
             assert "boxmot" not in sys.modules, "tracker_status must not import boxmot"
 
 
+class TestFaceStatusModelPresence:
+    """face_status must reflect whether the model WEIGHTS are on disk, not just
+    whether the insightface package imports.
+
+    The "faces never save on Windows" symptom: an offline first-run has the
+    package installed but no ``buffalo_l`` weights, so SCRFD/ArcFace never load.
+    The old probe reported "ok" purely on package import — hiding the real cause.
+    """
+
+    def test_warns_when_package_present_but_model_missing(self, monkeypatch, tmp_path) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_module_present", lambda name: name == "insightface")
+        monkeypatch.setenv("INSIGHTFACE_HOME", str(tmp_path))  # empty → no weights
+        row = diag.face_status()
+        assert row["state"] == "warn"
+        assert "model" in row["detail"].lower()
+
+    def test_ok_when_model_weights_present(self, monkeypatch, tmp_path) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_module_present", lambda name: name == "insightface")
+        models = tmp_path / "models" / "buffalo_l"
+        models.mkdir(parents=True)
+        (models / "det_10g.onnx").write_bytes(b"x")
+        monkeypatch.setenv("INSIGHTFACE_HOME", str(tmp_path))
+        assert diag.face_status()["state"] == "ok"
+
+    def test_off_when_package_absent(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_module_present", lambda name: False)
+        assert diag.face_status()["state"] == "off"
+
+
 class TestInferencePoolRelease:
     """Releasing a pooled model drops the cached instance + re-arms the build."""
 

--- a/tests/test_ego_gate.py
+++ b/tests/test_ego_gate.py
@@ -1,11 +1,16 @@
-"""Ego-motion freshness gate — the ping-pong fix.
+"""Ego-motion freshness gate — the pan-jitter fix.
 
-Bug: ego-motion is decimated (optical flow every Nth inference frame). On the
-off-cadence frames the cached estimate is reused, but `_estimate_aim_velocity`
-ran every tick and unconditionally SUBTRACTED that stale/decayed estimate from
-the per-frame aim velocity — producing a sawtooth "phantom" world-velocity that
-the controller's predictive lead chased, i.e. the camera ping-ponged when it AND
-the subject moved. Fix: only subtract ego when it was freshly measured this tick.
+Bug: ego-motion is decimated (optical flow every Nth inference frame, default 3).
+`_estimate_aim_velocity` ran every tick: on the off-cadence frames it computed the
+per-tick d(error)/dt but zero-subtracted ego, injecting the FULL camera-pan
+velocity into the controller's feed-forward on 2 of every 3 frames — so the camera
+hunted (find/lose/find) during pans.
+
+Fix (window matching): the ego estimate spans `interval` frames, so the subject
+velocity must be measured over the SAME window for the subtraction to cancel.  We
+only recompute on a freshly-measured (`_ego_fresh`) tick and HOLD the last value
+between fresh ticks (when ego comp is enabled).  With ego comp OFF there is no
+multi-frame estimate to match, so velocity is computed every tick as before.
 """
 
 from __future__ import annotations
@@ -29,7 +34,9 @@ def _worker(**ptz):
 
 
 class TestEgoFreshnessGate:
-    def test_stale_ego_is_not_subtracted(self):
+    def test_stale_ego_tick_holds_and_does_not_inject_raw_velocity(self):
+        # Off-cadence tick (ego enabled): the camera-pan-contaminated d(error)/dt
+        # must NOT be injected.  The last subject velocity (0.0 here) is held.
         w = _worker()
         w._prev_aim_err = (0.0, 0.0)
         w._prev_aim_t = 0.0
@@ -37,8 +44,34 @@ class TestEgoFreshnessGate:
         w._ego_vel = (0.5, 0.0)  # a (stale) cached ego estimate
         w._ego_fresh = False  # decimated/off-cadence → not freshly measured
         vx, _ = w._estimate_aim_velocity((0.1, 0.0), 0.1)
-        # raw d(err)/dt = 1.0, ego NOT subtracted, EMA(0.5) from 0 → 0.5
-        assert abs(vx - 0.5) < 1e-6
+        assert abs(vx - 0.0) < 1e-6  # held, not the raw d(err)/dt of 1.0
+
+    def test_offcadence_holds_last_velocity_when_ego_enabled(self):
+        # Window-matched fix: on an off-cadence (not-fresh) tick with ego comp
+        # ENABLED, the per-tick d(error)/dt is camera-pan-contaminated (ego spans
+        # `interval` frames, the error delta spans 1) — so instead of injecting it
+        # we HOLD the last subject velocity and do not roll the prev marker, so the
+        # next fresh tick's delta spans the same window the ego estimate covers.
+        w = _worker(ego_comp_enabled=True, ego_comp_interval=3)
+        w._prev_aim_err = (0.0, 0.0)
+        w._prev_aim_t = 0.0
+        w._aim_vel = (0.2, 0.0)  # last good (subject) velocity
+        w._ego_fresh = False  # off-cadence
+        vx, _ = w._estimate_aim_velocity((0.1, 0.0), 0.1)
+        assert abs(vx - 0.2) < 1e-6  # held, not the raw d(err)/dt of 1.0
+        assert w._prev_aim_err == (0.0, 0.0)  # prev NOT rolled
+        assert w._prev_aim_t == 0.0
+
+    def test_offcadence_still_computes_when_ego_disabled(self):
+        # With ego comp OFF there is no multi-frame estimate to window-match, so
+        # the per-tick velocity is still computed every tick (legacy behaviour).
+        w = _worker(ego_comp_enabled=False)
+        w._prev_aim_err = (0.0, 0.0)
+        w._prev_aim_t = 0.0
+        w._aim_vel = (0.0, 0.0)
+        w._ego_fresh = False
+        vx, _ = w._estimate_aim_velocity((0.1, 0.0), 0.1)
+        assert abs(vx - 0.5) < 1e-6  # raw 1.0, EMA(0.5) from 0 → 0.5
 
     def test_fresh_ego_is_subtracted(self):
         w = _worker()

--- a/tests/test_egomotion.py
+++ b/tests/test_egomotion.py
@@ -129,6 +129,7 @@ def test_ego_comp_cancels_phantom_velocity_when_only_camera_moves() -> None:
         _aim_vel=(0.0, 0.0),
         _ego_vel=(0.0, 0.0),
         _ego_fresh=True,  # ego freshly measured this tick → trusted/subtracted
+        config=SimpleNamespace(ptz=SimpleNamespace(ego_comp_enabled=True)),
     )
     est_vel(ns, (0.0, 0.0), 0.0)  # establish previous error
     # Subject stationary in the world; camera pans → error drifts at -0.5/s, all
@@ -146,7 +147,8 @@ def test_without_ego_comp_phantom_velocity_appears() -> None:
         _prev_aim_t=0.0,
         _aim_vel=(0.0, 0.0),
         _ego_vel=(0.0, 0.0),
-        _ego_fresh=False,  # ego comp off / no fresh measurement → not subtracted
+        _ego_fresh=False,  # ego comp OFF → no estimate, computed every tick
+        config=SimpleNamespace(ptz=SimpleNamespace(ego_comp_enabled=False)),
     )
     est_vel(ns, (0.0, 0.0), 0.0)
     # Same drift but ego comp off (ego_vel stays zero) → a non-zero phantom

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -159,13 +159,48 @@ class TestFaceRecognizer:
         monkeypatch.setenv("INSIGHTFACE_HOME", str(tmp_path))
         assert insightface_root() == str(tmp_path)
 
-    def test_insightface_root_defaults_to_home(self, monkeypatch):
+    def test_insightface_root_defaults_to_home(self, monkeypatch, tmp_path):
         from pathlib import Path
 
+        import autoptz.engine.runtime.models as models_mod
         from autoptz.engine.pipeline.identify import insightface_root
 
         monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
+        # No bundled pack and no user-cache pack → fall back to insightface's own
+        # default (~/.insightface), where it auto-downloads when online.
+        monkeypatch.setattr(models_mod, "bundled_models_dir", lambda: tmp_path / "nobundle")
+        monkeypatch.setattr(models_mod, "_models_cache_dir", lambda: tmp_path / "nocache")
         assert insightface_root() == str(Path.home() / ".insightface")
+
+    def test_insightface_root_prefers_bundled_pack(self, monkeypatch, tmp_path):
+        # A packaged installer ships the pack under <bundled models>/insightface;
+        # the running app must resolve there so offline face enrolment works.
+        import autoptz.engine.runtime.models as models_mod
+        from autoptz.engine.pipeline.identify import insightface_root
+
+        monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
+        bundled_models = tmp_path / "bundled"
+        pack = bundled_models / "insightface" / "models" / "buffalo_l"
+        pack.mkdir(parents=True)
+        (pack / "det_10g.onnx").write_bytes(b"x")
+        monkeypatch.setattr(models_mod, "bundled_models_dir", lambda: bundled_models)
+        monkeypatch.setattr(models_mod, "_models_cache_dir", lambda: tmp_path / "nocache")
+        assert insightface_root() == str(bundled_models / "insightface")
+
+    def test_insightface_root_uses_user_cache_when_no_bundle(self, monkeypatch, tmp_path):
+        # A source/dev user who ran `fetch_models` has the pack in the app-data
+        # model cache; resolve there when nothing is bundled.
+        import autoptz.engine.runtime.models as models_mod
+        from autoptz.engine.pipeline.identify import insightface_root
+
+        monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
+        cache = tmp_path / "cache"
+        pack = cache / "insightface" / "models" / "buffalo_l"
+        pack.mkdir(parents=True)
+        (pack / "w600k_r50.onnx").write_bytes(b"x")
+        monkeypatch.setattr(models_mod, "bundled_models_dir", lambda: tmp_path / "nobundle")
+        monkeypatch.setattr(models_mod, "_models_cache_dir", lambda: cache)
+        assert insightface_root() == str(cache / "insightface")
 
     def test_face_recognizer_passes_root_to_insightface(self, monkeypatch, tmp_path):
         # A2: the model storage root must be controllable (so a bundled/relocated

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -128,6 +128,89 @@ class TestFaceRecognizer:
         assert rec.available is False
         assert rec.detect(np.zeros((480, 640, 3), dtype=np.uint8)) == []
 
+    def test_records_last_error_when_insightface_unavailable(self, monkeypatch):
+        # The silent-failure bug: when insightface (or its model) fails to load,
+        # the recognizer disables itself but gives no diagnosable reason, so the
+        # Windows "faces never save" symptom has no surfaced cause.  After the
+        # fix, the captured failure reason is readable via ``last_error``.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "insightface" or name.startswith("insightface."):
+                raise ImportError("simulated: insightface unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        rec = FaceRecognizer()
+        assert rec.available is False
+        assert rec.last_error  # non-empty diagnostic
+        assert "insightface" in rec.last_error.lower()
+
+    def test_no_last_error_when_app_injected(self):
+        rec = FaceRecognizer(_app=_FakeApp())
+        assert rec.available is True
+        assert rec.last_error is None
+
+    def test_insightface_root_honors_env(self, monkeypatch, tmp_path):
+        from autoptz.engine.pipeline.identify import insightface_root
+
+        monkeypatch.setenv("INSIGHTFACE_HOME", str(tmp_path))
+        assert insightface_root() == str(tmp_path)
+
+    def test_insightface_root_defaults_to_home(self, monkeypatch):
+        from pathlib import Path
+
+        from autoptz.engine.pipeline.identify import insightface_root
+
+        monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
+        assert insightface_root() == str(Path.home() / ".insightface")
+
+    def test_face_recognizer_passes_root_to_insightface(self, monkeypatch, tmp_path):
+        # A2: the model storage root must be controllable (so a bundled/relocated
+        # cache is honoured offline), threaded into FaceAnalysis like detector/pose.
+        import sys
+        import types
+
+        captured: dict[str, object] = {}
+
+        class _FakeFA:
+            def __init__(self, name, root=None, providers=None, allowed_modules=None, **kw):
+                captured["root"] = root
+
+            def prepare(self, **kw):
+                return None
+
+            def get(self, frame):
+                return []
+
+        fake_app = types.ModuleType("insightface.app")
+        fake_app.FaceAnalysis = _FakeFA  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "insightface", types.ModuleType("insightface"))
+        monkeypatch.setitem(sys.modules, "insightface.app", fake_app)
+        monkeypatch.setenv("INSIGHTFACE_HOME", str(tmp_path))
+
+        rec = FaceRecognizer()
+        assert rec.available is True
+        assert captured["root"] == str(tmp_path)
+
+    def test_ensure_face_model_returns_error_when_unavailable(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "insightface" or name.startswith("insightface."):
+                raise ImportError("simulated: insightface unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        from autoptz.engine.pipeline.identify import ensure_face_model
+
+        err = ensure_face_model()
+        assert err and "insightface" in err.lower()  # graceful, never raises
+
     def test_injected_app_available(self):
         rec = FaceRecognizer(_app=_FakeApp())
         assert rec.available is True

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -400,6 +400,46 @@ class TestSafeZoneCentering:
         assert pan > 0.0
 
 
+class TestWarmReacquire:
+    """A brief target loss (within the coast window) must resume smoothly, not
+    cold-reset the controller and re-ramp from a dead stop — the "find" lurch in
+    the find/lose/find cycle during pans."""
+
+    def _ctrl(self, coast_ms: int) -> PTZController:
+        return PTZController(
+            MockBackend(),
+            _cfg(kp=1.0, kd=0.0, aim_smoothing=0.0, safe_zone_enabled=False, max_accel=2.0),
+            coast_window_ms=coast_ms,
+            rate_hz=20.0,
+        )
+
+    def _ramp_to_steady(self, ctrl: PTZController, t0: float) -> tuple[float, float]:
+        t = t0
+        pan = 0.0
+        for _ in range(30):
+            pan, _, _ = ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=t)
+            t += 0.05
+        return pan, t
+
+    def test_brief_coast_reacquire_resumes_without_reramping(self) -> None:
+        ctrl = self._ctrl(coast_ms=1500)
+        steady, t = self._ramp_to_steady(ctrl, 0.0)
+        assert steady > 0.3
+        ctrl.step((0.0, 0.0), (0.0, 0.0), 0.0, False, t=t)  # one lost tick → COASTING
+        t += 0.05
+        pan_re, _, _ = ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=t)
+        assert pan_re == pytest.approx(steady, abs=0.06)  # warm: no slew from 0
+
+    def test_long_loss_reacquire_cold_resets(self) -> None:
+        ctrl = self._ctrl(coast_ms=100)  # coast expires after ~2 lost ticks
+        steady, t = self._ramp_to_steady(ctrl, 0.0)
+        for _ in range(5):  # long loss → COASTING → SEARCHING
+            ctrl.step((0.0, 0.0), (0.0, 0.0), 0.0, False, t=t)
+            t += 0.05
+        pan_re, _, _ = ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=t)
+        assert pan_re < steady - 0.1  # cold: slew limiter ramps from 0
+
+
 class TestZoneGeometry:
     def test_square_zone_contains_corner_round_zone_excludes_it(self) -> None:
         from autoptz.engine.ptz.controller import _zone_norm

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -301,17 +301,25 @@ class TestControllerMath:
         assert pan1 > pan0
 
     def test_deadzone_suppresses_small_error(self) -> None:
-        ctrl = PTZController(MockBackend(), _cfg(kp=0.6, deadzone_x=0.1, deadzone_y=0.1))
+        # The per-axis dead-zone path is the safe-zone-OFF behaviour.
+        ctrl = PTZController(
+            MockBackend(), _cfg(kp=0.6, safe_zone_enabled=False, deadzone_x=0.1, deadzone_y=0.1)
+        )
         pan, tilt, _ = ctrl.step((0.05, 0.08), (0.0, 0.0), 0.45, True, t=0.0)
         assert pan == pytest.approx(0.0, abs=1e-6)
         assert tilt == pytest.approx(0.0, abs=1e-6)
 
     def test_deadzone_passes_large_error(self) -> None:
-        ctrl = PTZController(MockBackend(), _cfg(kp=0.6, deadzone_x=0.05, deadzone_y=0.05))
+        ctrl = PTZController(
+            MockBackend(), _cfg(kp=0.6, safe_zone_enabled=False, deadzone_x=0.05, deadzone_y=0.05)
+        )
         pan, _, _ = ctrl.step((0.3, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
         assert pan > 0.0
 
-    def test_shifted_safe_zone_suppresses_error_around_box_center(self) -> None:
+    def test_shifted_safe_zone_holds_at_box_center(self) -> None:
+        # The setpoint is the zone centre: a subject AT the (offset) box centre is
+        # held still.  (Off-centre-inside-zone now eases toward centre — see
+        # TestSafeZoneCentering — rather than freezing as it used to.)
         ctrl = PTZController(
             MockBackend(),
             _cfg(
@@ -322,7 +330,7 @@ class TestControllerMath:
                 safe_zone_h=0.1,
             ),
         )
-        pan, tilt, _ = ctrl.step((0.34, -0.24), (0.0, 0.0), 0.45, True, t=0.0)
+        pan, tilt, _ = ctrl.step((0.3, -0.2), (0.0, 0.0), 0.45, True, t=0.0)
         assert pan == pytest.approx(0.0, abs=1e-6)
         assert tilt == pytest.approx(0.0, abs=1e-6)
 
@@ -344,6 +352,63 @@ class TestControllerMath:
         ctrl = PTZController(MockBackend(), _cfg(kp=0.6, invert_pan=True))
         pan, _, _ = ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
         assert pan < 0.0  # positive error + invert → negative command
+
+
+class TestSafeZoneCentering:
+    """The safe zone must ease the subject toward the zone CENTRE (Center-Stage
+    feel), not merely freeze them anywhere inside the oval (the old deadzone-only
+    behaviour that 'never centered' and let a big zone ignore the frame edges)."""
+
+    def _zone(self, **kw: object) -> PTZController:
+        defaults: dict[str, object] = {
+            "kp": 0.6,
+            "safe_zone_enabled": True,
+            "safe_zone_x": 0.0,
+            "safe_zone_y": 0.0,
+            "safe_zone_w": 0.15,
+            "safe_zone_h": 0.22,
+        }
+        defaults.update(kw)
+        return PTZController(MockBackend(), _cfg(**defaults))
+
+    def test_offcenter_subject_inside_zone_is_eased_to_center(self) -> None:
+        # Subject right-of-centre but inside the oval: old code froze (pan==0);
+        # now it eases back toward the centre (pan>0).
+        ctrl = self._zone()
+        pan, _, _ = ctrl.step((0.12, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        assert pan > 0.0
+
+    def test_centered_subject_holds_still(self) -> None:
+        # Within the small inner deadband around the zone centre → no micro-moves.
+        ctrl = self._zone()
+        pan, tilt, _ = ctrl.step((0.01, 0.01), (0.0, 0.0), 0.45, True, t=0.0)
+        assert pan == pytest.approx(0.0, abs=1e-6)
+        assert tilt == pytest.approx(0.0, abs=1e-6)
+
+    def test_offset_zone_drives_subject_to_box_center(self) -> None:
+        # The setpoint is the zone centre, not the frame centre: a subject at the
+        # FRAME centre with a right-shifted zone is moved toward the zone centre.
+        # Old code used frame-centre error → pan==0 (ignored the offset).
+        ctrl = self._zone(safe_zone_x=0.3, safe_zone_w=0.1, safe_zone_h=0.1)
+        pan, _, _ = ctrl.step((0.0, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        assert pan < 0.0
+
+    def test_large_zone_still_centers_subject_near_frame_edge(self) -> None:
+        # A big safe zone must NOT let the subject sit at the frame edge.
+        ctrl = self._zone(safe_zone_w=0.9, safe_zone_h=0.9)
+        pan, _, _ = ctrl.step((0.85, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        assert pan > 0.0
+
+
+class TestZoneGeometry:
+    def test_square_zone_contains_corner_round_zone_excludes_it(self) -> None:
+        from autoptz.engine.ptz.controller import _zone_norm
+
+        # A corner point at (hw, hh): inside a square zone (roundness 0), outside
+        # an elliptical one (roundness 1) — so a configured "square" respects its
+        # corners instead of being treated as an ellipse.
+        assert _zone_norm(0.1, 0.1, 0.1, 0.1, 0.0) <= 1.0
+        assert _zone_norm(0.1, 0.1, 0.1, 0.1, 1.0) > 1.0
 
     def test_invert_tilt(self) -> None:
         ctrl = PTZController(MockBackend(), _cfg(kp=0.6, invert_tilt=True))

--- a/tools/fetch_models.py
+++ b/tools/fetch_models.py
@@ -106,10 +106,16 @@ def main(argv: list[str] | None = None) -> int:
     # faces.  Best-effort — a failure here is a warning, never a hard exit, since
     # face recognition is optional (manual click-to-track still works).
     if not args.detector_only:
-        from autoptz.engine.pipeline.identify import ensure_face_model, insightface_root
+        from autoptz.engine.pipeline.identify import ensure_face_model
 
-        log.info("Fetching face model (insightface buffalo_l) into %s ...", insightface_root())
-        face_err = ensure_face_model()
+        # Fetch INTO the model cache dir (…/insightface) — the same tree the build
+        # scripts pass via --cache-dir autoptz/models, so the pack is bundled by
+        # packaging/autoptz.spec and resolved by insightface_root() at runtime.
+        # (Plain ensure_face_model() would write to ~/.insightface, which is NOT
+        # bundled — the gap that left installer users without face weights.)
+        face_root = str(mgr.cache_dir / "insightface")
+        log.info("Fetching face model (insightface buffalo_l) into %s ...", face_root)
+        face_err = ensure_face_model(root=face_root)
         if face_err:
             log.warning(
                 "  → face model NOT available (offline face enrolment will be disabled): %s",

--- a/tools/fetch_models.py
+++ b/tools/fetch_models.py
@@ -9,12 +9,15 @@ detection working even when later run offline:
 
 It downloads/exports the detector tiers and pose model into the platform
 app-data ``…/AutoPTZ/models`` dir (the same dir
-:class:`autoptz.engine.runtime.models.ModelManager` reads at engine start).
+:class:`autoptz.engine.runtime.models.ModelManager` reads at engine start), and
+pre-downloads the face-recognition pack (insightface ``buffalo_l``) into the
+insightface cache so face enrolment works when later run OFFLINE — the fix for
+"faces never save on an offline first-run".  Skip the face step with
+``--detector-only``.  ReID (boxmot) weights use their upstream cache and are not
+fetched here.
 
-Face (insightface) and ReID (boxmot) weights use their upstream caches and are
-not removed by this CLI.
-
-Exit code 0 if a usable detector ONNX is available afterwards, 1 otherwise.
+Exit code 0 if a usable detector ONNX is available afterwards, 1 otherwise.  A
+failed face download is a warning only (face is optional), not a hard failure.
 """
 
 from __future__ import annotations
@@ -39,7 +42,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--detector-only",
         action="store_true",
-        help="Fetch detector tiers only; skip the pose model.",
+        help="Fetch detector tiers only; skip the pose and face models.",
     )
     parser.add_argument(
         "--remove",
@@ -98,6 +101,23 @@ def main(argv: list[str] | None = None) -> int:
             "network access, or set AUTOPTZ_MODEL_URL):\n  - %s",
             "\n  - ".join(failed),
         )
+
+    # Face pack (insightface buffalo_l): pre-download so offline runs can enrol
+    # faces.  Best-effort — a failure here is a warning, never a hard exit, since
+    # face recognition is optional (manual click-to-track still works).
+    if not args.detector_only:
+        from autoptz.engine.pipeline.identify import ensure_face_model, insightface_root
+
+        log.info("Fetching face model (insightface buffalo_l) into %s ...", insightface_root())
+        face_err = ensure_face_model()
+        if face_err:
+            log.warning(
+                "  → face model NOT available (offline face enrolment will be disabled): %s",
+                face_err,
+            )
+        else:
+            log.info("  → ready: insightface buffalo_l")
+
     return 0 if ok_any and not failed else (0 if ok_any else 1)
 
 


### PR DESCRIPTION
Fixes the three issues reported on 2.2.0-rc3, each diagnosed via a verified multi-agent investigation and implemented test-first (1095 tests pass, ruff lint+format clean, no new mypy errors). A pre-merge review pass (verdict: **ready-with-fixes**) caught a packaging gap that's also addressed here.

## Issue 1 — Windows: faces never save
Root cause was **not** storage — the face pipeline is hard-gated on insightface loading and the failure was swallowed silently, so no "Person N" was ever harvested and Register had nothing to save.
- `FaceRecognizer.last_error` captures the real reason; `face_status()` checks the `buffalo_l` weights on disk (reports *"model not downloaded"* instead of a misleading "ok").
- `insightface_root()` resolves `INSIGHTFACE_HOME` → bundled `<models>/insightface` → user cache → `~/.insightface`, and `fetch_models` writes the pack into the bundled models tree, so **offline installers ship the weights** and a fresh offline machine can enroll.
- Honest scope: this makes the failure diagnosable + fixes the offline/network cause. A non-network cause (dependency/ABI break) would now be **surfaced** in the Services panel rather than fixed by this PR.

## Issue 2 — PTZ jitter (find/lose/find) while panning
- **Window-matched ego compensation** — stop injecting the camera's own pan velocity into the controller feed-forward on the frames between ego measurements (the dominant hunting cause). CPU-neutral.
- **Warm re-acquire** — a brief target loss resumes from the pre-loss speed instead of cold-restarting the slew ramp (the "find" lurch).
- Scope: fixes the **control-loop** half. A detector/tracker dropping the box during very fast pans is a separate, still-open item (needs on-hardware repro).

## Issue 3 — safe zone never centers / ignores edges → "smooth like Center Stage"
- Setpoint is now the **zone center** (was: frame center); a soft deadband eases the subject to center instead of freezing at the oval edge.
- **Frame-edge guard** so a wide zone can't strand the subject off-screen; `Roundness`-aware zone test so a square respects its corners.
- Ports Center Stage *principles* into the existing one-euro/PD/slew controller (no rewrite).

## Validation still owed (per the test-before-merge policy)
- **Windows box:** `python -c "from autoptz.engine.pipeline.identify import FaceRecognizer as F; r=F(); print(r.available,'|',r.last_error)"` to confirm the real cause class.
- **Physical PTZ:** confirm panning is smooth and the subject eases to the safe-zone center.

## Note
The installer now bundles the `buffalo_l` face pack (~hundreds of MB) so offline enrollment works — this increases installer size. Easy to scope to Windows-only or revert if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)