### PR TITLE
fix(ptz): auto-detect VISCA-USB serial PTZ + configurable baud

### DIFF
--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -170,6 +170,11 @@ class PtzPresetSlot(BaseModel, frozen=True):
 class PTZConfig(BaseModel, frozen=True):
     backend: Literal["auto", "ndi", "visca_ip", "visca_usb", "onvif", "digital"] = "auto"
     address: str | None = None
+    # VISCA-USB serial baud rate.  Most legacy Sony cameras are 9600; many newer
+    # USB PTZ cameras run at 115200 and *silently ignore* every command at the
+    # wrong rate.  Used by the ``visca_usb`` backend; the ``auto`` backend probes
+    # for the right value during serial discovery (see ``engine.ptz.visca_serial``).
+    baud: int = Field(default=9600, ge=1200, le=921600)
     max_pan_speed: float = Field(default=0.7, ge=0.0, le=1.0)
     max_tilt_speed: float = Field(default=0.7, ge=0.0, le=1.0)
     max_zoom_speed: float = Field(default=0.3, ge=0.0, le=1.0)

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3060,11 +3060,17 @@ class CameraWorker:
             # this, NDI PTZ (auto-follow + manual) silently never builds.
             ndi_name: str | None = None
             src = getattr(self.config, "source", None)
-            if src is not None and getattr(src, "type", "") == "ndi":
+            src_type = getattr(src, "type", "") if src is not None else ""
+            if src_type == "ndi":
                 addr = (getattr(src, "address", "") or "").strip()
                 ndi_name = addr[len("ndi://") :] if addr.startswith("ndi://") else addr
 
-            backend = build_backend(self.config.ptz, ndi_name=ndi_name)
+            # Only USB/UVC sources auto-probe serial ports for a VISCA control
+            # port — so a network camera's "auto" never grabs an unrelated
+            # USB-serial device.
+            backend = build_backend(
+                self.config.ptz, ndi_name=ndi_name, is_usb=(src_type == "usb")
+            )
             if backend is None:
                 return
             self._ptz_backend = backend

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3068,9 +3068,7 @@ class CameraWorker:
             # Only USB/UVC sources auto-probe serial ports for a VISCA control
             # port — so a network camera's "auto" never grabs an unrelated
             # USB-serial device.
-            backend = build_backend(
-                self.config.ptz, ndi_name=ndi_name, is_usb=(src_type == "usb")
-            )
+            backend = build_backend(self.config.ptz, ndi_name=ndi_name, is_usb=(src_type == "usb"))
             if backend is None:
                 return
             self._ptz_backend = backend

--- a/autoptz/engine/ptz/factory.py
+++ b/autoptz/engine/ptz/factory.py
@@ -18,6 +18,7 @@ also returns ``None``.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -108,6 +109,18 @@ def _build_visca_usb(ptz: PTZConfig) -> PTZBackend | None:
     return backend
 
 
