### PR TITLE
fix(engine): crash-safe worker threads + visible hot-path errors

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -142,6 +142,13 @@ _HARVEST_COOLDOWN_S = 2.0
 # spamming a line per missed frame.
 _DROP_LOG_INTERVAL_S = 10.0
 
+# Throttle interval for the per-iteration crash-guard WARNINGs in the capture and
+# inference loops: a persistent fault would otherwise emit a stack trace every
+# tick (~hundreds/s).  At most one WARNING per interval keeps the failure visible
+# without flooding the log.
+_TICK_WARN_INTERVAL_S = 5.0
+_INFER_WARN_INTERVAL_S = 5.0
+
 # Capture idle/reconnect backoff: a stalled, offline, or permission-denied source
 # returns no frame, and a flat 10 ms retry then spins the capture thread at ~100 Hz
 # (real, measurable idle CPU per camera).  Retry fast for a short window to ride out
@@ -628,6 +635,18 @@ class CameraWorker:
         # PTZ command-rate-limit so DEBUG nudge/auto lines don't spam at
         # per-frame rate — only log when the command meaningfully changes.
         self._last_logged_ptz: tuple[float, float, float] | None = None
+
+        # Crash-safety throttles: monotonic timestamp of the last per-iteration
+        # WARNING in the capture / inference loops, so a persistent fault stays
+        # visible without spamming a stack trace every tick.  _infer_last_error
+        # surfaces the most recent inference-stage failure for the Camera Info
+        # panel (cleared implicitly once ticks succeed again and telemetry moves
+        # on).
+        self._last_tick_warn_t = 0.0
+        self._last_infer_warn_t = 0.0
+        self._infer_last_error: str | None = None
+        # Throttle for the shm-push failure WARNING (per-camera, monotonic).
+        self._last_shm_push_warn_t = 0.0
 
     # ── lifecycle ───────────────────────────────────────────────────────────────
 
@@ -2464,127 +2483,176 @@ class CameraWorker:
             float(getattr(src, "fps", 0.0) or 0.0),
             self.shm_name,
         )
-        self._open_resources()
+        # Crash-safety: the whole worker body runs under a try/finally so an
+        # unhandled exception anywhere (including _open_resources) can never kill
+        # the capture thread WITHOUT releasing resources — the finally ALWAYS
+        # joins the inference thread, runs _close_resources (no leaked cv2
+        # capture / shm segment), and emits a STOPPED telemetry so the UI
+        # reflects the camera going down instead of a silent hang.
+        last_health = HealthState.OK
+        last_error: str | None = None
+        try:
+            self._open_resources()
 
-        # Start the inference thread AFTER the source is open.  It builds the
-        # heavy models itself (so a slow first-time EP compile never blocks the
-        # live preview) and processes the latest captured frame.
-        self._inference_thread = threading.Thread(
-            target=self._inference_loop,
-            name=f"caminfer-{self.camera_id[:8]}",
-            daemon=True,
-        )
-        self._inference_thread.start()
+            # Start the inference thread AFTER the source is open.  It builds the
+            # heavy models itself (so a slow first-time EP compile never blocks the
+            # live preview) and processes the latest captured frame.
+            self._inference_thread = threading.Thread(
+                target=self._inference_loop,
+                name=f"caminfer-{self.camera_id[:8]}",
+                daemon=True,
+            )
+            self._inference_thread.start()
 
-        last_telemetry = 0.0
-        miss_streak = 0  # consecutive no-frame reads, drives the reconnect backoff
-        fps_window_start = time.monotonic()
-        fps_window_frames = 0
-        self._next_drop_log_t = time.monotonic() + _DROP_LOG_INTERVAL_S
-        last_health = HealthState.OK if self._source is not None else HealthState.ERROR
-        last_error: str | None = None if self._source is not None else "frame source unavailable"
+            last_telemetry = 0.0
+            miss_streak = 0  # consecutive no-frame reads, drives the reconnect backoff
+            fps_window_start = time.monotonic()
+            fps_window_frames = 0
+            self._next_drop_log_t = time.monotonic() + _DROP_LOG_INTERVAL_S
+            last_health = HealthState.OK if self._source is not None else HealthState.ERROR
+            last_error = None if self._source is not None else "frame source unavailable"
 
-        # If the source could not be opened at all, still emit telemetry so the
-        # UI shows an error/no-signal state instead of a silent hang.
-        if self._source is None:
-            self._emit_telemetry(tracks=[], health=last_health, last_error=last_error)
+            # If the source could not be opened at all, still emit telemetry so the
+            # UI shows an error/no-signal state instead of a silent hang.
+            if self._source is None:
+                self._emit_telemetry(tracks=[], health=last_health, last_error=last_error)
 
-        while not self._stop_event.is_set():
-            # Apply any pending manual PTZ first thing each tick (low-latency path,
-            # independent of inference) so the joystick/D-pad feels immediate.
-            self._drain_ptz_commands()
-
-            tick_t0 = time.perf_counter()
-            frame: NDArray[np.uint8] | None = None
-            if self._source is not None:
+            while not self._stop_event.is_set():
+                # Per-iteration guard: a single bad frame/tick logs a throttled
+                # WARNING and the loop CONTINUES rather than killing the capture
+                # thread.  Only the unrecoverable case (a raise escaping here)
+                # falls through to the outer handler + finally cleanup.
                 try:
