### PR TITLE
fix(update): distinct check states, loading indicator, Intel TLS + arch safety

### DIFF
--- a/autoptz/ui/update_manager.py
+++ b/autoptz/ui/update_manager.py
@@ -21,7 +21,7 @@ _CHECK_INTERVAL_S = 24 * 3600
 
 
 class _CheckSignals(QObject):
-    finished = Signal(object, bool)  # (UpdateInfo | None, manual)
+    finished = Signal(object, bool)  # (CheckResult, manual)
 
 
 class _DownloadSignals(QObject):
@@ -41,14 +41,16 @@ class _CheckTask(QRunnable):
         self._signals = signals
 
     def run(self) -> None:
-        from autoptz.update.checker import check_for_update
+        from autoptz.update.checker import CheckResult, check_for_update_result
 
         try:
-            info = check_for_update(self._current, include_prereleases=self._pre)
-        except Exception:  # noqa: BLE001 — never let a worker crash the pool
+            result = check_for_update_result(self._current, include_prereleases=self._pre)
+        except Exception as exc:  # noqa: BLE001 — never let a worker crash the pool
             log.debug("update check task failed", exc_info=True)
-            info = None
-        self._signals.finished.emit(info, self._manual)
+            result = CheckResult(
+                status="failed", error_kind="network", error=str(exc) or "Update check failed."
+            )
+        self._signals.finished.emit(result, self._manual)
 
 
 class _DownloadTask(QRunnable):
@@ -75,8 +77,10 @@ class _DownloadTask(QRunnable):
 class UpdateManager(QObject):
     """Owns update-check scheduling, settings, and result routing."""
 
+    checkStarted = Signal(bool)  # manual? — a check just began (show "Checking…")
     updateAvailable = Signal(object)  # UpdateInfo
     upToDate = Signal(bool)  # manual?
+    checkFailed = Signal(str, bool)  # (reason, manual?) — distinct from upToDate
     downloadStarted = Signal(object)  # UpdateInfo
     downloadProgress = Signal(int, int)  # (bytes_downloaded, total_bytes)
     downloadFinished = Signal(object)  # DownloadedUpdate
@@ -141,7 +145,9 @@ class UpdateManager(QObject):
         self._start(manual=True)
 
     def _start(self, *, manual: bool) -> None:
-        self._set("update_last_check", time.time())
+        # NB: the 24h throttle is stamped on SUCCESS (in _on_finished), not here —
+        # a failed/offline check must not suppress the next startup retry.
+        self.checkStarted.emit(manual)
         task = _CheckTask(self._current, self.include_prereleases, manual, self._signals)
         QThreadPool.globalInstance().start(task)
 
@@ -152,10 +158,25 @@ class UpdateManager(QObject):
         QThreadPool.globalInstance().start(task)
 
     @Slot(object, bool)
-    def _on_finished(self, info: object, manual: bool) -> None:
-        if info is None:
+    def _on_finished(self, result: object, manual: bool) -> None:
+        status = getattr(result, "status", "failed")
+
+        # A failed check is reported as such — never as "up to date" — and does
+        # NOT arm the 24h throttle, so the next launch retries.
+        if status == "failed":
+            reason = str(getattr(result, "error", "") or "The update check could not be completed.")
+            log.info("update check failed (%s): %s", getattr(result, "error_kind", "?"), reason)
+            self.checkFailed.emit(reason, manual)
+            return
+
+        # Successful check (up-to-date or update-available) → remember when.
+        self._set("update_last_check", time.time())
+
+        if status != "update_available":
             self.upToDate.emit(manual)
             return
+
+        info = getattr(result, "info", None)
         version = getattr(info, "version", "")
         if not manual:
             skip = str(self._get("update_skip_version", "") or "")

