### PR TITLE
feat(center-stage): dead-zone hold, calmer zoom, sharper upscale, 30fps vcam

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -71,6 +71,21 @@ _PREVIEW_H = 720
 # sources. Detection/tracking use the full-rate frame on a separate path.
 _PREVIEW_PUSH_FPS = 20.0
 _PREVIEW_PUSH_MIN_PERIOD_S = 1.0 / _PREVIEW_PUSH_FPS
+# The virtual-camera output is a real product feed (Zoom/OBS), not a monitoring
+# tile, so it runs on its OWN, faster gate — decoupled from the preview cap so it
+# isn't throttled to ≤20 fps while the source delivers 30. The vcam send and the
+# preview push are gated independently in ``_push_frame``.
+_VCAM_PUSH_FPS = 30.0
+_VCAM_PUSH_MIN_PERIOD_S = 1.0 / _VCAM_PUSH_FPS
+
+
+def _push_due(now: float, last: float, min_period: float) -> bool:
+    """Whether a rate-gated push is due: at least ``min_period`` since ``last``.
+
+    Pure helper so the preview/vcam send cadence is unit-testable without timing.
+    """
+    return (now - last) >= min_period
+
 
 # Center Stage crop tightness per "Framing" preset → (subject fill of crop,
 # max crop as a fraction of the frame). A smaller ``max_frac`` forces a tighter
@@ -345,6 +360,7 @@ class CameraWorker:
         self._face: Any | None = None
         self._last_face_t = 0.0
         self._last_preview_push_t = 0.0
+        self._last_vcam_push_t = 0.0
         self._last_harvest_t = 0.0
         self._last_crop_t = 0.0
         # Most recent face→identity bindings seen this tick: track_id → (id, conf).
@@ -3395,7 +3411,12 @@ class CameraWorker:
         crop = frame[y : y + ch, x : x + cw]
         if crop.size == 0:
             return frame