-                    frame = self._source.read()
-                    if frame is None:
-                        # A transient read() miss (decode failure / dropped
-                        # frame) — count it for Camera Info.
-                        self._dropped_frames += 1
-                except Exception as exc:  # noqa: BLE001
-                    if last_health is not HealthState.RECONNECTING:
-                        log.warning(
-                            "camera_id=%s frame read failed (%s); reconnecting", self.camera_id, exc
+                    # Apply any pending manual PTZ first thing each tick (low-latency
+                    # path, independent of inference) so the joystick/D-pad feels
+                    # immediate.
+                    self._drain_ptz_commands()
+
+                    tick_t0 = time.perf_counter()
+                    frame: NDArray[np.uint8] | None = None
+                    if self._source is not None:
+                        try:
+                            frame = self._source.read()
+                            if frame is None:
+                                # A transient read() miss (decode failure / dropped
+                                # frame) — count it for Camera Info.
+                                self._dropped_frames += 1
+                        except Exception as exc:  # noqa: BLE001
+                            if last_health is not HealthState.RECONNECTING:
+                                log.warning(
+                                    "camera_id=%s frame read failed (%s); reconnecting",
+                                    self.camera_id,
+                                    exc,
+                                )
+                            last_health = HealthState.RECONNECTING
+                            last_error = str(exc)
+                            self._dropped_frames += 1
+                            frame = None
+                    ingest_ms = (time.perf_counter() - tick_t0) * 1000.0
+
+                    now = time.monotonic()
+
+                    if frame is not None:
+                        self._record_stage("ingest", ingest_ms)
+                        if last_health is HealthState.RECONNECTING:
+                            log.info("camera_id=%s frame source recovered", self.camera_id)
+                        self._record_frame_dims(frame)
+                        self._push_frame(frame)
+                        fps_window_frames += 1
+                        miss_streak = 0  # got a frame → drop back to fast retries
+                        last_health = HealthState.OK
+                        last_error = None
+
+                        # Hand the newest frame to the inference thread (latest wins)
+                        # so detection/face never gate the capture+preview rate.
+                        with self._frame_lock:
+                            self._latest_frame = frame
+                            self._latest_frame_id += 1
+                        self._frames_captured += 1
+                        self._frame_ready.set()
+
+                        self._ingest_ms = ingest_ms
+                        # Latency = capture read + the latest inference detect+track.
+                        self._latency_ms = ingest_ms + self._inference_ms
+
+                        elapsed = now - fps_window_start
+                        if elapsed >= 1.0:
+                            self._fps = fps_window_frames / elapsed
+                            fps_window_start = now
+                            fps_window_frames = 0
+
+                    # Periodic frame-drop summary (INFO) when drops keep accruing.
+                    self._maybe_log_drops(now)
+
+                    # Telemetry pacing (~telemetry_hz) — report latest inference.
+                    if now - last_telemetry >= self._telemetry_period:
+                        self._apply_inference_watchdog(now)
+                        self._emit_telemetry(
+                            tracks=list(self._last_tracks),
+                            health=last_health,
+                            last_error=last_error,
                         )
-                    last_health = HealthState.RECONNECTING
+                        last_telemetry = now
+
+                    # No frame: retry fast briefly (transient decode miss on a
+                    # healthy source), then back off a sustained no-frame source up
+                    # to the cap so a stalled/offline/denied camera doesn't spin the
+                    # capture thread.
+                    if frame is None:
+                        miss_streak += 1
+                        if miss_streak <= _RECONNECT_FAST_RETRIES:
+                            wait = 0.01
+                        else:
+                            over = miss_streak - _RECONNECT_FAST_RETRIES
+                            wait = min(_RECONNECT_BACKOFF_MAX_S, 0.01 + 0.05 * over)
+                        # Interruptible: a manual PTZ command (or stop) wakes this
+                        # early so the joystick stays responsive even while the video
+                        # feed is stalled (the next loop iteration drains the PTZ
+                        # queue at the top).
+                        self._capture_wake.wait(timeout=wait)
+                        self._capture_wake.clear()
+                except Exception as exc:  # noqa: BLE001 — one bad tick must not kill capture
+                    now = time.monotonic()
+                    if now - self._last_tick_warn_t >= _TICK_WARN_INTERVAL_S:
+                        self._last_tick_warn_t = now
+                        log.warning(
+                            "camera_id=%s capture tick failed (%s); continuing",
+                            self.camera_id,
+                            exc,
+                            exc_info=True,
+                        )
+                    last_health = HealthState.ERROR
                     last_error = str(exc)
-                    self._dropped_frames += 1
-                    frame = None
-            ingest_ms = (time.perf_counter() - tick_t0) * 1000.0
-
-            now = time.monotonic()
-
-            if frame is not None:
-                self._record_stage("ingest", ingest_ms)
-                if last_health is HealthState.RECONNECTING:
-                    log.info("camera_id=%s frame source recovered", self.camera_id)
-                self._record_frame_dims(frame)
-                self._push_frame(frame)
-                fps_window_frames += 1
-                miss_streak = 0  # got a frame → drop back to fast retries
-                last_health = HealthState.OK
-                last_error = None
-
-                # Hand the newest frame to the inference thread (latest wins) so
-                # detection/face never gate the capture+preview rate.
-                with self._frame_lock:
-                    self._latest_frame = frame
-                    self._latest_frame_id += 1
-                self._frames_captured += 1
-                self._frame_ready.set()
-
-                self._ingest_ms = ingest_ms
-                # Latency = capture read + the latest inference detect+track cost.
-                self._latency_ms = ingest_ms + self._inference_ms
-
-                elapsed = now - fps_window_start
-                if elapsed >= 1.0:
-                    self._fps = fps_window_frames / elapsed
-                    fps_window_start = now
-                    fps_window_frames = 0
-
-            # Periodic frame-drop summary (INFO) when drops continue to accrue.
-            self._maybe_log_drops(now)
-
-            # Telemetry pacing (~telemetry_hz) — report the latest inference output.
-            if now - last_telemetry >= self._telemetry_period:
-                self._apply_inference_watchdog(now)
+                    # Brief interruptible pause so a persistent fault can't spin.
+                    self._capture_wake.wait(timeout=0.05)
+                    self._capture_wake.clear()
+        except Exception:  # noqa: BLE001 — fatal: log + emit ERROR, finally cleans up
+            log.error("camera_id=%s capture thread died", self.camera_id, exc_info=True)
+            try:
                 self._emit_telemetry(
-                    tracks=list(self._last_tracks), health=last_health, last_error=last_error
+                    tracks=[], health=HealthState.ERROR, last_error="capture thread error"
                 )
-                last_telemetry = now
-
-            # No frame: retry fast briefly (transient decode miss on a healthy
-            # source), then back off a sustained no-frame source up to the cap so a
-            # stalled/offline/denied camera doesn't spin the capture thread.
-            if frame is None:
-                miss_streak += 1
-                if miss_streak <= _RECONNECT_FAST_RETRIES:
-                    wait = 0.01
-                else:
-                    over = miss_streak - _RECONNECT_FAST_RETRIES
-                    wait = min(_RECONNECT_BACKOFF_MAX_S, 0.01 + 0.05 * over)
-                # Interruptible: a manual PTZ command (or stop) wakes this early so
-                # the joystick stays responsive even while the video feed is stalled
-                # (the next loop iteration drains the PTZ queue at the top).
-                self._capture_wake.wait(timeout=wait)
-                self._capture_wake.clear()
-
-        # Shutdown: wake + join the inference thread, then release resources.
-        self._frame_ready.set()
-        if self._inference_thread is not None:
-            self._inference_thread.join(timeout=5.0)
-            self._inference_thread = None
-        self._close_resources()
-        log.info(
-            "camera_id=%s worker stopped (frames dropped total=%d)",
-            self.camera_id,
-            self._dropped_frames,
-        )
-        # Final STOPPED telemetry so the UI reflects the camera going down.
-        self._emit_telemetry(tracks=[], health=HealthState.STOPPED, last_error=None)
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            # Shutdown: wake + join the inference thread, then release resources.
+            # ALWAYS runs — even on a fatal exception above — so the cv2 capture
+            # and the shared-memory segment are never leaked.
+            self._frame_ready.set()
+            if self._inference_thread is not None:
+                self._inference_thread.join(timeout=5.0)
+                self._inference_thread = None
+            self._close_resources()
+            log.info(
+                "camera_id=%s worker stopped (frames dropped total=%d)",
+                self.camera_id,
+                self._dropped_frames,
+            )
+            # Final STOPPED telemetry so the UI reflects the camera going down.
+            try:
+                self._emit_telemetry(tracks=[], health=HealthState.STOPPED, last_error=None)
+            except Exception:  # noqa: BLE001
+                pass
 
     def _inference_loop(self) -> None:
         """Detect → track → face → pose → PTZ on the latest captured frame.
@@ -2598,106 +2666,135 @@ class CameraWorker:
             self._drain_commands()
         if self._stop_event.is_set():
             return
-        self._build_inference_stacks()
-        # Seed so the first lifecycle pass sees no spurious transition.
-        self._prev_model_features = self._features_snapshot()
-        self._start_appearance_thread()
-        last_id = 0
-        while not self._stop_event.is_set():
-            # Wake on a new frame, but fall through on the timeout too so commands
-            # (nudge / set-target / enable-tracking) are still drained when no
-            # frames are arriving — they must never depend on frame delivery.
-            self._frame_ready.wait(timeout=0.05)
-            self._frame_ready.clear()
-            if self._stop_event.is_set():
-                break
-            self._drain_commands()
-            self._apply_model_lifecycle()
-            with self._frame_lock:
-                frame = self._latest_frame
-                fid = self._latest_frame_id
-            if frame is None or fid == last_id:
-                continue
-            last_id = fid
-            self._frames_inferred += 1
-            self._current_inference_frame_id = fid
-            now = time.monotonic()
-            self._seed_subservice_phases(now)
+        # Crash-safety: everything from the model build onward runs under a
+        # try/finally so an unhandled exception (build or a hot-loop stage) can
+        # never orphan the appearance thread — the finally ALWAYS joins it.  A
+        # per-iteration guard inside the while keeps one raising stage from
+        # killing inference (the camera would otherwise go dark with no boxes).
+        try:
+            self._build_inference_stacks()
+            # Seed so the first lifecycle pass sees no spurious transition.
+            self._prev_model_features = self._features_snapshot()
+            self._start_appearance_thread()
+            last_id = 0
+            while not self._stop_event.is_set():
+                # Wake on a new frame, but fall through on the timeout too so
+                # commands (nudge / set-target / enable-tracking) are still drained
+                # when no frames are arriving — they must never depend on frame
+                # delivery.
+                self._frame_ready.wait(timeout=0.05)
+                self._frame_ready.clear()
+                if self._stop_event.is_set():
+                    break
+                try:
+                    self._drain_commands()
+                    self._apply_model_lifecycle()
+                    with self._frame_lock:
+                        frame = self._latest_frame
+                        fid = self._latest_frame_id
+                    if frame is None or fid == last_id:
+                        continue
+                    last_id = fid
+                    self._frames_inferred += 1
+                    self._current_inference_frame_id = fid
+                    now = time.monotonic()
+                    self._seed_subservice_phases(now)
 
-            detect_t0 = time.perf_counter()
-            tracks = self._maybe_track(frame)
-            self._inference_ms = (time.perf_counter() - detect_t0) * 1000.0
+                    detect_t0 = time.perf_counter()
+                    tracks = self._maybe_track(frame)
+                    self._inference_ms = (time.perf_counter() - detect_t0) * 1000.0
 
-            self._apply_target_lock(tracks, frame, now)
+                    self._apply_target_lock(tracks, frame, now)
 
-            if self._async_appearance:
-                # Hand the heavy appearance passes (ReID + face) to their own
-                # thread so they overlap detect+track+PTZ instead of stalling the
-                # control loop.  Shared target/identity state is serialised by
-                # _appearance_lock inside those methods; the hot loop re-reads the
-                # (possibly rebound) target via _apply_target_lock each tick.
-                # Only publish when there's actually appearance work — otherwise we
-                # wake the appearance thread every frame for two passes that both
-                # immediately no-op with face + ReID off (pure idle overhead).
-                if self._feature("face_recognition") or self._feature("reid"):
-                    self._publish_appearance_input(frame, tracks, now, fid)
-            else:
-                # Inline (sync) path — preserves the exact original ordering.
-                self._maybe_reid_recover(tracks, frame, now)
-                self._apply_target_lock(tracks, frame, now)
-                face_t0 = time.perf_counter()
-                self._maybe_identify(frame, tracks, now)
-                face_dt = (time.perf_counter() - face_t0) * 1000.0
-                if face_dt > 0.5:
-                    self._face_ms = face_dt
-                    self._record_stage("face", face_dt)
-                self._apply_target_lock(tracks, frame, now)
+                    if self._async_appearance:
+                        # Hand the heavy appearance passes (ReID + face) to their own
+                        # thread so they overlap detect+track+PTZ instead of stalling
+                        # the control loop.  Shared target/identity state is
+                        # serialised by _appearance_lock inside those methods; the
+                        # hot loop re-reads the (possibly rebound) target via
+                        # _apply_target_lock each tick.  Only publish when there's
+                        # actually appearance work — otherwise we wake the appearance
+                        # thread every frame for two passes that both immediately
+                        # no-op with face + ReID off (pure idle overhead).
+                        if self._feature("face_recognition") or self._feature("reid"):
+                            self._publish_appearance_input(frame, tracks, now, fid)
+                    else:
+                        # Inline (sync) path — preserves the exact original ordering.
+                        self._maybe_reid_recover(tracks, frame, now)
+                        self._apply_target_lock(tracks, frame, now)
+                        face_t0 = time.perf_counter()
+                        self._maybe_identify(frame, tracks, now)
+                        face_dt = (time.perf_counter() - face_t0) * 1000.0
+                        if face_dt > 0.5:
+                            self._face_ms = face_dt
+                            self._record_stage("face", face_dt)
+                        self._apply_target_lock(tracks, frame, now)
 
-            # Estimate pose for the selected person so the pose overlay shows the
-            # moment you click someone — independent of whether PTZ auto-follow is
-            # actively driving (which is the only place pose ran before).
-            if self._pose_allowed_this_tick():
-                self._maybe_estimate_pose_overlay(tracks, frame, now)
-            self._annotate_target_aim(tracks, frame, now)
+                    # Estimate pose for the selected person so the pose overlay shows
+                    # the moment you click someone — independent of whether PTZ
+                    # auto-follow is actively driving (the only place pose ran
+                    # before).
+                    if self._pose_allowed_this_tick():
+                        self._maybe_estimate_pose_overlay(tracks, frame, now)
+                    self._annotate_target_aim(tracks, frame, now)
 
-            # Estimate the camera's own image motion for this tick BEFORE driving
-            # the PTZ — _drive_ptz_auto → _estimate_aim_velocity subtracts it so the
-            # feed-forward follows the subject's world motion, not the frame shift.
-            # (_ptz_last_cmd still holds the *previous* command here — exactly the
-            # one that produced this frame's observed shift.)
-            #
-            # Ego-motion runs sparse optical flow on every frame, but its only
-            # consumer is the aim-velocity feed-forward, which only runs while
-            # actively following (tracking on).  With tracking off it burned ~15%
-            # of a core computing a value nothing reads — so gate it on tracking
-            # and keep the estimate zeroed otherwise.
-            if self._feature("tracking"):
-                self._update_ego_motion(tracks, frame, now)
-            elif self._ego_source != "none":
-                self._ego_vel = (0.0, 0.0)
-                self._ego_source = "none"
+                    # Estimate the camera's own image motion for this tick BEFORE
+                    # driving the PTZ — _drive_ptz_auto → _estimate_aim_velocity
+                    # subtracts it so the feed-forward follows the subject's world
+                    # motion, not the frame shift.  (_ptz_last_cmd still holds the
+                    # *previous* command here — exactly the one that produced this
+                    # frame's observed shift.)
+                    #
+                    # Ego-motion runs sparse optical flow on every frame, but its
+                    # only consumer is the aim-velocity feed-forward, which only runs
+                    # while actively following (tracking on).  With tracking off it
+                    # burned ~15% of a core computing a value nothing reads — so gate
+                    # it on tracking and keep the estimate zeroed otherwise.
+                    if self._feature("tracking"):
+                        self._update_ego_motion(tracks, frame, now)
+                    elif self._ego_source != "none":
+                        self._ego_vel = (0.0, 0.0)
+                        self._ego_source = "none"
 
-            # Auto PTZ control (suspended during a manual-override window).  Lock
-            # the backend so a concurrent telemetry position read can't interleave.
-            with self._ptz_lock:
-                self._drive_ptz_auto(tracks, frame, now)
+                    # Auto PTZ control (suspended during a manual-override window).
+                    # Lock the backend so a concurrent telemetry position read can't
+                    # interleave.
+                    with self._ptz_lock:
+                        self._drive_ptz_auto(tracks, frame, now)
 
-            self._last_tracks = tracks
-            self._last_tracks_frame_id = fid
-            # Heartbeat: advance so the capture-thread watchdog knows inference
-            # is alive.  Set AFTER all work for this frame is committed.
-            self._last_infer_t = time.monotonic()
-            if log.isEnabledFor(logging.DEBUG):
-                log.debug(
-                    "camera_id=%s timings detect+track=%.1fms face=%.1fms tracks=%d fps=%.1f",
-                    self.camera_id,
-                    self._detect_ms,
-                    self._face_ms,
-                    len(tracks),
-                    self._fps,
-                )
-
-        self._stop_appearance_thread()
+                    self._last_tracks = tracks
+                    self._last_tracks_frame_id = fid
+                    # Heartbeat: advance so the capture-thread watchdog knows
+                    # inference is alive.  Set AFTER all work for this frame is
+                    # committed.
+                    self._last_infer_t = time.monotonic()
+                    if log.isEnabledFor(logging.DEBUG):
+                        log.debug(
+                            "camera_id=%s timings detect+track=%.1fms face=%.1fms "
+                            "tracks=%d fps=%.1f",
+                            self.camera_id,
+                            self._detect_ms,
+                            self._face_ms,
+                            len(tracks),
+                            self._fps,
+                        )
+                except Exception as exc:  # noqa: BLE001 — one stage must not kill inference
+                    now = time.monotonic()
+                    if now - self._last_infer_warn_t >= _INFER_WARN_INTERVAL_S:
+                        self._last_infer_warn_t = now
+                        log.warning(
+                            "camera_id=%s inference tick failed (%s); continuing",
+                            self.camera_id,
+                            exc,
+                            exc_info=True,
+                        )
+                    self._infer_last_error = str(exc)
+        except Exception:  # noqa: BLE001 — fatal: log; finally still joins appearance
+            log.error("camera_id=%s inference thread died", self.camera_id, exc_info=True)
+        finally:
+            # ALWAYS join the appearance thread — even on a fatal error — so it is
+            # never orphaned when inference goes down.
+            self._stop_appearance_thread()
 
     # ── async appearance (face + ReID) thread ───────────────────────────────────
 
@@ -3348,7 +3445,13 @@ class CameraWorker:
                 self._vcam.close()
                 self._vcam = None
         except Exception:  # noqa: BLE001
-            log.debug("camera_id=%s shm push failed", self.camera_id, exc_info=True)
+            # Was DEBUG-only: a broken preview pipe (shm/vcam) left the operator
+            # staring at a frozen preview with an empty log.  Surface it as a
+            # throttled WARNING so a persistent failure is visible without
+            # spamming one line per pushed frame.
+            if now - self._last_shm_push_warn_t >= _TICK_WARN_INTERVAL_S:
+                self._last_shm_push_warn_t = now
+                log.warning("camera_id=%s preview/shm push failed", self.camera_id, exc_info=True)
 
     def _fit_frame(self, frame: NDArray[np.uint8]) -> NDArray[np.uint8]:
         """Resize / coerce a BGR frame to the ShmWriter's exact dimensions."""
@@ -3423,8 +3526,15 @@ class CameraWorker:
             self._track_ms = (_t2 - _t1) * 1000.0
             self._record_stage("detect", self._detect_ms)
             self._record_stage("track", self._track_ms)
-        except Exception:  # noqa: BLE001
-            log.debug("camera_id=%s detect/track failed", self.camera_id, exc_info=True)
+        except Exception as exc:  # noqa: BLE001
+            # Surface the FIRST detect/track failure at WARNING (then throttle) and
+            # stash it as last_error so the Camera Info panel can show *why* the
+            # camera went box-blind instead of leaving an empty DEBUG-only log.
+            now = time.monotonic()
+            if now - self._last_infer_warn_t >= _INFER_WARN_INTERVAL_S:
+                self._last_infer_warn_t = now
+                log.warning("camera_id=%s detect/track failed", self.camera_id, exc_info=True)
+            self._infer_last_error = str(exc)
             return []
 
         out: list[TrackInfo] = []
@@ -4612,6 +4722,11 @@ class CameraWorker:
         health: HealthState,
         last_error: str | None,
     ) -> None:
+        # Surface a recent inference-stage failure (detect/track raise) when the
+        # capture path itself is healthy, so the Camera Info panel can show *why*
+        # a streaming-but-box-blind camera has no tracks.
+        if last_error is None and self._infer_last_error is not None:
+            last_error = self._infer_last_error
         msg = TelemetryMsg(
             camera_id=self.camera_id,
             seq=self._seq,

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -640,8 +640,10 @@ class CameraWorker:
         # WARNING in the capture / inference loops, so a persistent fault stays
         # visible without spamming a stack trace every tick.  _infer_last_error
         # surfaces the most recent inference-stage failure for the Camera Info
-        # panel (cleared implicitly once ticks succeed again and telemetry moves
-        # on).
+        # panel.  It is cleared on the next successful detect/track tick (see
+        # _maybe_track) so a transient failure does not pin a stale error onto
+        # later healthy telemetry; the inference fatal handler sets a terminal
+        # value so a dead inference thread stays visible while capture streams.
         self._last_tick_warn_t = 0.0
         self._last_infer_warn_t = 0.0
         self._infer_last_error: str | None = None
@@ -2789,8 +2791,13 @@ class CameraWorker:
                             exc_info=True,
                         )
                     self._infer_last_error = str(exc)
-        except Exception:  # noqa: BLE001 — fatal: log; finally still joins appearance
+        except Exception as exc:  # noqa: BLE001 — fatal: log; finally still joins appearance
             log.error("camera_id=%s inference thread died", self.camera_id, exc_info=True)