--- a/autoptz/ui/widgets/main_window.py
+++ b/autoptz/ui/widgets/main_window.py
@@ -98,13 +98,16 @@ class MainWindow(QMainWindow):
         from autoptz.ui.update_manager import UpdateManager
 
         self._updates = UpdateManager(client, _app_version(), self)
+        self._updates.checkStarted.connect(self._on_update_check_started)
         self._updates.updateAvailable.connect(self._on_update_available)
         self._updates.upToDate.connect(self._on_up_to_date)
+        self._updates.checkFailed.connect(self._on_update_check_failed)
         self._updates.downloadStarted.connect(self._on_update_download_started)
         self._updates.downloadProgress.connect(self._on_update_download_progress)
         self._updates.downloadFinished.connect(self._on_update_download_finished)
         self._updates.downloadFailed.connect(self._on_update_download_failed)
         self._update_progress: Any | None = None
+        self._update_check_busy: Any | None = None
         self._startup_update_checked = False
 
         self._build_central()
@@ -842,6 +845,7 @@ class MainWindow(QMainWindow):
         self._open_model_manager(startup_prompt=True, selected_keys=missing)
 
     def _on_update_available(self, info: Any) -> None:
+        self._set_update_check_busy(False)
         from autoptz import version as _app_version
 
         UpdateDialog(
@@ -928,20 +932,66 @@ class MainWindow(QMainWindow):
             f"{message}\n\nYou can still download the installer from the Releases page.",
         )
 
-    def _on_up_to_date(self, manual: bool) -> None:
-        # Only nag for manual checks; the silent startup check stays silent.
-        if not manual:
-            return
-        from PySide6.QtWidgets import QMessageBox
+    def _on_update_check_started(self, manual: bool) -> None:
+        """Show a 'Checking for updates…' indicator while the check runs."""
+        self._set_update_check_busy(True)
 
+    def _set_update_check_busy(self, on: bool) -> None:
+        """Add/remove an indeterminate progress bar + status message for a check."""
+        if on:
+            if self._update_check_busy is None:
+                bar = QProgressBar()
+                bar.setRange(0, 0)  # indeterminate "working" animation
+                bar.setMaximumWidth(T.fs(120))
+                bar.setMaximumHeight(T.fs(14))
+                bar.setTextVisible(False)
+                self.statusBar().addWidget(bar)
+                self._update_check_busy = bar
+            self.statusBar().showMessage("Checking for updates…")
+        else:
+            bar = self._update_check_busy
+            self._update_check_busy = None
+            if bar is not None:
+                self.statusBar().removeWidget(bar)
+                bar.deleteLater()
+
+    def _on_up_to_date(self, manual: bool) -> None:
+        self._set_update_check_busy(False)
         from autoptz import version as _app_version
 
-        QMessageBox.information(
-            self,
-            "Check for Updates",
-            f"You're up to date.\n\nAutoPTZ {_app_version()} is the latest version "
-            "available (or the update server couldn't be reached).",
-        )
+        if manual:
+            from PySide6.QtWidgets import QMessageBox
+
+            QMessageBox.information(
+                self,
+                "Check for Updates",
+                f"You're on the latest version.\n\nAutoPTZ {_app_version()} is up to date.",
+            )
+        else:
+            # Startup check: visible (so it's clearly working) but unobtrusive.
+            self.statusBar().showMessage(f"AutoPTZ {_app_version()} is up to date.", 6000)
+
+    def _on_update_check_failed(self, reason: str, manual: bool) -> None:
+        self._set_update_check_busy(False)
+        if manual:
+            from PySide6.QtWidgets import QMessageBox
+
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Icon.Warning)
+            box.setWindowTitle("Couldn't Check for Updates")
+            box.setText(reason)
+            box.setInformativeText(
+                "AutoPTZ couldn't reach the update server, so it can't tell whether "
+                "you're on the latest version. Check your internet connection and try again."
+            )
+            retry = box.addButton("Retry", QMessageBox.ButtonRole.AcceptRole)
+            box.addButton("Close", QMessageBox.ButtonRole.RejectRole)
+            box.exec()
+            if box.clickedButton() is retry:
+                self._updates.check_now()
+        else:
+            # Startup check failure: don't interrupt; surface briefly + log.
+            self.statusBar().showMessage("Couldn't check for updates (offline?).", 6000)
 
     # ── saved dock layouts ───────────────────────────────────────────────────────
 

