### PR TITLE
fix(ptz): stop-on-loss — ONVIF dead-man's-switch + VISCA halt-on-reconnect

### DIFF
--- a/autoptz/engine/ptz/onvif_ptz.py
+++ b/autoptz/engine/ptz/onvif_ptz.py
@@ -10,16 +10,31 @@ Implements:
   GotoPreset      — by integer slot (1-based, as ONVIF spec requires)
   SetPreset       — store current position as named preset
   GetStatus       — PTZState with current position
+
+Safety: every ContinuousMove carries a Timeout so the camera self-stops if
+the next command does not arrive (dead-man's switch).  Transport errors in
+move_velocity / stop are caught and logged at WARNING (throttled) so a hung
+or dropped camera never blocks or crashes the control loop.
 """
 
 from __future__ import annotations
 
 import logging
+import time
+from datetime import timedelta
 from typing import Any
 
 from autoptz.engine.ptz.base import PTZBackend, PTZCaps, PTZState
 
 log = logging.getLogger(__name__)
+
+# How long the camera keeps moving if no new command arrives.
+# Set to ~1 second — a comfortable dead-man window at 10–30 Hz command rates.
+_CONTINUOUSMOVE_TIMEOUT: timedelta = timedelta(seconds=1)
+
+# Throttle transport-error log messages: emit at most one WARNING per this many
+# seconds so a sustained outage doesn't flood the log.
+_LOG_THROTTLE_S: float = 5.0
 
 
 def _require_onvif() -> Any:
@@ -94,18 +109,39 @@ class ONVIFPTZBackend(PTZBackend):
             native_presets=True,
             query_position=True,
         )
+
+        # Throttle-gate for transport-error WARNING messages.
+        self._last_err_log_t: float = 0.0
+
         log.info("ONVIFPTZBackend ready: %s:%d profile=%r", host, port, self._profile_token)
+
+    # ── internal helpers ──────────────────────────────────────────────────────
+
+    def _log_transport_error(self, context: str, exc: Exception) -> None:
+        """Emit a throttled WARNING for transport errors."""
+        now = time.monotonic()
+        if now - self._last_err_log_t >= _LOG_THROTTLE_S:
+            log.warning("ONVIFPTZBackend transport error in %s: %s", context, exc)
+            self._last_err_log_t = now
+        else:
+            log.debug("ONVIFPTZBackend transport error in %s (throttled): %s", context, exc)
 
     # ── PTZBackend interface ──────────────────────────────────────────────────
 
     def move_velocity(self, pan: float, tilt: float, zoom: float = 0.0) -> None:
-        request = self._ptz.create_type("ContinuousMove")
-        request.ProfileToken = self._profile_token
-        request.Velocity = {
-            "PanTilt": {"x": pan, "y": tilt},
-            "Zoom": {"x": zoom},
-        }
-        self._ptz.ContinuousMove(request)
+        try:
+            request = self._ptz.create_type("ContinuousMove")
+            request.ProfileToken = self._profile_token
+            request.Velocity = {
+                "PanTilt": {"x": pan, "y": tilt},
+                "Zoom": {"x": zoom},
+            }
+            # Dead-man's switch: camera self-stops after _CONTINUOUSMOVE_TIMEOUT
+            # if no new command arrives (e.g. on connection loss).
+            request.Timeout = _CONTINUOUSMOVE_TIMEOUT
+            self._ptz.ContinuousMove(request)
+        except Exception as exc:
+            self._log_transport_error("move_velocity", exc)
 
     def move_absolute(self, pan: float, tilt: float, zoom: float) -> None:
         request = self._ptz.create_type("AbsoluteMove")

--- a/autoptz/engine/ptz/visca_ip.py
+++ b/autoptz/engine/ptz/visca_ip.py
@@ -12,6 +12,11 @@ Auto-reconnect: on any OSError the socket is closed and a ReconnectPolicy gate
 is consulted; if the backoff interval has elapsed a single reconnect attempt is
 made and the command is retried once.  Neither move_velocity nor stop ever raise
 into the caller.
+
+Safety (halt-on-reconnect): when a reconnect succeeds, a stop is always sent
+FIRST before retrying any command.  This ensures a camera that was mid-pan on
+disconnect halts rather than continuing a stale continuous-move.  Sending a
+stop to an already-stopped camera is a safe no-op.
 """
 
 from __future__ import annotations
@@ -144,6 +149,16 @@ class ViscaIPBackend(PTZBackend):
                 log.warning("ViscaIP reconnect to %s:%d failed: %s", self._host, self._port, exc)
                 self._policy.record_failure(time.monotonic())
                 return
+
+            # Safety halt-on-reconnect: always send a stop immediately after
+            # reconnect so a camera that was mid-pan on disconnect halts before
+            # we retry any new command.  Sending a stop to an already-stopped
+            # camera is a safe no-op.
+            try:
+                self._sock.sendall(self._frame(visca_stop_cmd()))  # type: ignore[union-attr]
+                self._sock.sendall(self._frame(visca_zoom_stop_cmd()))  # type: ignore[union-attr]
+            except OSError:
+                pass  # best-effort; the retry below will handle further errors
 
             # Retry the command once on the fresh socket.
             try:

--- a/autoptz/engine/ptz/visca_usb.py
+++ b/autoptz/engine/ptz/visca_usb.py
@@ -8,6 +8,11 @@ Auto-reconnect: on SerialException or OSError the port is closed and a
 ReconnectPolicy gate is consulted; if the backoff interval has elapsed a single
 reconnect is attempted and the command is retried once.  Neither move_velocity
 nor stop ever raise into the caller.
+
+Safety (halt-on-reconnect): when a reconnect succeeds, a stop is always sent
+FIRST before retrying any command.  This ensures a camera that was mid-pan on
+disconnect halts rather than continuing a stale continuous-move.  Sending a
+stop to an already-stopped camera is a safe no-op.
 """
 
 from __future__ import annotations
@@ -121,6 +126,18 @@ class ViscaUSBBackend(PTZBackend):
             log.warning("ViscaUSB reconnect to %s failed: %s", self._port, exc)
             self._policy.record_failure(time.monotonic())
             return
+
+        # Safety halt-on-reconnect: always send a stop immediately after
+        # reconnect so a camera that was mid-pan on disconnect halts before
+        # we retry any new command.  Sending a stop to an already-stopped
+        # camera is a safe no-op.
+        stop_patched = bytes([self._addr]) + visca_stop_cmd()[1:]
+        zoom_stop_patched = bytes([self._addr]) + visca_zoom_stop_cmd()[1:]
+        try:
+            self._do_write(stop_patched)
+            self._do_write(zoom_stop_patched)
+        except (serial.SerialException, OSError):
+            pass  # best-effort; the retry below will handle further errors
 
         # Retry the command once on the fresh port.
         try:

--- a/tests/test_ptz_stop_on_loss.py
+++ b/tests/test_ptz_stop_on_loss.py
@@ -1,0 +1,385 @@
+"""Tests for PTZ stop-on-loss safety features.
+
+Covers:
+  1. ONVIF dead-man's switch: ContinuousMove carries a Timeout field.
+  2. ONVIF transport-error resilience: move_velocity / stop never raise.
+  3. VISCA IP halt-on-reconnect: a stop is always sent before the retried
+     command after a reconnect so a mid-pan camera halts on reconnect.
+  4. VISCA USB halt-on-reconnect: same guarantee for the serial backend.
+
+No real hardware or network — all services/transports are mocked.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import autoptz.engine.ptz.visca_ip as visca_ip_mod
+import autoptz.engine.ptz.visca_usb as visca_usb_mod
+from autoptz.engine.ptz.base import visca_stop_cmd, visca_zoom_stop_cmd
+from autoptz.engine.ptz.visca_ip import ViscaIPBackend
+from autoptz.engine.ptz.visca_usb import ViscaUSBBackend
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fake transports (shared by VISCA tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class FakeSocket:
+    """Fake TCP socket that records sendall calls and can be flipped to raise."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.should_fail: bool = False
+        self.closed: bool = False
+
+    def sendall(self, data: bytes) -> None:
+        if self.should_fail:
+            raise OSError("simulated network failure")
+        self.sent.append(data)
+
+    def settimeout(self, t: float) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSerial:
+    """Fake pyserial Serial instance."""
+
+    def __init__(self, port: str, baud: int, timeout: float = 0.1) -> None:
+        self.port = port
+        self.baud = baud
+        self.written: list[bytes] = []
+        self.should_fail: bool = False
+        self.closed: bool = False
+        self.in_waiting: int = 0
+
+    def write(self, data: bytes) -> None:
+        if self.should_fail:
+            raise visca_usb_mod.serial.SerialException("simulated serial failure")
+        self.written.append(data)
+
+    def read(self, n: int) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSerialFactory:
+    """Collects all FakeSerial instances created so tests can inspect them."""
+
+    def __init__(self) -> None:
+        self.instances: list[FakeSerial] = []
+
+    def __call__(self, port: str, baud: int, timeout: float = 0.1) -> FakeSerial:
+        s = FakeSerial(port, baud, timeout)
+        self.instances.append(s)
+        return s
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. ONVIF dead-man's switch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestONVIFDeadMansSwitch:
+    """ContinuousMove must carry a Timeout so the camera self-stops on loss."""
+
+    def _make(self) -> tuple[Any, MagicMock]:
+        """Return (backend, mock_ptz) with all ONVIF network calls stubbed."""
+        from autoptz.engine.ptz.onvif_ptz import ONVIFPTZBackend
+
+        mock_cam = MagicMock()
+        mock_ptz = MagicMock()
+        mock_media = MagicMock()
+
+        mock_cam.create_ptz_service.return_value = mock_ptz
+        mock_cam.create_media_service.return_value = mock_media
+
+        fake_profile = MagicMock()
+        fake_profile.token = "Profile_1"
+        mock_media.GetProfiles.return_value = [fake_profile]
+        mock_ptz.GetConfigurationOptions.return_value = MagicMock(Spaces=MagicMock())
+
+        # create_type returns a plain settable object so attribute assignments
+        # are captured without MagicMock auto-creating everything.
+        class _Req:
+            pass
+
+        mock_ptz.create_type.side_effect = lambda _name: _Req()
+
+        with patch("autoptz.engine.ptz.onvif_ptz._require_onvif") as mock_req:
+            mock_req.return_value = lambda *a, **kw: mock_cam
+            backend = ONVIFPTZBackend("192.0.2.1")
+
+        return backend, mock_ptz
+
+    def test_continuousmove_sets_timeout_field(self) -> None:
+        """move_velocity must set request.Timeout to the expected timedelta."""
+        from autoptz.engine.ptz.onvif_ptz import _CONTINUOUSMOVE_TIMEOUT
+
+        backend, mock_ptz = self._make()
+
+        # Capture the request object passed to ContinuousMove.
+        captured: list[Any] = []
+        mock_ptz.ContinuousMove.side_effect = lambda req: captured.append(req)
+
+        backend.move_velocity(0.3, 0.0, 0.0)
+
+        assert len(captured) == 1, "ContinuousMove was not called"
+        req = captured[0]
+        assert hasattr(req, "Timeout"), "request.Timeout was not set"
+        assert req.Timeout == _CONTINUOUSMOVE_TIMEOUT
+
+    def test_timeout_is_timedelta_of_one_second(self) -> None:
+        """The dead-man timeout must be a timedelta of exactly 1 second."""
+        from autoptz.engine.ptz.onvif_ptz import _CONTINUOUSMOVE_TIMEOUT
+
+        assert isinstance(_CONTINUOUSMOVE_TIMEOUT, timedelta)
+        assert _CONTINUOUSMOVE_TIMEOUT == timedelta(seconds=1)
+
+    def test_move_velocity_velocity_fields_correct(self) -> None:
+        """move_velocity must still set PanTilt and Zoom on the request."""
+        backend, mock_ptz = self._make()
+
+        captured: list[Any] = []
+        mock_ptz.ContinuousMove.side_effect = lambda req: captured.append(req)
+
+        backend.move_velocity(0.5, -0.3, 0.1)
+
+        req = captured[0]
+        assert req.Velocity["PanTilt"]["x"] == pytest.approx(0.5)
+        assert req.Velocity["PanTilt"]["y"] == pytest.approx(-0.3)
+        assert req.Velocity["Zoom"]["x"] == pytest.approx(0.1)
+
+    def test_transport_error_does_not_propagate(self) -> None:
+        """A SOAP/transport error in move_velocity must be caught — never raised."""
+        backend, mock_ptz = self._make()
+        mock_ptz.ContinuousMove.side_effect = Exception("simulated SOAP transport error")
+
+        backend.move_velocity(0.3, 0.0, 0.0)  # must not raise
+
+    def test_stop_transport_error_does_not_propagate(self) -> None:
+        """A transport error in stop() must be caught — never raised."""
+        backend, mock_ptz = self._make()
+        mock_ptz.Stop.side_effect = Exception("simulated SOAP transport error")
+
+        backend.stop()  # must not raise
+
+    def test_repeated_errors_throttle_log_warnings(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Repeated transport errors within the throttle window emit only one WARNING."""
+        import autoptz.engine.ptz.onvif_ptz as onvif_mod
+
+        backend, mock_ptz = self._make()
+        mock_ptz.ContinuousMove.side_effect = Exception("transport down")
+
+        # Fix the monotonic clock at t=100.0 and set last_err_log well in the
+        # past (t=0) so the first call is past the throttle window and emits a
+        # WARNING, while the second call (also at t=100.0) is within the window
+        # and must be silenced.
+        backend._last_err_log_t = 0.0  # far in the past relative to now=100.0
+
+        # Patch time.monotonic in the onvif_ptz module namespace so the
+        # throttle gate sees our fixed clock.
+        with patch.object(onvif_mod.time, "monotonic", return_value=100.0):
+            with caplog.at_level(logging.WARNING, logger="autoptz.engine.ptz.onvif_ptz"):
+                backend.move_velocity(0.3, 0.0)  # first error → WARNING emitted
+                n_after_first = caplog.text.count("transport error")
+                backend.move_velocity(0.3, 0.0)  # still at t=100.0 → throttled
+                n_after_second = caplog.text.count("transport error")
+
+        assert n_after_first == 1
+        assert n_after_second == 1  # throttled: still only one
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. VISCA IP halt-on-reconnect
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestViscaIPHaltOnReconnect:
+    """ViscaIPBackend must always send a stop before retrying a command after
+    a reconnect, whether or not the camera was previously moving."""
+
+    def _make_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[ViscaIPBackend, list[FakeSocket]]:
+        sockets: list[FakeSocket] = []
+
+        def fake_create_connection(
+            addr: tuple[str, int], timeout: float | None = None
+        ) -> FakeSocket:
+            s = FakeSocket()
+            sockets.append(s)
+            return s
+
+        monkeypatch.setattr(visca_ip_mod.socket, "create_connection", fake_create_connection)
+        backend = ViscaIPBackend("192.0.2.1", port=52381, mode="raw", timeout=0.5)
+        return backend, sockets
+
+    def test_halt_sent_before_move_after_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After a connection drop, reconnect must send stop bytes before the move."""
+        backend, sockets = self._make_backend(monkeypatch)
+
+        # Issue a non-zero move, then simulate a drop on the next send.
+        backend.move_velocity(0.5, 0.0, 0.0)
+        sockets[0].should_fail = True
+
+        # Trigger send → disconnect → reconnect.
+        backend.move_velocity(0.5, 0.0, 0.0)
+
+        # Two sockets: original (dropped) + fresh (reconnect).
+        assert len(sockets) == 2
+
+        fresh_sock = sockets[1]
+        # Fresh socket must receive at least: stop, zoom-stop, retried move.
+        assert len(fresh_sock.sent) >= 3, (
+            f"Expected ≥3 frames on reconnect (stop, zoom-stop, move), got {len(fresh_sock.sent)}"
+        )
+
+        # First two frames must be the stop commands (raw mode: no framing).
+        assert fresh_sock.sent[0] == visca_stop_cmd(), (
+            f"First frame must be stop cmd, got {fresh_sock.sent[0].hex()}"
+        )
+        assert fresh_sock.sent[1] == visca_zoom_stop_cmd(), (
+            f"Second frame must be zoom-stop cmd, got {fresh_sock.sent[1].hex()}"
+        )
+
+    def test_halt_sent_even_when_camera_was_stopped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stop is sent on reconnect regardless of prior command (always-safe)."""
+        backend, sockets = self._make_backend(monkeypatch)
+
+        # Explicitly stop the camera, then simulate a connection failure.
+        backend.stop()
+        sockets[0].should_fail = True
+        backend.move_velocity(0.3, 0.0, 0.0)
+
+        assert len(sockets) == 2
+        fresh_sock = sockets[1]
+
+        # Even though the camera was stopped, halt bytes are still sent first.
+        assert len(fresh_sock.sent) >= 3
+        assert fresh_sock.sent[0] == visca_stop_cmd()
+        assert fresh_sock.sent[1] == visca_zoom_stop_cmd()
+
+    def test_stop_bytes_precede_retried_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pantilt move is always retried AFTER the stop sequence."""
+        from autoptz.engine.ptz.base import visca_pantilt_cmd
+
+        backend, sockets = self._make_backend(monkeypatch)
+        backend.move_velocity(0.5, 0.0, 0.0)
+        sockets[0].should_fail = True
+        backend.move_velocity(0.5, 0.0, 0.0)
+
+        fresh_sock = sockets[1]
+        # Determine which frame is the pantilt move cmd.
+        pantilt_bytes = visca_pantilt_cmd(0.5, 0.0)
+        stop_bytes = visca_stop_cmd()
+
+        stop_idx = next((i for i, b in enumerate(fresh_sock.sent) if b == stop_bytes), None)
+        move_idx = next((i for i, b in enumerate(fresh_sock.sent) if b == pantilt_bytes), None)
+
+        assert stop_idx is not None, "stop cmd not found in fresh socket frames"
+        assert move_idx is not None, "pantilt move cmd not found in fresh socket frames"
+        assert stop_idx < move_idx, (
+            f"stop (idx {stop_idx}) must precede pantilt move (idx {move_idx})"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. VISCA USB halt-on-reconnect
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestViscaUSBHaltOnReconnect:
+    """ViscaUSBBackend must always send a stop before retrying a command after
+    a reconnect, whether or not the camera was previously moving."""
+
+    def _make_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[ViscaUSBBackend, FakeSerialFactory]:
+        factory = FakeSerialFactory()
+        monkeypatch.setattr(visca_usb_mod.serial, "Serial", factory)
+        backend = ViscaUSBBackend("/dev/ttyUSB0", baud=9600)
+        return backend, factory
+
+    def test_halt_sent_before_move_after_reconnect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After a port drop, reconnect must send stop bytes before the move."""
+        backend, factory = self._make_backend(monkeypatch)
+
+        # Issue a non-zero move, then simulate a port failure on the next send.
+        backend.move_velocity(0.5, 0.0, 0.0)
+        factory.instances[0].should_fail = True
+
+        # Trigger send → disconnect → reconnect.
+        backend.move_velocity(0.5, 0.0, 0.0)
+
+        # Two serial instances: original (dropped) + fresh (reconnect).
+        assert len(factory.instances) == 2
+
+        fresh_ser = factory.instances[1]
+        # Address byte is patched to 0x81 (camera addr 1).
+        # Fresh port must receive: stop, zoom-stop, then the retried move.
+        assert len(fresh_ser.written) >= 3, (
+            f"Expected ≥3 writes on reconnect (stop, zoom-stop, move), got {len(fresh_ser.written)}"
+        )
+
+        # Build expected stop bytes with address patched.
+        expected_stop = bytes([0x81]) + visca_stop_cmd()[1:]
+        expected_zoom_stop = bytes([0x81]) + visca_zoom_stop_cmd()[1:]
+
+        assert fresh_ser.written[0] == expected_stop, (
+            f"First write must be stop cmd, got {fresh_ser.written[0].hex()}"
+        )
+        assert fresh_ser.written[1] == expected_zoom_stop, (
+            f"Second write must be zoom-stop cmd, got {fresh_ser.written[1].hex()}"
+        )
+
+    def test_halt_sent_even_when_camera_was_stopped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stop is sent on reconnect regardless of prior command (always-safe)."""
+        backend, factory = self._make_backend(monkeypatch)
+
+        backend.stop()
+        factory.instances[0].should_fail = True
+        backend.move_velocity(0.3, 0.0, 0.0)
+
+        assert len(factory.instances) == 2
+        fresh_ser = factory.instances[1]
+
+        expected_stop = bytes([0x81]) + visca_stop_cmd()[1:]
+        expected_zoom_stop = bytes([0x81]) + visca_zoom_stop_cmd()[1:]
+
+        assert len(fresh_ser.written) >= 3
+        assert fresh_ser.written[0] == expected_stop
+        assert fresh_ser.written[1] == expected_zoom_stop
+
+    def test_stop_bytes_precede_retried_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pantilt move is always retried AFTER the stop sequence."""
+        from autoptz.engine.ptz.base import visca_pantilt_cmd
+
+        backend, factory = self._make_backend(monkeypatch)
+        backend.move_velocity(0.5, 0.0, 0.0)
+        factory.instances[0].should_fail = True
+        backend.move_velocity(0.5, 0.0, 0.0)
+
+        fresh_ser = factory.instances[1]
+        # Address-patched bytes.
+        expected_stop = bytes([0x81]) + visca_stop_cmd()[1:]
+        expected_pantilt = bytes([0x81]) + visca_pantilt_cmd(0.5, 0.0)[1:]
+
+        stop_idx = next((i for i, b in enumerate(fresh_ser.written) if b == expected_stop), None)
+        move_idx = next((i for i, b in enumerate(fresh_ser.written) if b == expected_pantilt), None)
+
+        assert stop_idx is not None, "stop cmd not found in fresh serial writes"
+        assert move_idx is not None, "pantilt move cmd not found in fresh serial writes"
+        assert stop_idx < move_idx, (
+            f"stop (idx {stop_idx}) must precede pantilt move (idx {move_idx})"
+        )


### PR DESCRIPTION
## What / Why

A PTZ camera must not run away when its connection drops. This PR adds two backend-local safety mechanisms:

**ONVIF dead-man's switch (`onvif_ptz.py`)**
- Sets `Timeout=timedelta(seconds=1)` on every `ContinuousMove` request so the camera self-stops if no new command arrives within ~1 s (connection loss, hung network). Uses Python `datetime.timedelta` which zeep accepts directly.
- Wraps `move_velocity` in `try/except` with a throttled WARNING (one per 5 s) so a sustained transport outage logs once and never crashes the control loop.
- `stop()` already had a bare `except Exception: pass`; unchanged.

**VISCA halt-on-reconnect (`visca_ip.py`, `visca_usb.py`)**
- After a successful reconnect inside `_send`, always sends pantilt-stop + zoom-stop *before* retrying the pending command. A camera that was mid-pan when the link dropped halts rather than continuing a stale continuous-move. Sending stop to an already-stopped camera is a safe no-op.
- No changes to `reconnect.py` or `base.py`; no changes to `camera_worker.py` / `controller.py` (those get the complementary heartbeat in a later PR).

## Tests

12 new tests in `tests/test_ptz_stop_on_loss.py`:
- ONVIF: `Timeout` field present and correct value; velocity fields intact; transport errors caught (move + stop); log throttle
- VISCA IP: stop before move on reconnect (mid-move and already-stopped cases); ordering assertion
- VISCA USB: same three tests for serial backend

No real hardware/network — all transports mocked (same style as `test_ptz_reconnect.py`).

## Gate results

```
ruff check   — ✓ all checks passed
ruff format  — ✓ 4 files already formatted
mypy         — ✓ no issues (11 source files)
pytest       — ✓ 1218 passed in 30.62s
selftest     — ✓ all checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)