+            # The inference thread is gone but capture may keep streaming, so the
+            # UI would otherwise show a healthy-but-box-blind camera with no error.
+            # Pin a terminal error onto telemetry so the still-running capture loop
+            # surfaces *why* tracks stopped flowing.
+            self._infer_last_error = f"inference thread stopped: {exc}"
         finally:
             # ALWAYS join the appearance thread — even on a fatal error — so it is
             # never orphaned when inference goes down.
@@ -3526,6 +3533,11 @@ class CameraWorker:
             self._track_ms = (_t2 - _t1) * 1000.0
             self._record_stage("detect", self._detect_ms)
             self._record_stage("track", self._track_ms)
+            # Detect/track succeeded this tick — clear any stale inference error so
+            # a single transient failure does not pin last_error on every later
+            # healthy telemetry (the camera would otherwise look permanently
+            # faulted long after it recovered).
+            self._infer_last_error = None
         except Exception as exc:  # noqa: BLE001
             # Surface the FIRST detect/track failure at WARNING (then throttle) and
             # stash it as last_error so the Camera Info panel can show *why* the

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -12,6 +12,7 @@ coast_window_ms, then stop and enter SEARCHING state.
 
 from __future__ import annotations
 
+import logging
 import math
 import threading
 import time
@@ -22,6 +23,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from autoptz.config.models import PTZConfig
     from autoptz.engine.ptz.base import PTZBackend