--- a/autoptz/update/checker.py
+++ b/autoptz/update/checker.py
@@ -1,9 +1,17 @@
 """Check GitHub Releases for a newer AutoPTZ version.
 
-Pure and network-tolerant: :func:`check_for_update` never raises — any failure
-(offline, rate-limited, bad JSON) returns ``None`` so the UI simply shows
-"up to date" or nothing. Download/install lives in :mod:`autoptz.update.installer`
-so release parsing stays pure and easy to test.
+:func:`check_for_update_result` never raises and reports a **three-way** outcome
+— update-available / up-to-date / failed(reason) — so the UI can tell "you're on
+the latest" apart from "the check couldn't run" (offline, TLS, rate-limited).
+The legacy :func:`check_for_update` (``UpdateInfo | None``) is kept as a thin
+wrapper for callers that only care about an available update.
+
+HTTPS uses certifi's CA bundle when present so the check works in frozen
+(PyInstaller) builds, where a missing system trust store caused TLS verification
+to fail silently — the root cause of "Intel Macs can't check for updates".
+
+Download/install lives in :mod:`autoptz.update.installer` so release parsing
+stays pure and easy to test.
 """
 
 from __future__ import annotations
@@ -11,10 +19,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import ssl
 import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from typing import Literal
 
 from packaging.version import InvalidVersion, Version
 
@@ -24,6 +34,10 @@ DEFAULT_REPO = "AutoPTZ/autoptz"
 _API_RELEASES = "https://api.github.com/repos/{repo}/releases?per_page=20"
 _TIMEOUT_S = 6.0
 _USER_AGENT = "AutoPTZ-Updater"
+
+#: Why a check failed — drives the user-facing message and whether to retry soon.
+ErrorKind = Literal["network", "timeout", "tls", "rate_limited", "parse", "bad_version"]
+CheckStatus = Literal["update_available", "up_to_date", "failed"]
 
 
 @dataclass(frozen=True)
@@ -39,18 +53,36 @@ class UpdateInfo:
     assets: tuple[tuple[str, str], ...] = ()  # (filename, browser_download_url)
 
     def asset_for_platform(self) -> tuple[str, str] | None:
-        """Return ``(filename, url)`` for this OS (and arch on macOS), or None."""
+        """Return ``(filename, url)`` for this OS (and arch on macOS), or None.
+
+        On macOS this is **architecture-safe**: an Intel Mac never falls back to
+        an arm64-only build (or vice versa) — handing the wrong-arch installer to
+        a user just produces a binary that won't run.  A genuinely arch-agnostic
+        dmg (no ``arm64``/``x86_64`` marker, e.g. an old universal release) is
+        still accepted.
+        """
         if sys.platform == "darwin":
-            # Releases ship separate arm64 and x86_64 dmgs; prefer the one matching
-            # this Mac, falling back to any .dmg (e.g. an older single-arch release).
             import platform
 
             arch = platform.machine().lower()  # "arm64" or "x86_64"
+            if arch == "x86_64":
+                want = ("x86_64", "x64", "intel")
+            elif arch == "arm64":
+                want = ("arm64", "aarch64", "apple", "silicon")
+            else:  # unknown arch → only an exact substring match
+                want = (arch,)
             dmgs = [(n, u) for n, u in self.assets if n.lower().endswith(".dmg")]
+            # 1. An asset that names this architecture.
             for name, url in dmgs:
-                if arch in name.lower():
+                if any(tok in name.lower() for tok in want):
                     return name, url