+def _serial_autoprobe_enabled() -> bool:
+    """Whether ``auto`` may scan serial ports for a VISCA-USB camera.
+
+    On by default; set ``AUTOPTZ_PTZ_SERIAL_AUTOPROBE=0`` to disable.  Discovery
+    opens real serial ports, so the test suite sets this off (a conftest fixture)
+    to keep worker startup from touching hardware, and users on machines with
+    unrelated serial peripherals can opt out.
+    """
+    val = os.environ.get("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
 def _autodetect_visca_usb(ptz: PTZConfig) -> PTZBackend | None:
     """Scan serial ports for a VISCA camera and build a backend, or ``None``.
 
@@ -115,6 +128,10 @@ def _autodetect_visca_usb(ptz: PTZConfig) -> PTZBackend | None:
     VISCA version inquiry and, on a hit, opens a :class:`ViscaUSBBackend` at the
     detected baud.  Never raises.
     """
+    if not _serial_autoprobe_enabled():
+        log.debug("PTZ serial auto-probe disabled (AUTOPTZ_PTZ_SERIAL_AUTOPROBE); skipping.")
+        return None
+
     from autoptz.engine.ptz.visca_serial import discover_visca_usb
     from autoptz.engine.ptz.visca_usb import ViscaUSBBackend
 

--- a/autoptz/engine/ptz/factory.py
+++ b/autoptz/engine/ptz/factory.py
@@ -36,6 +36,7 @@ def build_backend(
     *,
     ndi_source: Any | None = None,
     ndi_name: str | None = None,
+    is_usb: bool = False,
 ) -> PTZBackend | None:
     """Construct the PTZ backend described by *ptz*, or ``None``.
 
@@ -47,6 +48,10 @@ def build_backend(
                     backend opens its own low-bandwidth PTZ receiver to it.  This
                     is what makes NDI cameras controllable without threading the
                     video receiver through (the video adapter keeps its own).
+        is_usb:     True when the camera's *video* source is a USB/UVC device.
+                    Only then does ``auto`` probe serial ports for a companion
+                    VISCA control port — so a network camera's ``auto`` never
+                    grabs an unrelated USB-serial device.
 
     Returns:
         A :class:`PTZBackend` instance, or ``None`` when unconfigured / the
@@ -59,7 +64,7 @@ def build_backend(
 
     try:
         if backend in ("", "auto"):
-            return _probe_auto(ptz, ndi_source=ndi_source, ndi_name=ndi_name)
+            return _probe_auto(ptz, ndi_source=ndi_source, ndi_name=ndi_name, is_usb=is_usb)
         if backend == "visca_usb":
             return _build_visca_usb(ptz)
         if backend == "visca_ip":
@@ -93,12 +98,46 @@ def _build_visca_usb(ptz: PTZConfig) -> PTZBackend | None:
     if not port:
         log.warning("visca_usb requested but no serial port in address; PTZ disabled.")
         return None
+    baud = int(getattr(ptz, "baud", 9600) or 9600)
     try:
-        backend = ViscaUSBBackend(port)
+        backend = ViscaUSBBackend(port, baud=baud)
     except Exception:  # noqa: BLE001 - pyserial missing / port not present
-        log.warning("ViscaUSB %s unavailable; PTZ disabled.", port, exc_info=True)
+        log.warning("ViscaUSB %s @ %d unavailable; PTZ disabled.", port, baud, exc_info=True)
         return None
-    log.info("PTZ backend: VISCA-USB on %s", port)
+    log.info("PTZ backend: VISCA-USB on %s @ %d baud", port, baud)
+    return backend
+
+
+def _autodetect_visca_usb(ptz: PTZConfig) -> PTZBackend | None:
+    """Scan serial ports for a VISCA camera and build a backend, or ``None``.
+
+    Used by ``auto`` on USB cameras: probes USB-serial ports with a read-only
+    VISCA version inquiry and, on a hit, opens a :class:`ViscaUSBBackend` at the
+    detected baud.  Never raises.
+    """
+    from autoptz.engine.ptz.visca_serial import discover_visca_usb
+    from autoptz.engine.ptz.visca_usb import ViscaUSBBackend
+
+    try:
+        found = discover_visca_usb()
+    except Exception:  # noqa: BLE001 - discovery is best-effort
+        log.debug("VISCA-USB serial discovery failed", exc_info=True)
+        return None
+    if found is None:
+        log.debug("PTZ auto-probe: USB camera but no VISCA serial port found; PTZ disabled.")
+        return None
+    port, baud = found
+    try:
+        backend = ViscaUSBBackend(port, baud=baud)
+    except Exception:  # noqa: BLE001 - port grabbed by another worker / vanished
+        log.warning(
+            "VISCA-USB auto-detected on %s @ %d but could not open; PTZ disabled.",
+            port,
+            baud,
+            exc_info=True,
+        )
+        return None
+    log.info("PTZ backend: VISCA-USB auto-detected on %s @ %d baud", port, baud)
     return backend
 
 
@@ -168,14 +207,19 @@ def _build_digital(ptz: PTZConfig) -> PTZBackend | None:
 
 
 def _probe_auto(
-    ptz: PTZConfig, *, ndi_source: Any | None, ndi_name: str | None = None
+    ptz: PTZConfig,
+    *,
+    ndi_source: Any | None,
+    ndi_name: str | None = None,
+    is_usb: bool = False,
 ) -> PTZBackend | None:
     """Best-effort backend discovery for ``backend="auto"``.
 
     Order:
       1. An NDI source/name → NDI PTZ (own or shared receiver).
-      2. An address present → try ONVIF, then VISCA-IP.
-      3. Nothing probable → ``None`` (manual PTZ no-ops; auto control disabled).
+      2. A USB camera with no address → scan serial ports for VISCA-USB.
+      3. An address present → try ONVIF, then VISCA-IP.
+      4. Nothing probable → ``None`` (manual PTZ no-ops; auto control disabled).
     """
     if ndi_source is not None or (ndi_name or "").strip():
         ndi = _build_ndi(ptz, ndi_source=ndi_source, ndi_name=ndi_name)
@@ -184,6 +228,11 @@ def _probe_auto(
 
     addr = (ptz.address or "").strip()
     if not addr:
+        # A USB/UVC camera may carry a companion VISCA serial control port.
+        if is_usb:
+            usb = _autodetect_visca_usb(ptz)
+            if usb is not None:
+                return usb
         log.debug("PTZ auto-probe: no NDI source and no address; PTZ disabled.")
         return None
 

--- a/autoptz/engine/ptz/visca_serial.py
+++ b/autoptz/engine/ptz/visca_serial.py
@@ -1,0 +1,128 @@
+"""Safe VISCA-over-USB serial auto-discovery.
+
+A USB PTZ camera typically presents **two** USB interfaces: a UVC *video* device
+(opened by the frame source) and a companion USB-serial *control* port — e.g.
+``/dev/cu.usbserial-XXXX`` (macOS), ``/dev/ttyUSB0`` (Linux), or ``COM3``
+(Windows) — that speaks VISCA.  Auto-probe never tried serial ports, so a plain
+USB camera got no PTZ backend and every move/menu command silently no-op'd.
+
+This module finds that port without moving the camera: it sends the VISCA
+``CAM_VersionInq`` (``81 09 00 02 FF``) — a read-only inquiry — and treats a port
+as a VISCA camera only when it answers with a valid completion frame.  It also
+detects the **baud** the camera answers on (many newer USB PTZ cameras run at
+115200 and silently ignore everything at the legacy 9600 default).
+
+Everything here is best-effort and must never raise into the engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import serial  # pyserial — already in requirements/base.txt
+from serial import SerialException
+from serial.tools import list_ports
+
+log = logging.getLogger(__name__)
+
+# CAM_VersionInq — a read-only inquiry that does NOT move the camera.
+_VISCA_VERSION_INQ = bytes([0x81, 0x09, 0x00, 0x02, 0xFF])
+
+# Bauds to try, in order.  9600 is the classic Sony/VISCA default; 115200 is
+# common on modern USB PTZ heads; 38400 is the occasional middle ground.
+DEFAULT_BAUDS: tuple[int, ...] = (9600, 115200, 38400)
+
+# Substrings (case-insensitive) that mark a real USB-serial adapter.  We never
+# poke Bluetooth, debug-console, or other virtual ports.
+_PORT_INCLUDE = ("usbserial", "usbmodem", "wchusbserial", "slab", "ttyusb", "ttyacm", "ftdi")
+_PORT_EXCLUDE = ("bluetooth", "debug-console", "debug-modem")
+
+
+def is_visca_reply(data: bytes) -> bool:
+    """True if *data* looks like a VISCA reply frame.
+
+    A VISCA reply starts with an address byte ``z0`` where ``z`` is ``9``–``F``
+    (camera address 1–7 → ``0x90``–``0xF0``) and ends with the ``0xFF``
+    terminator.  Requiring both makes a false positive from line noise unlikely.
+    """
+    return bool(data) and data[-1] == 0xFF and (data[0] & 0xF0) >= 0x90
+
+
+def probe_visca_baud(
+    port: str,
+    bauds: tuple[int, ...] = DEFAULT_BAUDS,
+    *,
+    settle_s: float = 0.25,
+    open_timeout_s: float = 0.5,
+    read_bytes: int = 16,
+) -> int | None:
+    """Return the first baud at which *port* answers a VISCA version inquiry.
+
+    Opens *port* at each baud, sends the (non-moving) ``CAM_VersionInq``, and
+    returns that baud when a valid VISCA reply comes back.  Returns ``None`` if
+    no baud answers, the port is busy, or the port is absent.  Never raises.
+    """
+    for baud in bauds:
+        ser = None
+        try:
+            ser = serial.Serial(port, baud, timeout=open_timeout_s)
+            ser.reset_input_buffer()
+            ser.write(_VISCA_VERSION_INQ)
+            time.sleep(settle_s)
+            pending = ser.in_waiting
+            data = ser.read(pending if pending else read_bytes)
+            if is_visca_reply(data):
+                log.debug("VISCA reply on %s @ %d baud: %s", port, baud, data.hex(" "))
+                return baud
+        except (SerialException, OSError) as exc:
+            log.debug("VISCA probe %s @ %d failed: %s", port, baud, exc)
+        except Exception:  # noqa: BLE001 — discovery must never raise
+            log.debug("VISCA probe %s @ %d errored", port, baud, exc_info=True)
+        finally:
+            if ser is not None:
+                try:
+                    ser.close()
+                except Exception:  # noqa: BLE001
+                    pass
+    return None
+
+
+def candidate_ports() -> list[str]:
+    """Enumerate serial ports that look like USB-serial adapters.
+
+    Filters out Bluetooth / debug / other virtual ports so we never write to
+    something that isn't a camera.  Best-effort: returns ``[]`` if enumeration
+    is unavailable.
+    """
+    try:
+        ports = list(list_ports.comports())
+    except Exception:  # noqa: BLE001
+        log.debug("serial port enumeration failed", exc_info=True)
+        return []
+    out: list[str] = []
+    for info in ports:
+        dev = getattr(info, "device", "") or ""
+        low = dev.lower()
+        if any(bad in low for bad in _PORT_EXCLUDE):
+            continue
+        if low.startswith("com") or any(tok in low for tok in _PORT_INCLUDE):
+            out.append(dev)
+    return out
+
+
+def discover_visca_usb(
+    *,
+    bauds: tuple[int, ...] = DEFAULT_BAUDS,
+    settle_s: float = 0.25,
+) -> tuple[str, int] | None:
+    """Scan USB-serial ports for a VISCA camera; return ``(port, baud)`` or ``None``.
+
+    Returns the first port that answers a VISCA version inquiry.  Never raises.
+    """
+    for port in candidate_ports():
+        baud = probe_visca_baud(port, bauds, settle_s=settle_s)
+        if baud is not None:
+            log.info("Discovered VISCA-USB camera on %s @ %d baud", port, baud)
+            return port, baud
+    return None

--- a/autoptz/ui/widgets/properties_panel.py
+++ b/autoptz/ui/widgets/properties_panel.py
@@ -692,6 +692,25 @@ class PropertiesPanel(QWidget):
                 ),
             ),
         )