+
+log = logging.getLogger(__name__)
+
+# Throttle for the control-loop tick failure WARNING: a persistent backend fault
+# would otherwise emit a stack trace at the full control rate — at most one line
+# per interval keeps it visible without flooding the log.
+_TICK_WARN_INTERVAL_S = 5.0
 
 # Named framing presets → target subject-height fraction of the frame.
 # A larger fraction means the subject fills more of the frame (tighter shot).
@@ -324,6 +332,9 @@ class PTZController:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
+        # Throttle for the control-loop tick failure WARNING (monotonic seconds).
+        self._last_tick_warn_t = 0.0
+
     # ── public API ────────────────────────────────────────────────────────────
 
     @property
@@ -470,8 +481,15 @@ class PTZController:
             t0 = time.perf_counter()
             try:
                 self._tick(t=t0)
-            except Exception:
-                pass
+            except Exception as exc:  # noqa: BLE001
+                # Was a bare ``pass`` — a backend/compute fault silently froze the
+                # PTZ with no log at all.  Surface it as a throttled WARNING so a
+                # persistent control fault is visible without spamming the log at
+                # the control rate.  The loop keeps running so motion can recover.
+                now = time.monotonic()
+                if now - self._last_tick_warn_t >= _TICK_WARN_INTERVAL_S:
+                    self._last_tick_warn_t = now
+                    log.warning("PTZ control tick failed (%s); continuing", exc, exc_info=True)
             elapsed = time.perf_counter() - t0
             self._stop_event.wait(max(0.0, interval - elapsed))
         # guarantee stop on thread exit

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -64,6 +64,7 @@ log = logging.getLogger(__name__)
 
 _PUMP_INTERVAL_S = 0.05  # 20 Hz command pump when run internally
 _CPU_SAMPLE_INTERVAL_S = 1.0  # system-CPU fan-out cadence (≈1 Hz)