-        return cv2.resize(crop, (ow, oh), interpolation=cv2.INTER_LINEAR)
+        from autoptz.engine.pipeline.vcam import pick_interpolation
+
+        # The crop is almost always UPSCALED to the output → INTER_LINEAR looks
+        # soft. Pick by scale factor: cubic up, area down, linear ~1:1.
+        interp = pick_interpolation((int(crop.shape[1]), int(crop.shape[0])), (ow, oh))
+        return cv2.resize(crop, (ow, oh), interpolation=interp)
 
     def _current_digital_target(self) -> tuple[float, float, float, float] | None:
         """The selected target's bbox (x1,y1,x2,y2) for Center Stage, or None.
@@ -3427,18 +3448,36 @@ class CameraWorker:
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:
             return
-        # Cap the preview rate: skip the resize/push when the last preview frame
-        # was pushed less than one preview period ago (saves CPU on >20fps sources
-        # without affecting tracking, which uses the full-rate frame elsewhere).
         now = time.monotonic()
-        if now - self._last_preview_push_t < _PREVIEW_PUSH_MIN_PERIOD_S:
+        vcam_on = bool(getattr(self.config.ptz, "vcam_out", False))
+        # Two INDEPENDENT rate gates:
+        #  • preview (~20 fps) — the SHM monitoring tile only; capping it skips the
+        #    per-frame resize/copy on faster sources (overlays come from telemetry).
+        #  • vcam (~30 fps) — a real product feed, so it is NOT throttled to the
+        #    preview rate; it sends up to 30 fps when ``vcam_out`` is on.
+        preview_due = _push_due(now, self._last_preview_push_t, _PREVIEW_PUSH_MIN_PERIOD_S)
+        vcam_due = vcam_on and _push_due(now, self._last_vcam_push_t, _VCAM_PUSH_MIN_PERIOD_S)
+
+        # Release the device promptly once output is turned off (so it disconnects
+        # from Zoom/OBS instead of lingering on a frozen frame) regardless of gates.
+        if not vcam_on and self._vcam is not None:
+            try:
+                self._vcam.close()
+            finally:
+                self._vcam = None
+
+        # CPU savings preserved: if neither sink is due this tick, do no framing.
+        if not preview_due and not vcam_due:
             return
-        self._last_preview_push_t = now
+
         try:
+            # Compute the framed (cropped+scaled) output ONCE and share it.
             framed = self._framed_output(frame)
-            f = self._fit_frame(framed)
-            self._shm.push(f)
-            if getattr(self.config.ptz, "vcam_out", False):
+            if preview_due:
+                self._last_preview_push_t = now
+                self._shm.push(self._fit_frame(framed))
+            if vcam_due:
+                self._last_vcam_push_t = now
                 ow = int(getattr(self.config.ptz, "digital_output_w", 1280))
                 oh = int(getattr(self.config.ptz, "digital_output_h", 720))
                 if self._vcam is None:
@@ -3446,11 +3485,6 @@ class CameraWorker:
 
                     self._vcam = VirtualCamSink(ow, oh)
                 self._vcam.send_bgr(framed)
-            elif self._vcam is not None:
-                # Virtual camera output was turned off — release the device so it
-                # disconnects from Zoom/OBS instead of lingering on a frozen frame.
-                self._vcam.close()
-                self._vcam = None
         except Exception:  # noqa: BLE001
             # Was DEBUG-only: a broken preview pipe (shm/vcam) left the operator
             # staring at a frozen preview with an empty log.  Surface it as a

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -64,18 +64,45 @@ def desired_crop(
 
 @dataclass
 class DigitalFramer:
-    """Stateful EMA-smoothed wrapper around :func:`desired_crop`."""
+    """Stateful EMA-smoothed wrapper around :func:`desired_crop`.
+
+    Position (x, y) and size (w, h) are smoothed *separately* so detector-height
+    flicker doesn't cause visible zoom breathing:
+
+    * **Position dead-zone** (``deadzone``) — the crop centre only re-targets when
+      the desired centre has moved more than ``deadzone`` of the current crop's
+      width/height. Inside the band the centre is *held* (a stationary subject
+      with normal bbox noise produces a still frame). Hysteresis: once the centre
+      is moving it keeps following until the desired centre is back inside a
+      *tighter* inner band (``deadzone * _INNER_BAND_FRAC``), so it does not
+      chatter on the boundary.
+    * **Size smoothing** (``size_smooth``) eases w/h at its own, slower constant,
+      and a **size dead-band** (``size_deadband``) ignores size changes under a
+      few percent so small height flicker leaves the zoom untouched.
+
+    ``deadzone=0.0`` with ``size_smooth == smooth`` and ``size_deadband=0.0``
+    reproduces the original uniform-EMA behaviour exactly.
+    """
 
     out_aspect: float = 16.0 / 9.0
     fill: float = 0.70
     min_frac: float = 0.34
     max_frac: float = 0.78  # crop is at most this fraction of the frame (always crops)
-    smooth: float = 0.18  # EMA weight toward the desired crop each frame
+    smooth: float = 0.18  # EMA weight toward the desired crop CENTRE each frame
+    size_smooth: float = 0.08  # slower EMA weight for crop SIZE (w, h) → calmer zoom
+    deadzone: float = 0.04  # hold centre while desired moves < this frac of crop w/h
+    size_deadband: float = 0.03  # ignore size changes under this fraction
     headroom: float = 0.10
     _crop: tuple[float, float, float, float] | None = None
+    _following: bool = False  # hysteresis: True once the centre is being tracked
+
+    # Once moving, keep following until the desired centre is back inside this
+    # (tighter) fraction of the dead-zone band — prevents boundary chatter.
+    _INNER_BAND_FRAC: float = 0.5
 
     def reset(self) -> None:
         self._crop = None
+        self._following = False
 
     def frame_for(
         self, bbox: tuple[float, float, float, float], frame_w: int, frame_h: int
@@ -100,10 +127,51 @@ class DigitalFramer:
     def _step(self, tgt: tuple[float, float, float, float]) -> tuple[int, int, int, int]:
         if self._crop is None:
             self._crop = tgt
-        else:
+            self._following = False
+            x, y, w, h = self._crop
+            return (int(round(x)), int(round(y)), max(1, int(round(w))), max(1, int(round(h))))
+
+        cx, cy, cw, ch = self._crop
+        tx, ty, tw, th = tgt
+
+        # ── Size (w, h): slower EMA, with a dead-band on small changes ──────────
+        nw = self._ease_size(cw, tw)
+        nh = self._ease_size(ch, th)
+
+        # ── Position (x, y): dead-zone hold + hysteresis on the crop CENTRE ─────
+        # Compare the desired crop CENTRE to the held centre; the band scales with
+        # the current crop size so it tracks the on-screen subject size.
+        held_cx, held_cy = cx + cw * 0.5, cy + ch * 0.5
+        des_cx, des_cy = tx + tw * 0.5, ty + th * 0.5
+        outer_x, outer_y = self.deadzone * cw, self.deadzone * ch
+        inner_x = outer_x * self._INNER_BAND_FRAC
+        inner_y = outer_y * self._INNER_BAND_FRAC
+        moved_x, moved_y = abs(des_cx - held_cx), abs(des_cy - held_cy)
+
+        if self._following:
+            # Keep following until BOTH axes settle back inside the inner band.
+            if moved_x <= inner_x and moved_y <= inner_y:
+                self._following = False
+        elif moved_x > outer_x or moved_y > outer_y:
+            self._following = True
+
+        if self._following:
             a = self.smooth
-            self._crop = tuple(  # type: ignore[assignment]
-                c + a * (t - c) for c, t in zip(self._crop, tgt, strict=True)
-            )
-        x, y, w, h = self._crop
-        return (int(round(x)), int(round(y)), max(1, int(round(w))), max(1, int(round(h))))
+            nx = cx + a * (tx - cx)
+            ny = cy + a * (ty - cy)
+        else:
+            # Held: keep the existing top-left (the centre does not move). If the
+            # size eased, re-anchor x/y so the *centre* stays put rather than the
+            # corner — otherwise a size change would drift the held subject.
+            nx = held_cx - nw * 0.5
+            ny = held_cy - nh * 0.5
+
+        self._crop = (nx, ny, nw, nh)
+        return (int(round(nx)), int(round(ny)), max(1, int(round(nw))), max(1, int(round(nh))))
+
+    def _ease_size(self, cur: float, tgt: float) -> float:
+        """Ease one crop dimension toward *tgt*: ignore sub-dead-band changes,
+        otherwise EMA at the (slower) ``size_smooth`` constant."""
+        if cur > 0.0 and abs(tgt - cur) <= self.size_deadband * cur:
+            return cur
+        return cur + self.size_smooth * (tgt - cur)

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -134,9 +134,14 @@ class DigitalFramer:
         cx, cy, cw, ch = self._crop
         tx, ty, tw, th = tgt
 
-        # ── Size (w, h): slower EMA, with a dead-band on small changes ──────────
-        nw = self._ease_size(cw, tw)
+        # ── Size: ease ONE aspect-locked scalar, then derive the other ──────────
+        # Easing w and h through INDEPENDENT dead-bands lets one axis cross while
+        # the other freezes (because cw != ch), so the crop drifts off-aspect and
+        # the fixed-size output resize stretches the subject. Ease HEIGHT through
+        # the dead-band + slower size constant, then DERIVE width from the output
+        # aspect so the crop stays locked on out_aspect every frame.
         nh = self._ease_size(ch, th)
+        nw = nh * self.out_aspect
 
         # ── Position (x, y): dead-zone hold + hysteresis on the crop CENTRE ─────
         # Compare the desired crop CENTRE to the held centre; the band scales with

--- a/autoptz/engine/pipeline/vcam.py
+++ b/autoptz/engine/pipeline/vcam.py
@@ -12,6 +12,29 @@ log = logging.getLogger(__name__)
 _PVC_AVAILABLE: bool | None = None
 
 
+def pick_interpolation(src_size: tuple[int, int], dst_size: tuple[int, int]) -> int:
+    """Choose the best ``cv2`` interpolation for a resize from *src* to *dst*.
+
+    Both sizes are ``(width, height)``. The Center-Stage crop is almost always
+    *upscaled* to the output (a window of the frame blown up), which looks soft
+    under ``INTER_LINEAR`` — so:
+
+    * **Up** (dst larger in either dimension) → ``INTER_CUBIC`` (sharper).
+    * **Down** (dst smaller in both dimensions) → ``INTER_AREA`` (best for shrink).
+    * **~1:1** → ``INTER_LINEAR`` (cheap, no quality loss when not scaling).
+    """
+    import cv2
+
+    sw, sh = src_size
+    dw, dh = dst_size
+    if dw == sw and dh == sh:
+        return int(cv2.INTER_LINEAR)
+    # If we are growing in *either* dimension, favour upscale sharpness.
+    if dw > sw or dh > sh:
+        return int(cv2.INTER_CUBIC)
+    return int(cv2.INTER_AREA)
+
+
 def _probe_pyvirtualcam() -> bool:
     global _PVC_AVAILABLE
     if _PVC_AVAILABLE is None:
@@ -54,7 +77,10 @@ class VirtualCamSink:
             if frame.shape[1] != self.width or frame.shape[0] != self.height:
                 import cv2
 
-                frame = cv2.resize(frame, (self.width, self.height))
+                interp = pick_interpolation(
+                    (int(frame.shape[1]), int(frame.shape[0])), (self.width, self.height)
+                )
+                frame = cv2.resize(frame, (self.width, self.height), interpolation=interp)
             self._cam.send(frame)
         except Exception:  # noqa: BLE001 — never let output break the pipeline
             log.debug("virtual camera send failed", exc_info=True)

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -146,6 +146,40 @@ class TestSizeSmoothing:
         # Both grow toward the new size, but the slower constant lags behind.
         assert s[3] > 0 and fa[3] > s[3]
 
+    def test_crop_stays_on_aspect_when_size_deltas_straddle_deadband(self):
+        # B4 regression guard (point case). When w and h were eased through
+        # INDEPENDENT size dead-bands, one axis could freeze while the other eased,
+        # because cw != ch makes the same target produce different per-axis deltas
+        # relative to the dead-band. Crop 800x450 (16:9) → target 818x470: w changes
+        # 2.25% (under a 3% dead-band → frozen) but h changes 4.4% (over → eases),
+        # so the OLD code returned 800x470 (aspect 1.70) and the fixed-size output
+        # resize stretched the subject. The fix eases height then DERIVES width from
+        # out_aspect, so the crop stays on aspect.
+        f = DigitalFramer(
+            out_aspect=ASPECT, smooth=1.0, size_smooth=1.0, deadzone=0.04, size_deadband=0.03
+        )
+        f._crop = (0.0, 0.0, 800.0, 450.0)
+        _, _, w, h = f._step((0.0, 0.0, 818.0, 470.0))
+        assert abs(w / h - ASPECT) < 0.01, f"crop went off-aspect: {w}x{h} = {w / h:.4f}"
+
+    def test_crop_stays_on_aspect_through_slow_zoom(self):
+        # B4 regression guard (sequence case): drive a slow zoom (subject grows over
+        # many frames, small per-frame size steps near the dead-band) and assert the
+        # crop aspect stays locked on out_aspect every frame.
+        f = DigitalFramer(
+            out_aspect=ASPECT,
+            smooth=1.0,
+            size_smooth=0.08,  # slow zoom → small per-frame size steps near the band
+            deadzone=0.04,
+            size_deadband=0.03,
+        )
+        for i in range(30):
+            half_h = 135 + i * 2  # subject slowly steps closer
+            half_w = 100
+            bbox = (960 - half_w, 540 - half_h, 960 + half_w, 540 + half_h)
+            _, _, w, h = f.frame_for(bbox, 1920, 1080)
+            assert abs(w / h - ASPECT) < 0.01, f"frame {i}: aspect {w / h:.4f} drifted"
+
     def test_size_smooth_equal_reproduces_prior_behavior(self):
         # size_smooth == smooth and no dead-bands → old uniform EMA on all 4 params.
         f = DigitalFramer(

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -71,3 +71,97 @@ class TestDigitalFramer:
         left = f.frame_for((300, 400, 500, 670), 1920, 1080)
         right = f.frame_for((1400, 400, 1600, 670), 1920, 1080)
         assert right[0] > left[0]  # crop followed the subject to the right
+
+
+class TestPositionDeadZone:
+    """B3 — a stationary subject with bbox noise must produce a still frame."""
+
+    def test_small_jitter_holds_center(self):
+        # Dead-zone on; tight position smoothing so any drift WOULD show without it.
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.04)
+        bbox = (860, 400, 1060, 670)
+        first = f.frame_for(bbox, 1920, 1080)
+        # Tiny per-frame jitter (a few px) around the same centre — well within the
+        # dead-zone band of the crop width.
+        jitter = [(-3, 2), (4, -1), (-2, -3), (3, 1), (-1, 2), (2, -2)]
+        last = first
+        for dx, dy in jitter:
+            jbox = (860 + dx, 400 + dy, 1060 + dx, 670 + dy)
+            last = f.frame_for(jbox, 1920, 1080)
+        # Crop centre held put despite the jitter.
+        assert last[0] == first[0]
+        assert last[1] == first[1]
+
+    def test_sustained_move_follows(self):
+        # A real, sustained move past the band must be followed.
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.04)
+        start = f.frame_for((860, 400, 1060, 670), 1920, 1080)
+        moved = start
+        for _ in range(20):
+            moved = f.frame_for((1300, 400, 1500, 670), 1920, 1080)
+        assert moved[0] > start[0] + 50  # crop clearly followed the subject
+
+    def test_deadzone_zero_reproduces_prior_behavior(self):
+        # deadzone=0 must reproduce the old per-frame tracking exactly.
+        old = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.0, size_smooth=1.0)
+        old.frame_for((860, 400, 1060, 670), 1920, 1080)
+        # A 5px nudge moves the crop with deadzone=0 (no hold band).
+        nudged = old.frame_for((870, 400, 1070, 670), 1920, 1080)
+        ref = desired_crop(
+            (870, 400, 1070, 670),
+            1920,
+            1080,
+            out_aspect=ASPECT,
+            fill=old.fill,
+            min_frac=old.min_frac,
+            max_frac=old.max_frac,
+            headroom=old.headroom,
+        )
+        assert nudged[0] == int(round(ref[0]))
+
+
+class TestSizeSmoothing:
+    """B4 — split size smoothing from position smoothing."""
+
+    def test_size_deadband_holds_w_h(self):
+        # Position locked (deadzone), size flicker within the size dead-band → w/h
+        # stays put.
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0, size_smooth=1.0, size_deadband=0.05)
+        first = f.frame_for((860, 400, 1060, 670), 1920, 1080)
+        # +2% subject height flicker — under the 5% size dead-band.
+        flicker = f.frame_for((860, 400, 1060, 675), 1920, 1080)
+        assert flicker[2] == first[2]
+        assert flicker[3] == first[3]
+
+    def test_sustained_size_change_eases_slowly(self):
+        # A big sustained size change is followed, but at the slower size constant.
+        slow = DigitalFramer(out_aspect=ASPECT, smooth=1.0, size_smooth=0.08, size_deadband=0.02)
+        fast = DigitalFramer(out_aspect=ASPECT, smooth=1.0, size_smooth=0.5, size_deadband=0.02)
+        slow.frame_for((860, 400, 1060, 670), 1920, 1080)
+        fast.frame_for((860, 400, 1060, 670), 1920, 1080)
+        # Subject grows a lot (steps closer).
+        big = (760, 300, 1160, 900)
+        s = slow.frame_for(big, 1920, 1080)
+        fa = fast.frame_for(big, 1920, 1080)
+        # Both grow toward the new size, but the slower constant lags behind.
+        assert s[3] > 0 and fa[3] > s[3]
+
+    def test_size_smooth_equal_reproduces_prior_behavior(self):
+        # size_smooth == smooth and no dead-bands → old uniform EMA on all 4 params.
+        f = DigitalFramer(
+            out_aspect=ASPECT, smooth=0.18, size_smooth=0.18, deadzone=0.0, size_deadband=0.0
+        )
+        f._crop = (100.0, 100.0, 800.0, 450.0)
+        ref = DigitalFramer(out_aspect=ASPECT, smooth=0.18)
+        ref._crop = (100.0, 100.0, 800.0, 450.0)
+        tgt = (200.0, 150.0, 900.0, 506.25)
+        got = f._step(tgt)
+        # Replicate the old uniform-EMA step for the reference.
+        a = 0.18
+        exp = tuple(c + a * (t - c) for c, t in zip((100.0, 100.0, 800.0, 450.0), tgt, strict=True))
+        assert got == (
+            int(round(exp[0])),
+            int(round(exp[1])),
+            max(1, int(round(exp[2]))),
+            max(1, int(round(exp[3]))),
+        )

--- a/tests/test_vcam.py
+++ b/tests/test_vcam.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from autoptz.engine.pipeline.vcam import VirtualCamSink
+from autoptz.engine.pipeline.vcam import VirtualCamSink, pick_interpolation
 
 
 def test_sink_is_noop_without_pyvirtualcam(monkeypatch):
@@ -13,3 +13,73 @@ def test_sink_is_noop_without_pyvirtualcam(monkeypatch):
     assert sink.available is False
     sink.send_bgr(np.zeros((480, 640, 3), dtype=np.uint8))  # must not raise
     sink.close()
+
+
+class TestPickInterpolation:
+    """B5 — choose a quality-appropriate interpolation by scale factor."""
+
+    def test_upscale_uses_cubic(self):
+        import cv2
+
+        # Source smaller than destination → upscaling → high-quality cubic.
+        assert pick_interpolation((640, 360), (1280, 720)) == cv2.INTER_CUBIC
+
+    def test_downscale_uses_area(self):
+        import cv2
+
+        # Source larger than destination → downscaling → area (best for shrink).
+        assert pick_interpolation((1920, 1080), (1280, 720)) == cv2.INTER_AREA
+
+    def test_one_to_one_uses_linear(self):
+        import cv2
+
+        assert pick_interpolation((1280, 720), (1280, 720)) == cv2.INTER_LINEAR
+
+    def test_mixed_scale_prefers_upscale_quality(self):
+        import cv2
+
+        # Width grows, height shrinks: treat as an upscale (favour sharpness).
+        assert pick_interpolation((1000, 800), (1280, 720)) == cv2.INTER_CUBIC
+
+
+class TestVcamRateGate:
+    """B6 — the vcam send runs on its own ~30fps gate, independent of the
+    ~20fps preview gate. The decision is a pure elapsed-vs-period check."""
+
+    def test_due_when_period_elapsed(self):
+        from autoptz.engine.camera_worker import _VCAM_PUSH_MIN_PERIOD_S, _push_due
+
+        last = 100.0
+        # Just under one period → not due.
+        assert (
+            _push_due(last + _VCAM_PUSH_MIN_PERIOD_S * 0.9, last, _VCAM_PUSH_MIN_PERIOD_S) is False
+        )
+        # At/after a full period → due.
+        assert (
+            _push_due(last + _VCAM_PUSH_MIN_PERIOD_S * 1.001, last, _VCAM_PUSH_MIN_PERIOD_S) is True
+        )
+
+    def test_vcam_faster_than_preview(self):
+        from autoptz.engine.camera_worker import (
+            _PREVIEW_PUSH_MIN_PERIOD_S,
+            _VCAM_PUSH_MIN_PERIOD_S,
+        )
+
+        # The vcam must run at a higher rate (shorter period) than the preview.
+        assert _VCAM_PUSH_MIN_PERIOD_S < _PREVIEW_PUSH_MIN_PERIOD_S
+
+    def test_vcam_due_independently_of_preview(self):
+        from autoptz.engine.camera_worker import (
+            _PREVIEW_PUSH_MIN_PERIOD_S,
+            _VCAM_PUSH_MIN_PERIOD_S,
+            _push_due,
+        )
+
+        # At a moment one vcam-period after the last vcam push but BEFORE a full
+        # preview period, the vcam is due while the preview is not — proving the
+        # vcam is no longer throttled to the preview rate.
+        t0 = 0.0
+        now = t0 + _VCAM_PUSH_MIN_PERIOD_S
+        assert now < t0 + _PREVIEW_PUSH_MIN_PERIOD_S  # within one preview period
+        assert _push_due(now, t0, _VCAM_PUSH_MIN_PERIOD_S) is True
+        assert _push_due(now, t0, _PREVIEW_PUSH_MIN_PERIOD_S) is False


### PR DESCRIPTION
Four quality fixes that make the digital **Center Stage** framer (what users see on the virtual camera) feel like a real product. TDD; tests added in `tests/test_digital_framer.py` and `tests/test_vcam.py`.

## B3 — Positional dead-zone / hold band
The crop centre used to track the raw bbox centre every frame, so detector jitter jittered the frame. `DigitalFramer` now **holds** the crop centre while the *desired* crop centre stays within `deadzone` of the current crop's width/height, with **hysteresis** (once moving it keeps following until the desired centre returns inside a tighter inner band at half the dead-zone) so it doesn't chatter on the boundary.
- A stationary subject with normal bbox noise → still frame.
- A sustained move past the band → followed.
- **Default `deadzone = 0.04`.** `deadzone = 0.0` (with `size_smooth == smooth`, dead-bands at 0) reproduces the prior per-frame behaviour exactly.

## B4 — Split size smoothing from position smoothing
`_step` eased all four crop params with one `smooth = 0.18` EMA, so detector-height flicker caused visible zoom breathing. Crop SIZE (w, h) now has its own slower constant plus a size dead-band; position (x, y) keeps `smooth = 0.18`.
- **Defaults: `size_smooth = 0.08`, `size_deadband = 0.03`** (ignore sub-3% size flicker).
- `size_smooth == smooth` with both dead-bands at 0 reproduces the old uniform EMA.

## B5 — Higher-quality upscaler
The crop is almost always **upscaled** to the output → `INTER_LINEAR` looked soft. New `pick_interpolation(src, dst)` helper in `vcam.py`: `INTER_CUBIC` when growing in either dimension (the common case), `INTER_AREA` when shrinking, `INTER_LINEAR` at ~1:1. Wired into `camera_worker._framed_output` (was hardcoded LINEAR) and `VirtualCamSink.send_bgr` (was default interpolation).

## B6 — Decouple the vcam output rate from the 20 fps preview cap
The vcam send sat inside `_push_frame`, which early-returns under the ~20 fps preview gate, throttling the virtual camera to ≤20 fps while webcams output 30. `_push_frame` now runs **two independent gates**:
- preview (`_PREVIEW_PUSH_FPS = 20`) → the SHM monitoring tile, unchanged;
- vcam (**`_VCAM_PUSH_FPS = 30`**) → its own gate, only when `vcam_out` is on.

The framed output is computed **once and shared**, and **only when preview OR vcam is due** — so the preview CPU savings are preserved (no framing when neither sink is due). The send decision is extracted as the pure `_push_due(now, last, period)` helper for unit testing (no real timing). The off-switch device release still runs every tick. **No NV12 conversion** — the pyvirtualcam BGR path is fine; NV12 belongs to future native-device work, out of scope here.

## Gates (all green)
- `ruff check` — All checks passed
- `ruff format --check` — 149 files already formatted
- `mypy autoptz/engine/runtime/ autoptz/config/` — Success, no issues
- `pytest tests/ --timeout=60` — **1185 passed**
- `python -m autoptz --selftest` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)