+        self._ptz_baud = QComboBox()
+        self._ptz_baud.setEditable(True)
+        self._ptz_baud.addItems(["9600", "38400", "115200"])
+        self._ptz_baud.setToolTip(
+            "VISCA-USB serial baud. 9600 suits most Sony cameras; many newer USB "
+            "PTZ cameras use 115200. Ignored by non-USB backends."
+        )
+        self._ptz_baud.currentTextChanged.connect(self._schedule)
+        apf.addRow(
+            "Baud (USB)",
+            _with_chip(
+                self._ptz_baud,
+                HelpBadge(
+                    "Serial speed for a VISCA-USB camera. If a USB camera doesn't move, "
+                    "try 115200 — a camera set to the wrong baud silently ignores every "
+                    "command. On the 'auto' backend this is detected for you."
+                ),
+            ),
+        )
         adv_ptz.add_widget(_wrap(apf))
         pz.add_widget(adv_ptz)
 
@@ -1371,6 +1390,7 @@ class PropertiesPanel(QWidget):
             _set_combo(self._backend, "auto" if is_center_stage else backend)
             self._backend.setEnabled(not is_center_stage)
             self._ptz_address.setText(pz.get("address") or "")
+            self._ptz_baud.setCurrentText(str(pz.get("baud", 9600)))
             self._auto_zoom.setChecked(bool(pz.get("auto_zoom", True)))
             self._vcam_out.setChecked(bool(pz.get("vcam_out", False)))
             # Advanced tracking tuning (sliders store hundredths of the cfg value).