+_TICK_WARN_INTERVAL_S = 5.0  # throttle for the pump-tick failure WARNING
 
 # Worker liveness / auto-restart constants
 _HEALTH_SCAN_INTERVAL_S = 2.0  # how often tick() runs the health scan
@@ -147,6 +148,9 @@ class Supervisor:
         self._pump_thread: threading.Thread | None = None
         self._pump_stop = threading.Event()
         self._startup_thread: threading.Thread | None = None
+        # Throttle for the pump-tick failure WARNING (monotonic seconds) so a
+        # persistent fault can't spam at the 20 Hz pump rate.
+        self._last_pump_warn_t = 0.0
 
         # ── worker health monitoring + auto-restart ──────────────────────────────
         # Per-camera backoff state: cid → (attempts, next_allowed_t).
@@ -444,8 +448,14 @@ class Supervisor:
             t0 = time.monotonic()
             try:
                 self.tick()
-            except Exception:  # noqa: BLE001
-                log.debug("pump tick error", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                # Was DEBUG-only: a pump-tick fault (health scan / command fan-out)
+                # was invisible at the default level.  Promote to a throttled
+                # WARNING so a persistent fault is visible without spamming at the
+                # pump rate.  The pump keeps running.
+                if t0 - self._last_pump_warn_t >= _TICK_WARN_INTERVAL_S:
+                    self._last_pump_warn_t = t0
+                    log.warning("pump tick error (%s); continuing", exc, exc_info=True)
             elapsed = time.monotonic() - t0
             self._pump_stop.wait(max(0.0, _PUMP_INTERVAL_S - elapsed))
 

--- a/tests/test_worker_crash_safety.py
+++ b/tests/test_worker_crash_safety.py
@@ -1,0 +1,257 @@
+"""Crash-safety tests for the per-camera worker threads.
+
+These drive a real :class:`CameraWorker` with fake frame sources / fake stages
+that raise, and assert the loop guards added for crash-safety hold:
+
+  - ``_run`` ALWAYS runs ``_close_resources`` in a ``finally`` even when
+    ``_open_resources`` or the loop body raises (no leaked cv2 capture / shm),
+    the failure is reported as an ERROR/STOPPED health telemetry, and the
+    capture thread exits cleanly instead of dying silently.
+  - A single raising ``source.read()`` (or per-iteration body fault) logs a
+    throttled warning and the loop CONTINUES rather than killing the thread.
+  - ``_inference_loop`` runs ``_stop_appearance_thread`` in a ``finally`` and a
+    single raising stage does not kill inference — later frames still produce
+    output.
+
+All tests are headless and inject fakes, so no camera, model, or GUI is
+required.  They follow the construction patterns in ``test_async_appearance``
+and ``test_inference_watchdog``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+
+from autoptz.config.models import CameraConfig, SourceConfig
+from autoptz.engine.camera_worker import CameraWorker
+from autoptz.engine.runtime.messages import HealthState, TelemetryMsg
+
+
+def _cfg(camera_id: str = "cam-crash-1234abcd") -> CameraConfig:
+    return CameraConfig(
+        id=camera_id,
+        name="Crash",
+        source=SourceConfig(type="usb", address="usb://0"),
+    )
+
+
+def _frame() -> np.ndarray:
+    return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+class _OkSource:
+    """Minimal frame source that opens and yields solid frames."""
+
+    def __init__(self) -> None:
+        self.opened = False
+        self.closed = False
+        self.reads = 0
+
+    def open(self) -> bool:
+        self.opened = True
+        return True
+
+    def read(self):  # noqa: ANN202
+        self.reads += 1
+        return _frame()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ReadRaisesOnceSource(_OkSource):
+    """Source whose ``read`` raises on the FIRST call, then succeeds."""
+
+    def read(self):  # noqa: ANN202
+        self.reads += 1
+        if self.reads == 1:
+            raise RuntimeError("decode boom")
+        return _frame()
+
+
+def _worker(source) -> CameraWorker:  # noqa: ANN001
+    w = CameraWorker(
+        "cam-crash-1234abcd",
+        _cfg(),
+        on_telemetry=lambda _m: None,
+        frame_source=source,
+    )
+    # Keep the capture-loop tests off the heavy ML path: the inference thread
+    # otherwise loads real models (insightface) and starves/serialises the
+    # capture loop, making read-count assertions flaky under suite load.
+    w._build_inference_stacks = lambda: None  # type: ignore[assignment]
+    return w
+
+
+def _run_until(w: CameraWorker, predicate, *, timeout: float = 5.0) -> threading.Thread:  # noqa: ANN001
+    """Run ``_run`` on a thread until ``predicate()`` holds, then stop + join."""
+    t = threading.Thread(target=w._run, daemon=True)
+    t.start()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not predicate():
+        time.sleep(0.01)
+    w._stop_event.set()
+    w._capture_wake.set()
+    w._inference_start.set()
+    t.join(timeout=5.0)
+    return t
+
+
+# ── _run: cleanup always runs ────────────────────────────────────────────────
+
+
+def test_run_closes_resources_when_open_resources_raises() -> None:
+    """An exception in ``_open_resources`` must NOT leak: ``_close_resources``
+    runs in the ``finally`` and the thread exits cleanly (no silent death)."""
+    src = _OkSource()
+    w = _worker(src)
+
+    closed = threading.Event()
+    orig_close = w._close_resources
+
+    def tracking_close() -> None:
+        orig_close()
+        closed.set()
+
+    w._close_resources = tracking_close  # type: ignore[assignment]
+    w._open_resources = lambda: (_ for _ in ()).throw(RuntimeError("open boom"))  # type: ignore[assignment]
+
+    t = threading.Thread(target=w._run, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive(), "capture thread should exit cleanly, not hang"
+    assert closed.is_set(), "_close_resources must run even when _open_resources raises"
+
+
+def test_run_emits_error_health_when_loop_dies() -> None:
+    """When the loop body raises fatally, the worker must emit an ERROR/STOPPED
+    health telemetry so the UI reflects the failure rather than going dark."""
+    src = _OkSource()
+    states: list[HealthState] = []
+
+    def on_tel(msg: TelemetryMsg) -> None:
+        states.append(msg.health.state)
+
+    w = CameraWorker("cam-crash-1234abcd", _cfg(), on_telemetry=on_tel, frame_source=src)
+    # Make the loop body raise fatally on the first iteration.
+    w._open_resources = lambda: (_ for _ in ()).throw(RuntimeError("fatal boom"))  # type: ignore[assignment]
+
+    t = threading.Thread(target=w._run, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive()
+    assert states, "expected at least one telemetry emit on failure"
+    assert any(s in (HealthState.ERROR, HealthState.STOPPED) for s in states), (
+        f"expected ERROR/STOPPED health, got {states}"
+    )
+
+
+def test_run_per_iteration_guard_survives_single_bad_read() -> None:
+    """A single raising ``source.read()`` is handled by the read guard (already
+    present) — the loop keeps going and the thread stays alive until stopped."""
+    src = _ReadRaisesOnceSource()
+    w = _worker(src)
+
+    # The first read raises; the loop must continue and read again.
+    t = _run_until(w, lambda: src.reads >= 3)
+
+    assert not t.is_alive()
+    # It read more than once → it did not die on the first raising read.
+    assert src.reads > 1, "loop should have continued past the raising read"
+    assert src.closed, "_close_resources should release the source on shutdown"
+
+
+def test_run_normal_shutdown_closes_resources() -> None:
+    """Happy path: a clean stop still releases resources (finally not regressed)."""
+    src = _OkSource()
+    w = _worker(src)
+
+    t = _run_until(w, lambda: src.reads >= 2)
+
+    assert not t.is_alive()
+    assert src.opened
+    assert src.closed
+    assert src.reads >= 1
+
+
+# ── _inference_loop: survives a raising stage + cleans up ────────────────────
+
+
+def test_inference_loop_survives_single_raising_stage() -> None:
+    """A stage that raises once then succeeds must NOT kill the inference loop —
+    later frames still produce output (per-iteration guard)."""
+    w = _worker(_OkSource())
+
+    outputs: list[int] = []
+    calls = {"n": 0}
+    gate = threading.Event()
+
+    def flaky_track(frame):  # noqa: ANN001, ANN202
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("stage boom")
+        outputs.append(calls["n"])
+        gate.set()
+        return []
+
+    # Stub the heavy build + the post-track work so we isolate the stage guard.
+    w._maybe_track = flaky_track  # type: ignore[assignment]
+    w._build_inference_stacks = lambda: None  # type: ignore[assignment]
+    w._apply_target_lock = lambda *a, **k: None  # type: ignore[assignment]
+    w._drive_ptz_auto = lambda *a, **k: None  # type: ignore[assignment]
+    w._annotate_target_aim = lambda *a, **k: None  # type: ignore[assignment]
+    w._update_ego_motion = lambda *a, **k: None  # type: ignore[assignment]
+    w._async_appearance = False
+    w._maybe_reid_recover = lambda *a, **k: None  # type: ignore[assignment]
+    w._maybe_identify = lambda *a, **k: None  # type: ignore[assignment]
+    w._maybe_estimate_pose_overlay = lambda *a, **k: None  # type: ignore[assignment]
+
+    w._inference_start.set()  # skip the wait-for-start gate
+    t = threading.Thread(target=w._inference_loop, daemon=True)
+    t.start()
+    try:
+        # Feed frame 1 → raises; feed frame 2 → succeeds.
+        for _ in range(1, 6):
+            with w._frame_lock:
+                w._latest_frame = _frame()
+                w._latest_frame_id += 1
+            w._frame_ready.set()
+            time.sleep(0.05)
+        assert gate.wait(2.0), "inference loop died after a raising stage"
+    finally:
+        w._stop_event.set()
+        w._frame_ready.set()
+        t.join(timeout=5.0)
+
+    assert not t.is_alive()
+    assert outputs, "later frames should still produce output after the raising stage"
+
+
+def test_inference_loop_stops_appearance_thread_on_fatal_exit() -> None:
+    """If the inference loop dies fatally, ``_stop_appearance_thread`` must run in
+    the ``finally`` so the appearance thread is never orphaned."""
+    w = _worker(_OkSource())
+
+    stopped = threading.Event()
+    orig_stop = w._stop_appearance_thread
+
+    def tracking_stop() -> None:
+        orig_stop()
+        stopped.set()
+
+    w._stop_appearance_thread = tracking_stop  # type: ignore[assignment]
+    # Make the loop setup itself raise fatally (outside the per-iteration guard).
+    w._build_inference_stacks = lambda: (_ for _ in ()).throw(RuntimeError("build boom"))  # type: ignore[assignment]
+
+    w._inference_start.set()
+    t = threading.Thread(target=w._inference_loop, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive(), "inference thread should exit cleanly on a fatal error"
+    assert stopped.is_set(), "_stop_appearance_thread must run in the finally"

--- a/tests/test_worker_crash_safety.py
+++ b/tests/test_worker_crash_safety.py
@@ -255,3 +255,102 @@ def test_inference_loop_stops_appearance_thread_on_fatal_exit() -> None:
 
     assert not t.is_alive(), "inference thread should exit cleanly on a fatal error"
     assert stopped.is_set(), "_stop_appearance_thread must run in the finally"
+
+
+# ── _infer_last_error: stale-error clearing + dead-thread visibility ──────────
+
+
+class _FakeDetector:
+    """Fake YOLO detector whose ``detect`` raises on the first N calls."""
+
+    def __init__(self, raise_calls: int = 0) -> None:
+        self.calls = 0
+        self.raise_calls = raise_calls
+
+    def detect(self, frame):  # noqa: ANN001, ANN202
+        self.calls += 1
+        if self.calls <= self.raise_calls:
+            raise RuntimeError("detect boom")
+        return []  # no detections → empty, healthy tick
+
+
+class _FakeTracker:
+    def update(self, detections, frame, fps=30.0):  # noqa: ANN001, ANN202, ANN001
+        return []
+
+
+class _FakeDetectStack:
+    def __init__(self, raise_calls: int = 0) -> None:
+        self.detector = _FakeDetector(raise_calls)
+        self.tracker = _FakeTracker()
+
+
+def test_transient_detect_failure_does_not_pin_stale_error() -> None:
+    """Finding #1: a transient detect/track failure sets ``_infer_last_error``,
+    but the NEXT successful tick must CLEAR it — otherwise the stale error gets
+    attached to every later healthy telemetry and the camera looks permanently
+    faulted long after it recovered."""
+    w = _worker(_OkSource())
+    # First call raises; subsequent calls succeed.
+    w._detect = _FakeDetectStack(raise_calls=1)  # type: ignore[assignment]
+
+    # Tick 1: detect raises → error is stashed for the Camera Info panel.
+    out1 = w._maybe_track(_frame())
+    assert out1 == []
+    assert w._infer_last_error is not None, "transient failure should stash an error"
+
+    # Tick 2: detect succeeds → the stale error MUST be cleared.
+    out2 = w._maybe_track(_frame())
+    assert out2 == []
+    assert w._infer_last_error is None, (
+        "a successful tick must clear the stale error so later healthy telemetry "
+        "does not report the camera as permanently faulted"
+    )
+
+
+def test_emit_telemetry_does_not_carry_cleared_error() -> None:
+    """End-to-end of finding #1: after a transient failure followed by a healthy
+    tick, ``_emit_telemetry`` must NOT attach the (now cleared) stale error."""
+    captured: list[TelemetryMsg] = []
+    w = CameraWorker(
+        "cam-crash-1234abcd",
+        _cfg(),
+        on_telemetry=captured.append,
+        frame_source=_OkSource(),
+    )
+    w._detect = _FakeDetectStack(raise_calls=1)  # type: ignore[assignment]
+
+    # Transient failure then recovery.
+    w._maybe_track(_frame())
+    assert w._infer_last_error is not None
+    w._maybe_track(_frame())
+    assert w._infer_last_error is None
+
+    w._emit_telemetry(tracks=[], health=HealthState.OK, last_error=None)
+
+    assert captured, "expected a telemetry emit"
+    assert captured[-1].health.last_error is None, (
+        "healthy telemetry must not carry the cleared transient error"
+    )
+
+
+def test_inference_loop_fatal_exit_surfaces_error_for_capture_telemetry() -> None:
+    """Finding #2: when the inference thread dies fatally, the fatal handler must
+    set ``_infer_last_error`` so the still-running capture telemetry surfaces a
+    dead, box-blind camera instead of showing it as healthy."""
+    w = _worker(_OkSource())
+    assert w._infer_last_error is None
+    # Make the loop setup raise fatally (outside the per-iteration guard).
+    w._build_inference_stacks = lambda: (_ for _ in ()).throw(RuntimeError("build boom"))  # type: ignore[assignment]
+
+    w._inference_start.set()
+    t = threading.Thread(target=w._inference_loop, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive()
+    assert w._infer_last_error is not None, (
+        "the inference fatal handler must pin an error so capture telemetry shows "
+        "the camera went box-blind"
+    )
+    assert "inference thread stopped" in w._infer_last_error


### PR DESCRIPTION
## What & why

The per-camera **capture** (`_run`) and **inference** (`_inference_loop`) threads could die silently on an unhandled exception, leaving the operator with a dead camera and an empty log. `_run` guarded only `source.read()`, so a raise in `_open_resources()` or anywhere else in the loop killed the capture thread **and skipped `_close_resources()`** — leaking the cv2 capture and the shared-memory segment. `_inference_loop` had no guard at all, so one raising stage killed inference and orphaned the appearance thread. Several hot-path errors were also swallowed at DEBUG/`pass`, so a real fault produced no log.

## The leak it fixes

- `_run` now wraps its whole body in `try/finally` so `_close_resources()` **always** runs (no leaked cv2 capture / shm segment), logs a fatal at ERROR with `exc_info`, and emits an ERROR/STOPPED health telemetry so the UI reflects the failure instead of hanging silently.
- A per-iteration `try/except` inside the `while` makes one bad tick log a throttled WARNING and continue rather than kill the thread.
- `_inference_loop` gets the same treatment: a `finally` that runs `_stop_appearance_thread()` (never orphaned), top-level ERROR logging, and a per-iteration guard so one raising stage doesn't kill inference — later frames still produce output. **Happy path preserved exactly.**

## Error-visibility changes (throttled WARNING, monotonic per-site gate)

- `ptz/controller.py` `_loop`: `except Exception: pass` → rate-limited `log.warning(exc_info=True)`.
- `supervisor.py` pump tick: DEBUG → rate-limited WARNING.
- `camera_worker.py` `_push_frame` shm/vcam push failure: DEBUG → throttled WARNING.
- `_maybe_track` detect/track failure: surface the first occurrence at WARNING (then throttle) and set a telemetry `last_error` (`_infer_last_error`, folded into telemetry) so the Camera Info panel can show **why** a streaming-but-box-blind camera has no tracks.

## Test coverage

New `tests/test_worker_crash_safety.py` drives a real `CameraWorker` with fake sources/stages that raise and asserts:
- `_close_resources()` runs (source released) even when `_open_resources` raises, and the thread exits cleanly.
- An ERROR/STOPPED health telemetry is emitted when a loop dies.
- A single raising `source.read()` doesn't kill capture.
- The inference loop survives a single raising stage (later frames still produce output).
- `_stop_appearance_thread()` runs in the `finally` on a fatal inference exit.

## Gates

- `ruff check` / `ruff format --check`: clean
- `mypy autoptz/engine/runtime/ autoptz/config/`: Success
- `pytest tests/`: **1147 passed**
- `python -m autoptz --selftest`: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)