### PR TITLE
release: 2.2.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0-rc4] — 2026-06-25
+
+> Pre-release for testing — fixes the three issues reported on rc3 (safe-zone
+> centering, PTZ pan jitter, and Windows face-recognition diagnosability +
+> offline model bundling). **Please validate on your real cameras** — especially
+> physical-PTZ panning and Windows face enrollment — and report back before this
+> becomes the stable 2.2.0.
+
 ### Fixed
 
 - **Safe zone now centers the subject (was: froze them at the oval edge).** The

--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.2.0-rc3"
+__version__ = "2.2.0-rc4"
 
 
 def version() -> str:


### PR DESCRIPTION
Cuts **2.2.0-rc4** off `main` (which now includes #103).

## What's in this RC (since rc3)
Fixes the three issues reported on rc3:
- **Safe-zone framing now centers the subject** — setpoint is the zone center (was the frame center); a soft deadband eases the subject to the middle (Center-Stage feel) instead of freezing at the oval edge, with a frame-edge guard and `Roundness`-aware zone shape.
- **Smoother PTZ tracking while panning** — window-matched ego-motion compensation (no more injecting the camera's own pan velocity on 2/3 frames) + warm re-acquire after a brief loss (no cold slew re-ramp). Control-loop half of the jitter; a tracker/detector dropping the box on very fast pans remains a separate item.
- **Windows face recognition: diagnosable + offline-capable** — failures surface the real reason in the Services panel (incl. "model not downloaded") instead of failing silently; the `buffalo_l` pack is provisioned via `fetch_models` and bundled into installers so offline machines can enroll.

## Release mechanics
- `__version__` 2.2.0-rc3 → **2.2.0-rc4** (single source; `pyproject.toml` derives it).
- CHANGELOG `[Unreleased]` rolled into `[2.2.0-rc4]`.
- Tagging `v2.2.0-rc4` after merge triggers the signed macOS/Windows/Linux build + GitHub pre-release.

## Validation still owed (per test-before-merge policy)
This RC is the vehicle for that validation — please test physical-PTZ panning + Windows face enrollment on real hardware and report back before 2.2.0 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)