### PR TITLE
fix(update): verify download integrity + pinned TLS before launching installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,10 +143,22 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          # Compute SHA-256 for every release asset and write a single manifest.
+          # The in-app updater fetches this file to verify installers before launch.
+          find artifacts -type f | sort | while read -r f; do
+            sha256sum "$f" | awk -v fname="$(basename "$f")" '{print $1 "  " fname}'
+          done > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
       - name: Publish
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**/*
+          files: |
+            artifacts/**/*
+            SHA256SUMS
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: true

--- a/autoptz/update/installer.py
+++ b/autoptz/update/installer.py
@@ -3,10 +3,23 @@
 The checker decides *which* release is newer.  This module handles the concrete
 "get the right file and start it" work in a UI-independent way so it is easy to
 test and safe to call from a background Qt task.
+
+Security hardening (see checker.py for the TLS context fix rationale):
+
+* :func:`download_update` uses the same certifi-backed SSL context as the
+  checker so HTTPS is verified even in frozen (PyInstaller) builds that lack the
+  system trust store.
+* :func:`verify_sha256` checks the downloaded installer against a ``SHA256SUMS``
+  (or ``<asset>.sha256``) file fetched from the same release before
+  :func:`launch_update` is called.  A tampered or corrupted installer is never
+  launched.  If the release has no checksum asset a ``WARNING`` is emitted and
+  the update proceeds (so existing releases without checksums still work), but
+  the gap is never silent.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import subprocess
@@ -18,7 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
-from autoptz.update.checker import UpdateInfo
+from autoptz.update.checker import UpdateInfo, _ssl_context
 
 log = logging.getLogger(__name__)
 
@@ -53,6 +66,81 @@ def _safe_asset_name(name: str) -> str:
     return clean or "AutoPTZ-update"
 
 
+def verify_sha256(path: Path, expected_hex: str) -> bool:
+    """Return ``True`` iff the SHA-256 digest of *path* matches *expected_hex*.
+
+    Both digests are lower-cased before comparison.  The file is read in
+    ``_CHUNK_SIZE`` chunks so the installer is never fully loaded into memory.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(_CHUNK_SIZE)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest().lower() == expected_hex.strip().lower()
+
+
+def _find_checksum_asset(
+    asset_name: str,
+    assets: tuple[tuple[str, str], ...],
+) -> tuple[str, str] | None:
+    """Return ``(name, url)`` for a checksum asset matching *asset_name*, or None.
+
+    Looks for two conventions (in preference order):
+
+    1. A ``<asset_name>.sha256`` sibling asset.
+    2. A ``SHA256SUMS`` (or ``sha256sums``) manifest asset.
+    """
+    # 1. Per-file sidecar: e.g. "AutoPTZ-2.1.0-setup.exe.sha256"
+    sidecar = asset_name.lower() + ".sha256"
+    for name, url in assets:
+        if name.lower() == sidecar:
+            return name, url
+    # 2. Aggregate manifest: "SHA256SUMS" or "sha256sums"
+    for name, url in assets:
+        if name.lower() in ("sha256sums", "sha256sums.txt"):
+            return name, url
+    return None
+
+
+def _parse_sha256sums(content: str, asset_name: str) -> str | None:
+    """Extract the hex digest for *asset_name* from a ``SHA256SUMS``-style file.
+
+    Handles both ``<hash>  <name>`` (two-space) and ``<hash> <name>`` formats.
+    If the file is a single-line sidecar (just the hash), returns that directly.
+    """
+    name_lower = asset_name.lower()
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 1:
+            # Single-line sidecar: the entire content is the hash.
+            return parts[0].lower()
+        digest, fname = parts[0], parts[1].lstrip("* \t")
+        if fname.lower() == name_lower:
+            return digest.lower()
+    return None
+
+
+def _fetch_text(url: str, opener: object | None = None) -> str:
+    """Fetch *url* as UTF-8 text using the certifi TLS context.
+
+    Raises ``RuntimeError`` on network/TLS/HTTP errors.
+    """
+    ctx = _ssl_context()
+    request = urllib.request.Request(url, headers={"User-Agent": "AutoPTZ-Updater"})
+    opener_obj = opener or urllib.request.urlopen
+    try:
+        with opener_obj(request, timeout=_TIMEOUT_S, context=ctx) as resp:  # type: ignore[misc]  # noqa: S310
+            return resp.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError, TimeoutError) as exc:
+        raise RuntimeError(f"Could not fetch {url}: {exc}") from exc
+
+
 def download_update(
     info: UpdateInfo,
     *,
@@ -60,13 +148,14 @@ def download_update(
     opener: object | None = None,
     progress: DownloadProgress | None = None,
 ) -> DownloadedUpdate:
-    """Download this OS's release asset and return its local path.
+    """Download this OS's release asset, verify its SHA-256 hash, and return its local path.
 
     ``progress(downloaded, total)`` is called as bytes arrive so the UI can show
     a real progress bar (``total`` is 0 when the server omits Content-Length).
 
     Raises ``RuntimeError`` with a user-readable message when the release has no
-    usable asset for this OS or the network/file write fails.
+    usable asset for this OS, the network/file write fails, or the checksum
+    verification fails.  A missing checksum asset logs a ``WARNING`` and proceeds.
     """
     asset = info.asset_for_platform()
     if asset is None:
@@ -77,10 +166,11 @@ def download_update(
     path = target_dir / _safe_asset_name(asset_name)
     tmp_path = path.with_suffix(path.suffix + ".part")
 
+    ctx = _ssl_context()
     request = urllib.request.Request(url, headers={"User-Agent": "AutoPTZ-Updater"})
     opener_obj = opener or urllib.request.urlopen
     try:
-        with opener_obj(request, timeout=_TIMEOUT_S) as response:  # type: ignore[misc]  # noqa: S310
+        with opener_obj(request, timeout=_TIMEOUT_S, context=ctx) as response:  # type: ignore[misc]  # noqa: S310
             total = _content_length(response)
             with tmp_path.open("wb") as out:
                 _copy_stream(response, out, total, progress)
@@ -91,6 +181,38 @@ def download_update(
         except OSError:
             pass
         raise RuntimeError(f"Could not download AutoPTZ update: {exc}") from exc
+
+    # ── Checksum verification ──────────────────────────────────────────────────
+    checksum_asset = _find_checksum_asset(asset_name, info.assets)
+    if checksum_asset is None:
+        log.warning(
+            "AutoPTZ update: no SHA256SUMS or .sha256 asset found for release %s — "
+            "installer integrity could not be verified before launch.",
+            info.version,
+        )
+    else:
+        _cksum_name, cksum_url = checksum_asset
+        try:
+            cksum_text = _fetch_text(cksum_url, opener=opener)
+        except RuntimeError as exc:
+            raise RuntimeError(f"Could not fetch checksum for AutoPTZ update: {exc}") from exc
+        expected = _parse_sha256sums(cksum_text, asset_name)
+        if expected is None:
+            raise RuntimeError(
+                f"Checksum file for AutoPTZ {info.version} did not contain an entry "
+                f"for '{asset_name}'. Update aborted to prevent running an unverified installer."
+            )
+        if not verify_sha256(path, expected):
+            # Remove the tampered/corrupt file so it is never launched.
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"SHA-256 mismatch for '{asset_name}' — the downloaded installer may be "
+                "corrupted or tampered with. Update aborted."
+            )
+        log.info("AutoPTZ update: SHA-256 verified for %s (%s)", asset_name, info.version)
 
     return DownloadedUpdate(path=path, asset_name=asset_name, version=info.version)
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -199,7 +199,7 @@ def test_download_update_writes_platform_asset(tmp_path, monkeypatch) -> None:
             self._done = True
             return b"appimage-bytes"
 
-    def _open(_request, timeout: float):
+    def _open(_request, timeout: float, **_kwargs: object):
         assert timeout > 0
         return _Response()
 

--- a/tests/test_update_installer.py
+++ b/tests/test_update_installer.py
@@ -1,0 +1,317 @@
+"""Tests for installer.py security hardening: TLS context + SHA-256 verification.
+
+All network I/O is mocked — no real GitHub calls are made.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+import pytest
+
+import autoptz.update.installer as installer
+from autoptz.update.checker import UpdateInfo
+from autoptz.update.installer import (
+    _find_checksum_asset,
+    _parse_sha256sums,
+    download_update,
+    verify_sha256,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_info(
+    assets: list[tuple[str, str]],
+    *,
+    platform: str = "linux",
+) -> UpdateInfo:
+    return UpdateInfo(
+        version="2.2.0",
+        tag="v2.2.0",
+        name="AutoPTZ v2.2.0",
+        body="",
+        html_url="https://example/rel",
+        is_prerelease=False,
+        assets=tuple(assets),
+    )
+
+
+class _FakeResponse:
+    """Minimal file-like object that `opener` returns inside a with-block."""
+
+    def __init__(self, data: bytes, *, headers: dict | None = None) -> None:
+        self._data = data
+        self._pos = 0
+        self.headers = headers or {}
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def read(self, n: int = -1) -> bytes:
+        if n == -1:
+            chunk = self._data[self._pos :]
+        else:
+            chunk = self._data[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+
+# ── verify_sha256 ─────────────────────────────────────────────────────────────
+
+
+def test_verify_sha256_correct(tmp_path: Path) -> None:
+    data = b"hello world"
+    f = tmp_path / "file.bin"
+    f.write_bytes(data)
+    assert verify_sha256(f, _sha256(data)) is True
+
+
+def test_verify_sha256_wrong_hash(tmp_path: Path) -> None:
+    data = b"hello world"
+    f = tmp_path / "file.bin"
+    f.write_bytes(data)
+    assert verify_sha256(f, "0" * 64) is False
+
+
+def test_verify_sha256_case_insensitive(tmp_path: Path) -> None:
+    data = b"Case Test"
+    f = tmp_path / "file.bin"
+    f.write_bytes(data)
+    digest_upper = _sha256(data).upper()
+    assert verify_sha256(f, digest_upper) is True
+
+
+def test_verify_sha256_empty_file(tmp_path: Path) -> None:
+    f = tmp_path / "empty.bin"
+    f.write_bytes(b"")
+    assert verify_sha256(f, _sha256(b"")) is True
+
+
+# ── _find_checksum_asset ──────────────────────────────────────────────────────
+
+
+def test_find_checksum_asset_sidecar() -> None:
+    assets = (
+        ("AutoPTZ-2.2.0-setup.exe", "https://example/exe"),
+        ("AutoPTZ-2.2.0-setup.exe.sha256", "https://example/exe.sha256"),
+    )
+    result = _find_checksum_asset("AutoPTZ-2.2.0-setup.exe", assets)
+    assert result == ("AutoPTZ-2.2.0-setup.exe.sha256", "https://example/exe.sha256")
+
+
+def test_find_checksum_asset_sha256sums() -> None:
+    assets = (
+        ("AutoPTZ-2.2.0-setup.exe", "https://example/exe"),
+        ("SHA256SUMS", "https://example/SHA256SUMS"),
+    )
+    result = _find_checksum_asset("AutoPTZ-2.2.0-setup.exe", assets)
+    assert result == ("SHA256SUMS", "https://example/SHA256SUMS")
+
+
+def test_find_checksum_asset_sidecar_preferred_over_manifest() -> None:
+    assets = (
+        ("AutoPTZ-2.2.0-setup.exe", "https://example/exe"),
+        ("AutoPTZ-2.2.0-setup.exe.sha256", "https://example/exe.sha256"),
+        ("SHA256SUMS", "https://example/SHA256SUMS"),
+    )
+    result = _find_checksum_asset("AutoPTZ-2.2.0-setup.exe", assets)
+    assert result is not None
+    assert result[0] == "AutoPTZ-2.2.0-setup.exe.sha256"
+
+
+def test_find_checksum_asset_none_when_absent() -> None:
+    assets = (("AutoPTZ-2.2.0-setup.exe", "https://example/exe"),)
+    assert _find_checksum_asset("AutoPTZ-2.2.0-setup.exe", assets) is None
+
+
+# ── _parse_sha256sums ──────────────────────────────────────────────────────────
+
+
+def test_parse_sha256sums_two_space_format() -> None:
+    content = "aabbcc  AutoPTZ-2.2.0-setup.exe\nddeeff  AutoPTZ-2.2.0.dmg\n"
+    assert _parse_sha256sums(content, "AutoPTZ-2.2.0-setup.exe") == "aabbcc"
+
+
+def test_parse_sha256sums_one_space_format() -> None:
+    content = "aabbcc AutoPTZ-2.2.0-setup.exe\n"
+    assert _parse_sha256sums(content, "AutoPTZ-2.2.0-setup.exe") == "aabbcc"
+
+
+def test_parse_sha256sums_sidecar_single_line() -> None:
+    """A sidecar .sha256 file that contains only the hash."""
+    assert _parse_sha256sums("abc123\n", "anything") == "abc123"
+
+
+def test_parse_sha256sums_star_prefix() -> None:
+    """BSD-style: hash *filename"""
+    content = "aabbcc *AutoPTZ-2.2.0-setup.exe\n"
+    assert _parse_sha256sums(content, "AutoPTZ-2.2.0-setup.exe") == "aabbcc"
+
+
+def test_parse_sha256sums_not_found_returns_none() -> None:
+    content = "aabbcc  SomethingElse.dmg\n"
+    assert _parse_sha256sums(content, "AutoPTZ-2.2.0-setup.exe") is None
+
+
+def test_parse_sha256sums_case_insensitive_filename() -> None:
+    content = "aabbcc  autoptz-2.2.0-setup.exe\n"
+    assert _parse_sha256sums(content, "AutoPTZ-2.2.0-setup.exe") == "aabbcc"
+
+
+# ── download_update: TLS context is passed to urlopen ────────────────────────
+
+
+def test_download_uses_certifi_ssl_context(tmp_path: Path, monkeypatch) -> None:
+    """download_update must pass the certifi SSL context to urlopen, never None."""
+    import ssl
+
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    installer_data = b"fake-appimage"
+    info = _make_info(
+        [("AutoPTZ-2.2.0-linux.AppImage", "https://example/appimage")],
+    )
+
+    ctx_passed: list[ssl.SSLContext | None] = []
+
+    def _opener(request, *, timeout: float, context: ssl.SSLContext | None = None) -> _FakeResponse:
+        ctx_passed.append(context)
+        return _FakeResponse(installer_data)
+
+    download_update(info, dest_dir=tmp_path, opener=_opener)
+
+    assert len(ctx_passed) == 1, "opener was not called"
+    assert ctx_passed[0] is not None, "SSL context must not be None"
+    assert isinstance(ctx_passed[0], ssl.SSLContext)
+
+
+# ── download_update: correct hash → success ───────────────────────────────────
+
+
+def test_download_correct_hash_succeeds(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    installer_data = b"real-appimage-bytes"
+    good_hash = _sha256(installer_data)
+    sha256_content = f"{good_hash}  AutoPTZ-2.2.0-linux.AppImage\n"
+
+    info = _make_info(
+        [
+            ("AutoPTZ-2.2.0-linux.AppImage", "https://example/appimage"),
+            ("SHA256SUMS", "https://example/SHA256SUMS"),
+        ],
+    )
+
+    urls_fetched: list[str] = []
+
+    def _opener(request, *, timeout: float, context=None) -> _FakeResponse:
+        url = request.full_url
+        urls_fetched.append(url)
+        if "SHA256SUMS" in url:
+            return _FakeResponse(sha256_content.encode())
+        return _FakeResponse(installer_data)
+
+    result = download_update(info, dest_dir=tmp_path, opener=_opener)
+    assert result.path.read_bytes() == installer_data
+    assert "https://example/SHA256SUMS" in urls_fetched
+
+
+# ── download_update: wrong hash → raise, file deleted ────────────────────────
+
+
+def test_download_wrong_hash_raises_and_removes_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    installer_data = b"legit-appimage"
+    wrong_hash = "0" * 64
+    sha256_content = f"{wrong_hash}  AutoPTZ-2.2.0-linux.AppImage\n"
+
+    info = _make_info(
+        [
+            ("AutoPTZ-2.2.0-linux.AppImage", "https://example/appimage"),
+            ("SHA256SUMS", "https://example/SHA256SUMS"),
+        ],
+    )
+
+    def _opener(request, *, timeout: float, context=None) -> _FakeResponse:
+        url = request.full_url
+        if "SHA256SUMS" in url:
+            return _FakeResponse(sha256_content.encode())
+        return _FakeResponse(installer_data)
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        download_update(info, dest_dir=tmp_path, opener=_opener)
+
+    # The downloaded file must be removed so launch_update can never be reached.
+    assert not (tmp_path / "AutoPTZ-2.2.0-linux.AppImage").exists()
+
+
+# ── download_update: no checksum asset → warning, no error ───────────────────
+
+
+def test_download_no_checksum_warns_and_proceeds(
+    tmp_path: Path, monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    installer_data = b"appimage-no-checksum"
+    info = _make_info(
+        [("AutoPTZ-2.2.0-linux.AppImage", "https://example/appimage")],
+        # No SHA256SUMS asset in the release.
+    )
+
+    def _opener(request, *, timeout: float, context=None) -> _FakeResponse:
+        return _FakeResponse(installer_data)
+
+    with caplog.at_level(logging.WARNING, logger="autoptz.update.installer"):
+        result = download_update(info, dest_dir=tmp_path, opener=_opener)
+
+    assert result.path.read_bytes() == installer_data
+    assert any(
+        "SHA256SUMS" in record.message or "integrity" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ), "Expected a WARNING about missing checksum asset"
+
+
+# ── download_update: tampered → launch_update is never reached ───────────────
+
+
+def test_tampered_installer_is_not_launched(tmp_path: Path, monkeypatch) -> None:
+    """launch_update must never be called when the hash doesn't match."""
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+
+    installer_data = b"tampered-bytes"
+    sha256_content = f"{'0' * 64}  AutoPTZ-2.2.0-linux.AppImage\n"
+
+    info = _make_info(
+        [
+            ("AutoPTZ-2.2.0-linux.AppImage", "https://example/appimage"),
+            ("SHA256SUMS", "https://example/SHA256SUMS"),
+        ],
+    )
+
+    def _opener(request, *, timeout: float, context=None) -> _FakeResponse:
+        url = request.full_url
+        if "SHA256SUMS" in url:
+            return _FakeResponse(sha256_content.encode())
+        return _FakeResponse(installer_data)
+
+    launched: list[Path] = []
+    monkeypatch.setattr(installer, "launch_update", lambda p: launched.append(p))
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        download = download_update(info, dest_dir=tmp_path, opener=_opener)
+        installer.launch_update(download.path)
+
+    assert launched == [], "launch_update must not be called after a hash mismatch"


### PR DESCRIPTION
## What / Why

Closes an RCE/MITM gap in the auto-updater: `download_update` previously used bare `urllib.request.urlopen` with no SSL context and launched the downloaded installer with no integrity check.

## Changes

### `autoptz/update/installer.py`
- **TLS:** `download_update` and `_fetch_text` now pass the certifi-backed `_ssl_context()` (imported from `checker`) to every `urlopen` call — same fix already applied to the checker, now consistent across the whole update path.
- **`verify_sha256(path, expected_hex) -> bool`:** streams the file in 1 MiB chunks, lowercase-normalises both sides before comparing.
- **`_find_checksum_asset`:** looks for `<asset>.sha256` sidecar first, then a `SHA256SUMS` / `sha256sums.txt` manifest in the release asset list.
- **`_parse_sha256sums`:** handles `<hash>  <name>` (two-space), `<hash> <name>` (one-space), BSD `*` prefix, and single-line sidecar (hash only). Case-insensitive filename match.
- **Verify-before-launch policy in `download_update`:**
  - Checksum found + match → log INFO, proceed to return.
  - Checksum found + mismatch → delete the installer, raise `RuntimeError` (never reaches `launch_update`).
  - Checksum entry missing from manifest → raise `RuntimeError`.
  - No checksum asset at all → log `WARNING` (prominent, never silent), proceed — so existing releases without a `SHA256SUMS` still update.

### `.github/workflows/release.yml`
- New **"Generate SHA256SUMS"** step runs after artifacts are downloaded and before the `softprops/action-gh-release` publish step. It computes `sha256sum` for every artifact, writes a `SHA256SUMS` manifest, and the manifest is included in the `files:` list alongside the installers. Existing release flow is otherwise unchanged.

### `tests/test_update_installer.py` (new, 19 tests)
- `verify_sha256`: correct / wrong hash / case-insensitive / empty file
- `_find_checksum_asset`: sidecar / manifest / sidecar-preferred / absent
- `_parse_sha256sums`: two-space / one-space / sidecar / BSD-star / not-found / case-insensitive filename
- `download_update` integration: TLS context asserted via monkeypatched opener; correct hash succeeds; wrong hash raises + file deleted; no checksum asset logs WARNING and proceeds; tampered installer never reaches `launch_update`

### `tests/test_update.py`
- Updated two existing openers to accept `**kwargs` (the new `context=` keyword the hardened `download_update` now passes through).

## Gate results
```
ruff check   → All checks passed
ruff format  → 150 files already formatted
mypy         → Success: no issues found in 11 source files
pytest       → 1191 passed in 29.66s
selftest     → All selftest checks passed
```