-            return dmgs[0] if dmgs else None
+            # 2. An arch-agnostic dmg (no arch marker at all) — legacy/universal.
+            markers = ("arm64", "aarch64", "x86_64", "x64", "intel", "apple", "silicon")
+            for name, url in dmgs:
+                if not any(m in name.lower() for m in markers):
+                    return name, url
+            # 3. Only wrong-arch dmgs exist → no safe asset for this Mac.
+            return None
         if sys.platform == "win32":
             exts: tuple[str, ...] = ("setup.exe", ".msi", ".exe")
         else:
@@ -66,23 +98,94 @@ class UpdateInfo:
         return asset[1] if asset else None
 
 
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of an update check.
+
+    ``status`` is one of ``update_available`` / ``up_to_date`` / ``failed``.
+    ``info`` is set only when an update is available; ``error`` / ``error_kind``
+    are set only on failure.
+    """
+
+    status: CheckStatus
+    info: UpdateInfo | None = None
+    error: str | None = None
+    error_kind: ErrorKind | None = None
+
+    @property
+    def has_update(self) -> bool:
+        return self.status == "update_available"
+
+    @property
+    def ok(self) -> bool:
+        """True unless the check failed (i.e. the result is trustworthy)."""
+        return self.status != "failed"
+
+
 def _repo() -> str:
     return os.environ.get("AUTOPTZ_UPDATE_REPO", DEFAULT_REPO)
 
 
-def _fetch_releases() -> list[dict] | None:
+def _ssl_context() -> ssl.SSLContext | None:
+    """Prefer certifi's CA bundle so HTTPS verifies in frozen builds.
+
+    PyInstaller bundles may lack the system trust store, so ``urllib`` could not
+    verify ``api.github.com`` → ``CERTIFICATE_VERIFY_FAILED`` → the check failed
+    silently (notably on Intel macOS).  Falls back to the default context, then
+    to ``None`` (urllib's default) if even that can't be built.
+    """
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:  # noqa: BLE001 — certifi missing → use the system default
+        try:
+            return ssl.create_default_context()
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def _fetch_releases() -> tuple[list[dict] | None, ErrorKind | None, str | None]:
+    """Fetch the releases list. Returns ``(releases, error_kind, error_message)``.
+
+    On success ``error_kind``/``error_message`` are ``None``; on failure
+    ``releases`` is ``None`` and the error is classified for the UI.  Never raises.
+    """
     url = _API_RELEASES.format(repo=_repo())
     req = urllib.request.Request(
         url,
         headers={"User-Agent": _USER_AGENT, "Accept": "application/vnd.github+json"},
     )
+    ctx = _ssl_context()
     try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S, context=ctx) as resp:  # noqa: S310
             data = json.loads(resp.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
-        log.info("update check: fetch failed (%s)", exc)
-        return None
-    return data if isinstance(data, list) else None
+    except urllib.error.HTTPError as exc:
+        if exc.code in (403, 429):
+            return (
+                None,
+                "rate_limited",
+                "GitHub's update API is rate-limited right now. Try again later.",
+            )
+        log.info("update check: HTTP %s", exc.code)
+        return None, "network", f"The update server returned an error (HTTP {exc.code})."
+    except urllib.error.URLError as exc:
+        reason = str(getattr(exc, "reason", exc))
+        if "CERTIFICATE_VERIFY" in reason.upper() or "SSL" in reason.upper():
+            log.info("update check: TLS failure (%s)", reason)
+            return None, "tls", "Couldn't establish a secure connection to the update server."
+        log.info("update check: network failure (%s)", reason)
+        return None, "network", "Couldn't reach the update server. Check your internet connection."
+    except TimeoutError:
+        return None, "timeout", "The update server timed out. Check your internet connection."
+    except ValueError:
+        return None, "parse", "The update server sent an unexpected response."
+    except OSError as exc:
+        log.info("update check: OS error (%s)", exc)
+        return None, "network", "Couldn't reach the update server. Check your internet connection."
+    if not isinstance(data, list):
+        return None, "parse", "The update server sent an unexpected response."
+    return data, None, None
 
 
 def _parse_release(raw: dict) -> tuple[Version, UpdateInfo] | None:
@@ -110,20 +213,24 @@ def _parse_release(raw: dict) -> tuple[Version, UpdateInfo] | None:
     return ver, info
 
 
-def check_for_update(current: str, *, include_prereleases: bool = False) -> UpdateInfo | None:
-    """Return the newest release strictly newer than *current*, else ``None``.
+def check_for_update_result(current: str, *, include_prereleases: bool = False) -> CheckResult:
+    """Check for a newer release and report a three-way :class:`CheckResult`.
 
-    Never raises. ``include_prereleases`` controls whether beta/rc builds count.
+    Never raises.  ``include_prereleases`` controls whether beta/rc builds count.
     """
     try:
         cur = Version(str(current).lstrip("vV"))
     except InvalidVersion:
         log.info("update check: unparseable current version %r", current)
-        return None
+        return CheckResult(
+            status="failed",
+            error_kind="bad_version",
+            error=f"Could not read the running version ({current!r}).",
+        )
 
-    releases = _fetch_releases()
-    if not releases:
-        return None
+    releases, kind, message = _fetch_releases()
+    if releases is None:
+        return CheckResult(status="failed", error_kind=kind, error=message)
 
     best: UpdateInfo | None = None
     best_ver: Version | None = None
@@ -141,4 +248,16 @@ def check_for_update(current: str, *, include_prereleases: bool = False) -> Upda
         if best_ver is None or ver > best_ver:
             best, best_ver = info, ver
 
-    return best
+    if best is not None:
+        return CheckResult(status="update_available", info=best)
+    return CheckResult(status="up_to_date")
+
+
+def check_for_update(current: str, *, include_prereleases: bool = False) -> UpdateInfo | None:
+    """Return the newest release strictly newer than *current*, else ``None``.
+
+    Thin wrapper over :func:`check_for_update_result`; ``None`` covers both
+    "up to date" and "check failed" (use the result form to tell them apart).
+    """
+    result = check_for_update_result(current, include_prereleases=include_prereleases)
+    return result.info if result.has_update else None

--- a/packaging/autoptz.spec
+++ b/packaging/autoptz.spec
@@ -140,9 +140,14 @@ hiddenimports += [
 # ML / engine deps that are imported lazily and may be missed by static analysis.
 for opt in (
     "onnxruntime", "cv2", "numpy", "scipy", "PIL",
-    "msgpack", "pydantic", "serial",
+    "msgpack", "pydantic", "serial", "certifi",
 ):
     hiddenimports.append(opt)
+
+# certifi's CA bundle (cacert.pem) must ship so the updater can verify HTTPS to
+# api.github.com in the frozen app — without it the TLS handshake fails and the
+# update check silently no-ops (the Intel-macOS "can't check for updates" bug).
+datas += collect_data_files("certifi")
 
 # Heavy optional deps: include their submodules ONLY if installed in the build
 # env (keeps a UI-only build from failing the analysis).

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,13 @@ Pillow==12.2.0
 pydantic==2.11.3
 msgpack==1.2.1
 
+# ── networking / TLS ──────────────────────────────────────────────────────────
+# CA bundle for HTTPS. Frozen (PyInstaller) builds can lack the system trust
+# store, so the updater's TLS handshake to api.github.com failed silently —
+# the root cause of "Intel Macs can't check for updates". The checker uses
+# certifi's bundle when present (see autoptz/update/checker._ssl_context).
+certifi==2026.6.17
+
 # ── PTZ control ───────────────────────────────────────────────────────────────
 pyserial==3.5
 visca-over-ip==0.5.1

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -25,7 +25,14 @@ def _release(tag: str, *, prerelease: bool = False, assets: list[str] | None = N
 
 
 def _patch(monkeypatch, releases: list[dict] | None) -> None:
-    monkeypatch.setattr(checker, "_fetch_releases", lambda: releases)
+    # _fetch_releases now returns (releases, error_kind, error_message); None
+    # releases models a network failure.
+    if releases is None:
+        monkeypatch.setattr(
+            checker, "_fetch_releases", lambda: (None, "network", "Couldn't reach the server.")
+        )
+    else:
+        monkeypatch.setattr(checker, "_fetch_releases", lambda: (releases, None, None))
 
 
 def test_newer_stable_returns_info(monkeypatch) -> None:

--- a/tests/test_update_feedback.py
+++ b/tests/test_update_feedback.py
@@ -1,0 +1,227 @@
+"""Update-check feedback: distinct outcomes, error classification, arch safety.
+
+Covers the changes that make the updater observable and correct:
+
+* ``check_for_update_result`` returns a 3-way result — update-available /
+  up-to-date / failed(reason) — instead of collapsing "no update" and "network
+  error" into a single ``None``.
+* Network/timeout/TLS/rate-limit/parse failures are classified with a
+  user-facing message (so the UI can say *why* it failed, not "up to date").
+* ``asset_for_platform`` never hands an Intel Mac an arm64-only build (and vice
+  versa) — it returns ``None`` rather than the wrong architecture.
+* ``UpdateManager`` routes a failed check to ``checkFailed`` (not ``upToDate``),
+  emits ``checkStarted``, and only arms the 24h throttle on a *successful* check.
+"""
+
+from __future__ import annotations
+
+import autoptz.update.checker as checker
+from autoptz.update.checker import CheckResult, UpdateInfo, check_for_update_result
+
+
+def _release(tag: str, *, prerelease: bool = False, assets: list[str] | None = None) -> dict:
+    return {
+        "tag_name": tag,
+        "name": f"AutoPTZ {tag}",
+        "body": "notes",
+        "html_url": f"https://github.com/AutoPTZ/autoptz/releases/tag/{tag}",
+        "prerelease": prerelease,
+        "draft": False,
+        "assets": [
+            {"name": n, "browser_download_url": f"https://example/{n}"} for n in (assets or [])
+        ],
+    }
+
+
+def _ok(monkeypatch, releases: list[dict]) -> None:
+    monkeypatch.setattr(checker, "_fetch_releases", lambda: (releases, None, None))
+
+
+def _fail(monkeypatch, kind: str, msg: str) -> None:
+    monkeypatch.setattr(checker, "_fetch_releases", lambda: (None, kind, msg))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Structured result: update_available / up_to_date / failed
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckResult:
+    def test_update_available(self, monkeypatch) -> None:
+        _ok(monkeypatch, [_release("v2.1.0")])
+        r = check_for_update_result("2.0.0")
+        assert r.status == "update_available"
+        assert r.has_update is True
+        assert isinstance(r.info, UpdateInfo) and r.info.version == "2.1.0"
+
+    def test_up_to_date_is_distinct_from_failure(self, monkeypatch) -> None:
+        _ok(monkeypatch, [_release("v2.0.0")])
+        r = check_for_update_result("2.0.0")
+        assert r.status == "up_to_date"
+        assert r.has_update is False
+        assert r.error is None and r.error_kind is None
+
+    def test_network_failure_is_failed_not_up_to_date(self, monkeypatch) -> None:
+        _fail(monkeypatch, "network", "Couldn't reach the update server.")
+        r = check_for_update_result("2.0.0")
+        assert r.status == "failed"
+        assert r.error_kind == "network"
+        assert r.error and "reach" in r.error.lower()
+
+    def test_tls_failure_classified(self, monkeypatch) -> None:
+        _fail(monkeypatch, "tls", "Couldn't verify a secure connection.")
+        r = check_for_update_result("2.0.0")
+        assert r.status == "failed" and r.error_kind == "tls"
+
+    def test_bad_current_version_is_failed(self, monkeypatch) -> None:
+        _ok(monkeypatch, [_release("v2.1.0")])
+        r = check_for_update_result("not-a-version")
+        assert r.status == "failed" and r.error_kind == "bad_version"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error classification at the fetch boundary
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFetchClassification:
+    def test_tls_error_classified_as_tls(self, monkeypatch) -> None:
+        import urllib.error
+
+        def boom(req, timeout, context=None):  # noqa: ARG001
+            raise urllib.error.URLError(
+                "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+            )
+
+        monkeypatch.setattr(checker.urllib.request, "urlopen", boom)
+        releases, kind, msg = checker._fetch_releases()
+        assert releases is None
+        assert kind == "tls"
+        assert msg
+
+    def test_timeout_classified(self, monkeypatch) -> None:
+        def boom(req, timeout, context=None):  # noqa: ARG001
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(checker.urllib.request, "urlopen", boom)
+        _releases, kind, _msg = checker._fetch_releases()
+        assert kind == "timeout"
+
+    def test_generic_urlerror_is_network(self, monkeypatch) -> None:
+        import urllib.error
+
+        def boom(req, timeout, context=None):  # noqa: ARG001
+            raise urllib.error.URLError("Name or service not known")
+
+        monkeypatch.setattr(checker.urllib.request, "urlopen", boom)
+        _releases, kind, _msg = checker._fetch_releases()
+        assert kind == "network"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Intel-Mac architecture safety
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _info(assets: tuple[tuple[str, str], ...]) -> UpdateInfo:
+    return UpdateInfo(
+        version="2.3.0",
+        tag="v2.3.0",
+        name="x",
+        body="",
+        html_url="https://example/rel",
+        is_prerelease=False,
+        assets=assets,
+    )
+
+
+class TestArchSafety:
+    def test_intel_never_gets_arm64_only_build(self, monkeypatch) -> None:
+        import platform as _platform
+
+        monkeypatch.setattr(checker.sys, "platform", "darwin")
+        monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+        info = _info((("AutoPTZ-2.3.0-macos-arm64.dmg", "https://example/arm"),))
+        # No x86_64 asset → must NOT fall back to the arm64 binary.
+        assert info.asset_for_platform() is None
+
+    def test_arm_never_gets_intel_only_build(self, monkeypatch) -> None:
+        import platform as _platform
+
+        monkeypatch.setattr(checker.sys, "platform", "darwin")
+        monkeypatch.setattr(_platform, "machine", lambda: "arm64")
+        info = _info((("AutoPTZ-2.3.0-macos-x86_64.dmg", "https://example/intel"),))
+        assert info.asset_for_platform() is None
+
+    def test_intel_alias_matches(self, monkeypatch) -> None:
+        import platform as _platform
+
+        monkeypatch.setattr(checker.sys, "platform", "darwin")
+        monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+        info = _info((("AutoPTZ-2.3.0-macos-intel.dmg", "https://example/intel"),))
+        assert info.asset_for_platform() == (
+            "AutoPTZ-2.3.0-macos-intel.dmg",
+            "https://example/intel",
+        )
+
+    def test_unmarked_dmg_still_resolves(self, monkeypatch) -> None:
+        import platform as _platform
+
+        monkeypatch.setattr(checker.sys, "platform", "darwin")
+        monkeypatch.setattr(_platform, "machine", lambda: "x86_64")
+        info = _info((("AutoPTZ-2.0.0.dmg", "https://example/any"),))
+        assert info.asset_for_platform() == ("AutoPTZ-2.0.0.dmg", "https://example/any")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UpdateManager routing + throttle
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _manager(store: dict, current: str = "2.0.0"):
+    from PySide6.QtCore import QCoreApplication
+
+    from autoptz.ui.update_manager import UpdateManager
+
+    if QCoreApplication.instance() is None:
+        QCoreApplication([])
+
+    class _Client:
+        def getSetting(self, key, default):
+            return store.get(key, default)
+
+        def setSetting(self, key, value):
+            store[key] = value
+
+    return UpdateManager(_Client(), current)
+
+
+class TestManagerRouting:
+    def test_failed_check_routes_to_checkFailed_not_upToDate(self, monkeypatch) -> None:
+        mgr = _manager({})
+        seen = {"failed": None, "uptodate": 0}
+        mgr.checkFailed.connect(lambda msg, manual: seen.__setitem__("failed", (msg, manual)))
+        mgr.upToDate.connect(lambda manual: seen.__setitem__("uptodate", seen["uptodate"] + 1))
+        mgr._on_finished(CheckResult(status="failed", error="offline", error_kind="network"), True)
+        assert seen["failed"] == ("offline", True)
+        assert seen["uptodate"] == 0
+
+    def test_up_to_date_routes_to_upToDate(self) -> None:
+        mgr = _manager({})
+        seen = {"uptodate": None}
+        mgr.upToDate.connect(lambda manual: seen.__setitem__("uptodate", manual))
+        mgr._on_finished(CheckResult(status="up_to_date"), True)
+        assert seen["uptodate"] is True
+
+    def test_throttle_not_armed_on_failure(self) -> None:
+        store: dict = {}
+        mgr = _manager(store)
+        mgr._on_finished(CheckResult(status="failed", error="x", error_kind="network"), False)
+        # A failed check must NOT stamp last-check (else startup won't retry for 24h).
+        assert "update_last_check" not in store or not store["update_last_check"]
+
+    def test_throttle_armed_on_success(self) -> None:
+        store: dict = {}
+        mgr = _manager(store)
+        mgr._on_finished(CheckResult(status="up_to_date"), False)
+        assert float(store.get("update_last_check", 0)) > 0


### PR DESCRIPTION
Fixes three real problems with "Check for updates":

## 1. Intel Macs couldn't check at all (root cause: TLS)
Frozen PyInstaller builds can lack a system CA trust store, so `urllib`'s HTTPS handshake to `api.github.com` failed with `CERTIFICATE_VERIFY_FAILED` — and the error was swallowed into a silent `None` that looked like "up to date." Now the checker uses **certifi's CA bundle** (`_ssl_context`), and `certifi` is bundled (requirements + spec `collect_data_files`).

Also: `asset_for_platform` is now **architecture-safe** — an Intel Mac never falls back to an arm64-only build (or vice versa). It returns `None` so the dialog offers the Releases page instead of a binary that won't run. Arch-agnostic/universal dmgs still resolve.

## 2. Startup check "never worked"
- It was **silent** on both up-to-date and error, so unless an update happened to exist you saw nothing. Now a startup check shows a brief, unobtrusive status result — visibly working.
- `_start()` stamped the 24h throttle **before** the check ran, so a failed/offline check blocked the next retry for a day. The throttle is now armed **only on success**.

## 3. Loading bar + distinct states (no more collapsed one-liner)
- A **"Checking for updates…"** indeterminate progress indicator shows while a check runs.
- Three distinct outcomes via a structured `CheckResult` (update_available / up_to_date / **failed-with-reason**): "You're on the latest version" (no "or couldn't reach" caveat), or a **specific** failure ("Couldn't reach the update server / secure-connection / rate-limited…") with a **Retry** button.

## Tests
`tests/test_update_feedback.py` (test-first): 3-way result, error classification (network/timeout/TLS), Intel arch-safety (arm64-only → `None`, intel alias, unmarked dmg), and manager routing/throttle. `test_update.py` updated for the new `_fetch_releases` shape. Full suite green (1141), ruff clean. Verified live against the real GitHub API (TLS via certifi; correct up-to-date and update-available + arch-correct asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)