### PR TITLE
release: 2.2.0-rc5

### DIFF
--- a/autoptz/__init__.py
+++ b/autoptz/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 #: Canonical version string. This is the single source of truth; ``pyproject.toml``
 #: reads it via ``[tool.setuptools.dynamic]`` and the UI imports it at runtime.
-__version__ = "2.2.0-rc4"
+__version__ = "2.2.0-rc5"
 
 
 def version() -> str:


### PR DESCRIPTION
Bumps `__version__` to **2.2.0-rc5** to cut the next release candidate.

Includes since rc4:
- **#105** USB VISCA PTZ auto-detect + configurable baud — fixes USB PTZ movement *and* the Menu button (serial control port auto-detected, e.g. `/dev/cu.usbserial-*` @ 115200).
- **#106** Dynamic error-proportional "catch-up" tracking speed (default 60%) — camera speeds up to catch off-centre/fast subjects, eases to precise near centre.
- **#107** Update-check fixes — distinct up-to-date vs failure states, "Checking…" loading indicator, Intel-macOS TLS/cert root-cause fix (bundles certifi) + architecture-safe asset selection, startup-check retry/visibility.

Tagging `v2.2.0-rc5` after merge triggers the build+publish workflow (macOS arm64+Intel, Windows, Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)