@@ -1572,6 +1592,10 @@ class PropertiesPanel(QWidget):
             "digital" if self._center_stage.isChecked() else self._backend.currentText()
         )
         cfg["ptz"]["address"] = self._ptz_address.text().strip() or None
+        try:
+            cfg["ptz"]["baud"] = int(str(self._ptz_baud.currentText()).strip())
+        except (TypeError, ValueError):
+            cfg["ptz"]["baud"] = 9600
         cfg["ptz"]["auto_zoom"] = self._auto_zoom.isChecked()
         cfg["ptz"]["vcam_out"] = self._vcam_out.isChecked()
         cfg["ptz"]["zoom_framing"] = framing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,18 @@ if TYPE_CHECKING:
     from pytest import ExitCode, Session
 
 
+@pytest.fixture(autouse=True)
+def _no_serial_autoprobe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never open real serial ports during tests.
+
+    A USB camera's ``auto`` PTZ backend scans serial ports for a VISCA control
+    port at worker startup; on CI that opens host serial devices and stalls the
+    worker thread (breaking timing-sensitive tests). Disable it globally; the
+    tests that exercise the probe path re-enable it explicitly.
+    """
+    monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "0")
+
+
 @pytest.fixture(scope="session")
 def qapp() -> Generator[object]:
     """One process-wide Qt application object for headless tests."""

--- a/tests/test_ptz_factory.py
+++ b/tests/test_ptz_factory.py
@@ -247,6 +247,7 @@ class TestAutoSerialProbe:
     """``auto`` backend on a USB-source camera auto-discovers a VISCA serial port."""
 
     def test_usb_auto_discovers_visca_serial(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "1")
         seen: dict[str, object] = {}
 
         def fake_ctor(port, *a, **k):
@@ -265,6 +266,7 @@ class TestAutoSerialProbe:
         assert seen["baud"] == 115200
 
     def test_usb_auto_no_serial_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "1")
         monkeypatch.setattr(
             "autoptz.engine.ptz.visca_serial.discover_visca_usb", lambda **k: None
         )
@@ -273,6 +275,7 @@ class TestAutoSerialProbe:
     def test_non_usb_auto_never_probes_serial(self, monkeypatch) -> None:
         # A non-USB auto camera (e.g. an NDI/RTSP source with no address) must not
         # scan serial ports — that risks grabbing another camera's control port.
+        monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "1")
         called = {"n": 0}
 
         def spy(**k):
@@ -281,6 +284,21 @@ class TestAutoSerialProbe:
 
         monkeypatch.setattr("autoptz.engine.ptz.visca_serial.discover_visca_usb", spy)
         assert build_backend(_cfg(backend="auto", address=None), is_usb=False) is None
+        assert called["n"] == 0
+
+    def test_serial_autoprobe_disabled_by_env(self, monkeypatch) -> None:
+        # AUTOPTZ_PTZ_SERIAL_AUTOPROBE=0 must skip discovery entirely — no real
+        # serial ports get opened. This keeps the worker-startup path (and the
+        # whole test suite) from touching hardware, the root of the CI regression.
+        monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "0")
+        called = {"n": 0}
+
+        def spy(**k):
+            called["n"] += 1
+            return ("/dev/cu.usbserial-21310", 115200)
+
+        monkeypatch.setattr("autoptz.engine.ptz.visca_serial.discover_visca_usb", spy)
+        assert build_backend(_cfg(backend="auto", address=None), is_usb=True) is None
         assert called["n"] == 0
 
 

--- a/tests/test_ptz_factory.py
+++ b/tests/test_ptz_factory.py
@@ -267,9 +267,7 @@ class TestAutoSerialProbe:
 
     def test_usb_auto_no_serial_returns_none(self, monkeypatch) -> None:
         monkeypatch.setenv("AUTOPTZ_PTZ_SERIAL_AUTOPROBE", "1")
-        monkeypatch.setattr(
-            "autoptz.engine.ptz.visca_serial.discover_visca_usb", lambda **k: None
-        )
+        monkeypatch.setattr("autoptz.engine.ptz.visca_serial.discover_visca_usb", lambda **k: None)
         assert build_backend(_cfg(backend="auto", address=None), is_usb=True) is None
 
     def test_non_usb_auto_never_probes_serial(self, monkeypatch) -> None:

--- a/tests/test_ptz_factory.py
+++ b/tests/test_ptz_factory.py
@@ -91,6 +91,21 @@ class TestFactoryDispatch:
     def test_visca_usb_no_address_returns_none(self) -> None:
         assert build_backend(_cfg(backend="visca_usb", address=None)) is None
 
+    def test_visca_usb_dispatch_passes_baud(self, monkeypatch) -> None:
+        # The configured baud must reach the backend ctor — a camera that speaks
+        # VISCA at 115200 silently ignores every byte at the old hardcoded 9600.
+        seen: dict[str, object] = {}
+
+        def fake_ctor(port, *a, **k):
+            seen["port"] = port
+            seen["baud"] = k.get("baud", (a[0] if a else None))
+            return RecordingBackend()
+
+        monkeypatch.setattr("autoptz.engine.ptz.visca_usb.ViscaUSBBackend", fake_ctor)
+        b = build_backend(_cfg(backend="visca_usb", address="/dev/tty.usbserial", baud=115200))
+        assert b is not None
+        assert seen["baud"] == 115200
+
     def test_visca_ip_dispatch_with_port(self, monkeypatch) -> None:
         seen: dict[str, object] = {}
 
@@ -226,6 +241,55 @@ class TestAutoProbe:
             lambda *a, **k: (_ for _ in ()).throw(OSError()),
         )
         assert build_backend(_cfg(backend="auto", address="192.168.0.10")) is None
+
+
+class TestAutoSerialProbe:
+    """``auto`` backend on a USB-source camera auto-discovers a VISCA serial port."""
+
+    def test_usb_auto_discovers_visca_serial(self, monkeypatch) -> None:
+        seen: dict[str, object] = {}
+
+        def fake_ctor(port, *a, **k):
+            seen["port"] = port
+            seen["baud"] = k.get("baud")
+            return RecordingBackend()
+
+        monkeypatch.setattr("autoptz.engine.ptz.visca_usb.ViscaUSBBackend", fake_ctor)
+        monkeypatch.setattr(
+            "autoptz.engine.ptz.visca_serial.discover_visca_usb",
+            lambda **k: ("/dev/cu.usbserial-21310", 115200),
+        )
+        b = build_backend(_cfg(backend="auto", address=None), is_usb=True)
+        assert b is not None
+        assert seen["port"] == "/dev/cu.usbserial-21310"
+        assert seen["baud"] == 115200
+
+    def test_usb_auto_no_serial_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "autoptz.engine.ptz.visca_serial.discover_visca_usb", lambda **k: None
+        )
+        assert build_backend(_cfg(backend="auto", address=None), is_usb=True) is None
+
+    def test_non_usb_auto_never_probes_serial(self, monkeypatch) -> None:
+        # A non-USB auto camera (e.g. an NDI/RTSP source with no address) must not
+        # scan serial ports — that risks grabbing another camera's control port.
+        called = {"n": 0}
+
+        def spy(**k):
+            called["n"] += 1
+            return ("/dev/cu.usbserial-21310", 115200)
+
+        monkeypatch.setattr("autoptz.engine.ptz.visca_serial.discover_visca_usb", spy)
+        assert build_backend(_cfg(backend="auto", address=None), is_usb=False) is None
+        assert called["n"] == 0
+
+
+class TestBaudModel:
+    def test_default_baud_is_9600(self) -> None:
+        assert PTZConfig().baud == 9600
+
+    def test_baud_is_configurable(self) -> None:
+        assert _cfg(baud=115200).baud == 115200
 
 
 class TestAddressParsing:

--- a/tests/test_visca_serial.py
+++ b/tests/test_visca_serial.py
@@ -1,0 +1,171 @@
+"""VISCA-over-USB serial auto-discovery.
+
+A USB PTZ camera presents a UVC *video* device plus a companion USB-serial
+control port (e.g. ``/dev/cu.usbserial-XXXX``) that speaks VISCA.  These tests
+cover the safe, non-moving discovery used to auto-wire such a camera:
+
+* ``is_visca_reply`` — recognising a VISCA completion frame.
+* ``probe_visca_baud`` — sending a (non-moving) version inquiry and detecting
+  the baud the camera actually answers on.
+* ``candidate_ports`` — filtering enumerated serial ports down to USB-serial
+  adapters (never Bluetooth / debug / virtual ports).
+* ``discover_visca_usb`` — scanning candidates and returning ``(port, baud)``.
+
+Everything is mocked — no real serial port is opened.
+"""
+
+from __future__ import annotations
+
+from autoptz.engine.ptz import visca_serial
+
+# A real CAM_VersionInq completion captured from hardware (vendor 0x0001 …).
+_REAL_REPLY = bytes([0x90, 0x50, 0x00, 0x01, 0x05, 0x04, 0x01, 0x04, 0x02, 0xFF])
+
+
+def _fake_serial(good: dict[str, int] | None = None, busy: set[str] | None = None):
+    """Build a ``serial.Serial`` stand-in.
+
+    ``good`` maps ``port -> baud`` that replies with a VISCA frame; opening a
+    port in ``busy`` raises (already in use); every other (port, baud) opens but
+    stays silent.
+    """
+    good = good or {}
+    busy = busy or set()
+
+    class _FakeSerial:
+        def __init__(self, port, baud, timeout=None):
+            if port in busy:
+                raise OSError(f"{port} busy")
+            self.port = port
+            self.baud = baud
+            self._out = _REAL_REPLY if good.get(port) == baud else b""
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, data):
+            pass
+
+        @property
+        def in_waiting(self):
+            return len(self._out)
+
+        def read(self, n):
+            chunk, self._out = self._out[:n], self._out[n:]
+            return chunk
+
+        def close(self):
+            pass
+
+    return _FakeSerial
+
+
+class _Port:
+    """Minimal ``serial.tools.list_ports`` ListPortInfo stand-in."""
+
+    def __init__(self, device: str) -> None:
+        self.device = device
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_visca_reply
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsViscaReply:
+    def test_accepts_real_completion_frame(self) -> None:
+        assert visca_serial.is_visca_reply(_REAL_REPLY) is True
+
+    def test_rejects_empty(self) -> None:
+        assert visca_serial.is_visca_reply(b"") is False
+
+    def test_rejects_missing_terminator(self) -> None:
+        assert visca_serial.is_visca_reply(bytes([0x90, 0x50, 0x00])) is False
+
+    def test_rejects_non_camera_address_byte(self) -> None:
+        # 0x80 is not a valid VISCA reply address (must be 0x90..0xF0).
+        assert visca_serial.is_visca_reply(bytes([0x80, 0x50, 0xFF])) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# probe_visca_baud
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestProbeViscaBaud:
+    def test_returns_baud_that_replies(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            visca_serial, "serial", type("S", (), {"Serial": _fake_serial({"/dev/x": 115200})})
+        )
+        baud = visca_serial.probe_visca_baud("/dev/x", (9600, 115200, 38400), settle_s=0.0)
+        assert baud == 115200
+
+    def test_tries_bauds_in_order_and_short_circuits(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            visca_serial, "serial", type("S", (), {"Serial": _fake_serial({"/dev/x": 9600})})
+        )
+        baud = visca_serial.probe_visca_baud("/dev/x", (9600, 115200, 38400), settle_s=0.0)
+        assert baud == 9600
+
+    def test_returns_none_when_silent(self, monkeypatch) -> None:
+        monkeypatch.setattr(visca_serial, "serial", type("S", (), {"Serial": _fake_serial({})}))
+        assert visca_serial.probe_visca_baud("/dev/x", (9600, 115200), settle_s=0.0) is None
+
+    def test_returns_none_when_port_busy(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            visca_serial, "serial", type("S", (), {"Serial": _fake_serial({}, busy={"/dev/x"})})
+        )
+        assert visca_serial.probe_visca_baud("/dev/x", (9600, 115200), settle_s=0.0) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# candidate_ports — filter to USB-serial adapters only
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCandidatePorts:
+    def test_includes_usbserial_excludes_bluetooth_and_debug(self, monkeypatch) -> None:
+        ports = [
+            _Port("/dev/cu.Bluetooth-Incoming-Port"),
+            _Port("/dev/cu.debug-console"),
+            _Port("/dev/cu.usbserial-21310"),
+            _Port("/dev/cu.usbmodem1234"),
+        ]
+        monkeypatch.setattr(visca_serial.list_ports, "comports", lambda: ports)
+        got = visca_serial.candidate_ports()
+        assert "/dev/cu.usbserial-21310" in got
+        assert "/dev/cu.usbmodem1234" in got
+        assert "/dev/cu.Bluetooth-Incoming-Port" not in got
+        assert "/dev/cu.debug-console" not in got
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# discover_visca_usb — scan candidates, return (port, baud)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDiscoverViscaUsb:
+    def test_returns_first_visca_port_and_baud(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            visca_serial,
+            "candidate_ports",
+            lambda: ["/dev/cu.usbserial-1", "/dev/cu.usbserial-2"],
+        )
+        monkeypatch.setattr(
+            visca_serial,
+            "serial",
+            type("S", (), {"Serial": _fake_serial({"/dev/cu.usbserial-2": 115200})}),
+        )
+        assert visca_serial.discover_visca_usb(bauds=(9600, 115200), settle_s=0.0) == (
+            "/dev/cu.usbserial-2",
+            115200,
+        )
+
+    def test_returns_none_when_no_candidates(self, monkeypatch) -> None:
+        monkeypatch.setattr(visca_serial, "candidate_ports", lambda: [])
+        assert visca_serial.discover_visca_usb(settle_s=0.0) is None
+
+    def test_returns_none_when_no_port_speaks_visca(self, monkeypatch) -> None:
+        monkeypatch.setattr(visca_serial, "candidate_ports", lambda: ["/dev/cu.usbserial-1"])
+        monkeypatch.setattr(visca_serial, "serial", type("S", (), {"Serial": _fake_serial({})}))
+        assert visca_serial.discover_visca_usb(bauds=(9600, 115200), settle_s=0.0) is None


### PR DESCRIPTION
## Problem

A USB PTZ camera presents a **UVC video** device plus a companion **USB-serial control port** that speaks VISCA. Two stacked bugs meant USB PTZ was completely dead:

1. **`auto` probe never scanned serial ports.** A USB camera defaults to `PTZConfig(backend="auto", address=None)`. The probe only tried NDI (no source) then needed an IP address (none) → returned `None` → no backend → every move command **and** the Menu button silently no-op'd.
2. **Wrong baud, no override.** `ViscaUSBBackend` hardcoded 9600, but many USB PTZ cameras run at **115200** and silently ignore every byte at the wrong rate. There was no baud field, so even explicit `visca_usb` config failed silently.

## Changes

- **New `engine/ptz/visca_serial.py`** — safe discovery: scans USB-serial ports (skips Bluetooth/debug), sends a **read-only** VISCA `CAM_VersionInq` (`81 09 00 02 FF`, non-moving), and auto-detects the baud the camera answers on.
- **`factory.build_backend(is_usb=...)`** — gates serial probing to USB sources so a network camera's `auto` never grabs an unrelated serial device; explicit `visca_usb` now passes the configured baud.
- **`PTZConfig.baud`** (default 9600, back-compat) + a **"Baud (USB)"** override in Advanced → PTZ.
- **`camera_worker`** passes `is_usb` from the source type.

The **Menu button fixes itself on USB** — once a backend exists, `osd_menu()` rides the same proven `_send` path. (NDI menu is a protocol limitation, tracked separately.)

## Verification

- Full suite **1113 passed**, ruff clean.
- New tests (test-first): serial discovery, baud config, USB auto-detect gating.
- **Real hardware:** `discover_visca_usb()` → `('/dev/cu.usbserial-21310', 115200)`; pan/tilt/zoom all physically move via the production code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)