### PR TITLE
feat(ptz): fixed-rate off-thread command pump (flag-gated) + stop-on-loss heartbeat

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -120,6 +120,14 @@ _INFER_STALL_S = 2.0
 _EVENT_MAX = 12
 _FPS_LOG_DELTA = 0.25
 
+# Max time the inference loop blocks waiting for a new frame before falling through
+# to drain commands.  The fall-through is what keeps PTZ commands (and nudges /
+# set-target / enable-tracking) flowing when frames are sparse, so a smaller value
+# tightens command latency.  Cost is one extra cheap drain per idle interval — the
+# loop body short-circuits on no new frame — so 10 ms is negligible vs. the prior
+# 50 ms wake ceiling.
+_INFER_WAKE_TIMEOUT_S = 0.01
+
 # ── auto-harvest quality gates ───────────────────────────────────────────────────
 # Auto-harvesting a NEW "Person N" is deliberately strict so the user rarely has
 # to merge junk identities.  A face must clear ALL of these before it earns a new
@@ -183,6 +191,25 @@ def _async_appearance_enabled() -> bool:
         "false",
         "no",
         "off",
+    )
+
+
+def _ptz_pump_enabled() -> bool:
+    """Emit PTZ commands from the controller's own fixed-rate thread (default OFF).
+
+    When ON (``AUTOPTZ_PTZ_PUMP=1``/``true``) the controller's background loop is
+    started and the inference thread merely ``update()``s the latest target via a
+    lock — the loop sends at its fixed ``rate_hz``, off the inference hot path, with
+    a stop-on-loss heartbeat.  When OFF (the default until real-camera validation),
+    behaviour is exactly the legacy inline ``step()`` path.
+    """
+    import os
+
+    return os.environ.get("AUTOPTZ_PTZ_PUMP", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 
@@ -398,6 +425,11 @@ class CameraWorker:
         self._ptz: Any | None = None
         self._ptz_backend: Any | None = ptz_backend
         self._ptz_owned = False  # True when we built the controller ourselves
+        # Fixed-rate off-thread command pump (flag-gated, default OFF). When ON the
+        # controller's own loop emits commands at its rate_hz and _drive_ptz_auto
+        # only publishes the latest target via update(); when OFF the worker drives
+        # the controller inline via step() each inference tick (legacy behaviour).
+        self._ptz_pump = _ptz_pump_enabled()
         if ptz_controller is not None:
             if hasattr(ptz_controller, "step"):
                 self._ptz = ptz_controller
@@ -1274,6 +1306,35 @@ class CameraWorker:
     def _manual_override_active(self, now: float) -> bool:
         return now < self._manual_override_until
 
+    def _publish_ptz(
+        self,
+        ctrl: Any,
+        err: tuple[float, float],
+        vel: tuple[float, float],
+        height: float,
+        *,
+        track_active: bool,
+        now: float,
+        log_label: str | None,
+    ) -> None:
+        """Hand this tick's target to the controller, branching on the pump flag.
+
+        - **Pump ON** (``AUTOPTZ_PTZ_PUMP``): publish the latest payload via
+          ``update()`` (lock-safe, non-blocking); the controller's own fixed-rate
+          loop sends the command off this inference thread.  No command is returned
+          to mirror, so ``_ptz_last_cmd`` is left for the loop/telemetry.
+        - **Pump OFF** (default): exactly the legacy inline path — ``step()`` runs
+          the control math here and drives the backend synchronously, returning the
+          command we mirror into ``_ptz_last_cmd`` and (for the active site) log.
+        """
+        if self._ptz_pump:
+            ctrl.update(err, vel, height, track_active)
+            return
+        pan, tilt, zoom = ctrl.step(err, vel, height, track_active=track_active, t=now)
+        self._ptz_last_cmd = (pan, tilt, zoom)
+        if log_label is not None:
+            self._log_ptz_cmd(log_label, pan, tilt, zoom)
+
     @_appearance_guarded
     def _drive_ptz_auto(
         self,
@@ -1328,9 +1389,9 @@ class CameraWorker:
                 # visible) is not a trustworthy aim — coast (track_active=False) so
                 # the controller holds instead of chasing it onto the legs/last-known
                 # partial position, and resumes when the subject reappears in full.
-                pan, tilt, zoom = ctrl.step(err, vel, height, track_active=not occluded, t=now)
-                self._ptz_last_cmd = (pan, tilt, zoom)
-                self._log_ptz_cmd("auto", pan, tilt, zoom)
+                self._publish_ptz(
+                    ctrl, err, vel, height, track_active=not occluded, now=now, log_label="auto"
+                )
             except Exception:  # noqa: BLE001
                 log.debug("camera_id=%s ptz auto step failed", self.camera_id, exc_info=True)
         else:
@@ -1338,8 +1399,9 @@ class CameraWorker:
             self._prev_aim_err = None
             self._aim_vel = (0.0, 0.0)
             try:
-                pan, tilt, zoom = ctrl.step((0.0, 0.0), (0.0, 0.0), 0.0, track_active=False, t=now)
-                self._ptz_last_cmd = (pan, tilt, zoom)
+                self._publish_ptz(
+                    ctrl, (0.0, 0.0), (0.0, 0.0), 0.0, track_active=False, now=now, log_label=None
+                )
             except Exception:  # noqa: BLE001
                 log.debug("camera_id=%s ptz auto idle step failed", self.camera_id, exc_info=True)
 
@@ -2700,7 +2762,7 @@ class CameraWorker:
                 # commands (nudge / set-target / enable-tracking) are still drained
                 # when no frames are arriving — they must never depend on frame
                 # delivery.
-                self._frame_ready.wait(timeout=0.05)
+                self._frame_ready.wait(timeout=_INFER_WAKE_TIMEOUT_S)
                 self._frame_ready.clear()
                 if self._stop_event.is_set():
                     break
@@ -2928,6 +2990,7 @@ class CameraWorker:
         # build, so it stays here; the heavy detect/face models are built on the
         # inference thread (see ``_build_inference_stacks``).
         self._build_ptz_stack()
+        self._maybe_start_ptz_pump()
 
     def _build_inference_stacks(self) -> None:
         """Build the detect + face stacks ON the inference thread.
@@ -3154,6 +3217,7 @@ class CameraWorker:
             self._ptz_owned = False
             self._digital_framer = None  # fresh framer for the new backend
             self._build_ptz_stack()
+            self._maybe_start_ptz_pump()
         log.info(
             "camera_id=%s PTZ backend rebuilt for backend=%s",
             self.camera_id,
@@ -3207,6 +3271,25 @@ class CameraWorker:
             )
             self._ptz = None
             self._ptz_backend = None
+
+    def _maybe_start_ptz_pump(self) -> None:
+        """Start the controller's fixed-rate command loop when the pump flag is ON.
+
+        No-op when the flag is OFF (legacy inline ``step()`` drive) or when there's
+        no controller / it lacks ``start()`` (bare-backend injection).  Starting is
+        idempotent in the controller, so a rebuild can safely call this again.
+        Never raises — a pump that fails to start must not break the worker.
+        """
+        if not self._ptz_pump:
+            return
+        ctrl = self._ptz
+        if ctrl is None or not hasattr(ctrl, "start"):
+            return
+        try:
+            ctrl.start()
+            log.info("camera_id=%s PTZ command pump started (AUTOPTZ_PTZ_PUMP)", self.camera_id)
+        except Exception:  # noqa: BLE001
+            log.warning("camera_id=%s PTZ pump start failed", self.camera_id, exc_info=True)
 
     def _create_shm_writer_eager(self) -> None:
         """Set ``self._shm`` from the injected writer or by creating one now.

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -1357,6 +1357,13 @@ class CameraWorker:
         if ctrl is None:
             return
         if self._manual_override_active(now):
+            # Pump mode (I1): while the operator holds a manual nudge we stop
+            # feeding the controller (manual owns the camera).  Refresh the
+            # heartbeat each tick so the background loop doesn't mistake the
+            # intentional update() gap for a stalled feed and inject a stop()
+            # that fights the nudge.  No-op when the pump is off (no heartbeat).
+            if self._ptz_pump and hasattr(ctrl, "note_manual_hold"):
+                ctrl.note_manual_hold()
             return
 
         # Tell the controller how long this machine's capture+inference pipeline
@@ -3204,6 +3211,22 @@ class CameraWorker:
         Center Stage). Never raises.
         """
         with self._ptz_lock:
+            # Pump mode (C1): the OLD controller owns a background loop thread that
+            # is still driving the (about-to-be-closed) backend.  Stop it *before*
+            # we drop the reference, otherwise its daemon loop is orphaned — it
+            # keeps spinning _tick against a closed backend while the new
+            # controller's loop also drives (two senders + a leaked thread per
+            # rebuild).  Gated on the pump flag because that is the only mode in
+            # which a controller loop is ever running; OFF mode never starts one,
+            # so this is a no-op there and the backend close below is unchanged.
+            old_ctrl = self._ptz
+            if self._ptz_pump and old_ctrl is not None and hasattr(old_ctrl, "stop"):
+                try:
+                    old_ctrl.stop()
+                except Exception:  # noqa: BLE001
+                    log.debug(
+                        "camera_id=%s ptz controller stop failed", self.camera_id, exc_info=True
+                    )
             old = self._ptz_backend
             if old is not None and self._ptz_owned:
                 try:

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -31,6 +31,18 @@ log = logging.getLogger(__name__)
 # per interval keeps it visible without flooding the log.
 _TICK_WARN_INTERVAL_S = 5.0
 
+# Stop-on-loss heartbeat (pump mode only): if the background loop is TRACKING but
+# no fresh update() has arrived from the inference thread for longer than this, the
+# loop commands a stop() so a stalled inference thread / dropped feed halts the
+# camera instead of coasting on a frozen aim.  Bounded to a small floor and a few
+# control periods, whichever is larger, so a momentarily slow producer doesn't trip
+# it while a genuinely wedged one halts within a fraction of a second.
+_HEARTBEAT_FLOOR_S = 0.3  # absolute minimum staleness before the heartbeat fires
+_HEARTBEAT_PERIODS = 4.0  # …or this many control periods, whichever is larger
+# Throttle for the heartbeat stop WARNING so a sustained producer stall logs once
+# per interval rather than at the full control rate.
+_HEARTBEAT_WARN_INTERVAL_S = 5.0
+
 # Named framing presets → target subject-height fraction of the frame.
 # A larger fraction means the subject fills more of the frame (tighter shot).
 #   face           — head fills most of the frame (closeup)
@@ -352,9 +364,22 @@ class PTZController:
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        # True only while the background _loop is running; gates the stop-on-loss
+        # heartbeat so the synchronous step() path (tests / inline mode) never trips
+        # it (step() refreshes the payload itself, immediately before _tick).
+        self._loop_running: bool = False
+
+        # Stop-on-loss heartbeat (pump mode): monotonic time of the last update()
+        # from the inference thread, and the staleness threshold past which the
+        # background loop halts a still-TRACKING camera.  The threshold is a few
+        # control periods or a small floor, whichever is larger.
+        self._last_update_t: float = time.monotonic()
+        self._heartbeat_stale_s = max(_HEARTBEAT_FLOOR_S, _HEARTBEAT_PERIODS / max(1.0, rate_hz))
 
         # Throttle for the control-loop tick failure WARNING (monotonic seconds).
         self._last_tick_warn_t = 0.0
+        # Throttle for the heartbeat stop WARNING (monotonic seconds).
+        self._last_heartbeat_warn_t = 0.0
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -432,6 +457,10 @@ class PTZController:
                 track_active=track_active,
                 seq=self._payload.seq + 1,
             )
+        # Heartbeat: record recency so the background loop can detect a stalled
+        # producer and halt the camera (pump mode).  Monotonic so a wall-clock
+        # adjustment can't make the feed look stale.
+        self._last_update_t = time.monotonic()
 
     def step(
         self,
@@ -498,6 +527,10 @@ class PTZController:
 
     def _loop(self) -> None:
         interval = 1.0 / self._rate_hz
+        # Reset recency on (re)start so a long-idle controller doesn't immediately
+        # trip the heartbeat before the first update() of the new session arrives.
+        self._last_update_t = time.monotonic()
+        self._loop_running = True
         while not self._stop_event.is_set():
             t0 = time.perf_counter()
             try:
@@ -513,6 +546,7 @@ class PTZController:
                     log.warning("PTZ control tick failed (%s); continuing", exc, exc_info=True)
             elapsed = time.perf_counter() - t0
             self._stop_event.wait(max(0.0, interval - elapsed))
+        self._loop_running = False
         # guarantee stop on thread exit
         try:
             self._backend.stop()
@@ -522,6 +556,13 @@ class PTZController:
     # ── tick (core logic) ─────────────────────────────────────────────────────
 
     def _tick(self, t: float) -> tuple[float, float, float]:
+        # Stop-on-loss heartbeat (pump mode only): if we're driving the camera but
+        # the inference thread has gone quiet (stalled / feed dropped) past the
+        # staleness threshold, halt rather than coast on a frozen aim.  Gated on the
+        # background loop running so the synchronous step() path never trips it.
+        if self._loop_running and self._heartbeat_stalled():
+            return self._heartbeat_stop()
+
         with self._lock:
             payload = self._payload
 
@@ -539,6 +580,41 @@ class PTZController:
             self._last_zoom = zoom_cmd
 
         return pan_cmd, tilt_cmd, zoom_cmd
+
+    def _heartbeat_stalled(self) -> bool:
+        """True when actively driving but the producer feed has gone stale.
+
+        Only relevant while TRACKING/COASTING (a camera that is actually moving or
+        about to be stopped by coast logic): IDLE/SEARCHING are already halted, so a
+        quiet feed there is expected and must not be flagged.
+        """
+        if self._state not in (ControllerState.TRACKING, ControllerState.COASTING):
+            return False
+        return (time.monotonic() - self._last_update_t) > self._heartbeat_stale_s
+
+    def _heartbeat_stop(self) -> tuple[float, float, float]:
+        """Halt the camera because the inference feed stalled; transition to IDLE.
+
+        Drops to IDLE so when fresh updates resume the controller does a clean
+        (re-)acquire instead of resuming a frozen mid-pan command, and sends a real
+        backend stop (bypassing the change-suppression in ``_tick``) so the halt is
+        guaranteed even if the last command was already zero.
+        """
+        now = time.monotonic()
+        if now - self._last_heartbeat_warn_t >= _HEARTBEAT_WARN_INTERVAL_S:
+            self._last_heartbeat_warn_t = now
+            log.warning(
+                "PTZ heartbeat: no tracking update for %.2fs (>%.2fs) — halting camera",
+                now - self._last_update_t,
+                self._heartbeat_stale_s,
+            )
+        self._state = ControllerState.IDLE
+        self._last_pan = self._last_tilt = self._last_zoom = 0.0
+        try:
+            self._backend.stop()
+        except Exception:
+            pass
+        return 0.0, 0.0, 0.0
 
     def _compute(self, p: _TrackPayload, t: float) -> tuple[float, float, float]:
         cfg = self._cfg

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -462,6 +462,19 @@ class PTZController:
         # adjustment can't make the feed look stale.
         self._last_update_t = time.monotonic()
 
+    def note_manual_hold(self) -> None:
+        """Pause the stop-on-loss heartbeat for one staleness window (pump mode).
+
+        While the operator holds a manual nudge the worker suspends ``update()``
+        (manual owns the camera, so the controller is intentionally fed nothing).
+        Without this, the background loop would see the producer as "stalled" and
+        inject a ``stop()`` that races the operator's nudge.  Refreshing recency
+        each tick of the override keeps the heartbeat from firing, without
+        touching the tracking payload (so the held aim/coast state is preserved
+        for when auto control resumes).
+        """
+        self._last_update_t = time.monotonic()
+
     def step(
         self,
         error: tuple[float, float],

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -743,6 +743,7 @@ class _SpyController:
         self.started = 0
         self.stopped = 0
         self.latencies: list[float] = []
+        self.manual_holds = 0
 
     def step(self, error, velocity, subject_height, track_active, t=None):
         self.steps.append((error, velocity, subject_height, track_active))
@@ -750,6 +751,9 @@ class _SpyController:
 
     def update(self, error, velocity, subject_height, track_active):
         self.updates.append((error, velocity, subject_height, track_active))
+
+    def note_manual_hold(self) -> None:
+        self.manual_holds += 1
 
     def start(self) -> None:
         self.started += 1
@@ -821,6 +825,148 @@ class TestPtzPumpFlag:
         worker, ctrl = self._worker(monkeypatch, pump=False)
         worker._maybe_start_ptz_pump()
         assert ctrl.started == 0
+
+    def test_manual_override_refreshes_heartbeat_when_pump_on(self, monkeypatch) -> None:
+        """I1: during a manual-override window the auto loop early-returns without
+        an update(); pump mode must refresh the heartbeat so the loop doesn't
+        inject a stop() that fights the operator's nudge."""
+        worker, ctrl = self._worker(monkeypatch, pump=True)
+        now = time.monotonic()
+        worker._manual_override_until = now + 10.0  # override is active
+        worker._drive_ptz_auto([], None, now)
+        assert ctrl.manual_holds == 1, "pump mode must refresh heartbeat during manual override"
+        assert ctrl.updates == [], "manual override must not feed the controller"
+        assert ctrl.steps == []
+
+    def test_manual_override_no_heartbeat_refresh_when_pump_off(self, monkeypatch) -> None:
+        """OFF mode has no heartbeat, so the override path must not touch it."""
+        worker, ctrl = self._worker(monkeypatch, pump=False)
+        now = time.monotonic()
+        worker._manual_override_until = now + 10.0
+        worker._drive_ptz_auto([], None, now)
+        assert ctrl.manual_holds == 0, "OFF mode must not call note_manual_hold"
+
+
+class _ThreadedSpyController:
+    """Spy controller with a real daemon loop, like the production controller.
+
+    ``start()`` spins a daemon thread that idles until ``stop()`` joins it, so a
+    test can assert the rebuild stops the OLD controller (no leaked/extra thread)
+    before the new stack comes up.  Records call ordering so we can prove the old
+    stop happens before the new pump starts.
+    """
+
+    _events: list[str] = []
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.started = 0
+        self.stopped = 0
+
+    # the worker only treats an object as a controller (not a bare backend) when
+    # it has step(); never actually invoked in pump mode but required for routing.
+    def step(self, *a, **k):  # pragma: no cover - not exercised in pump mode
+        return (0.0, 0.0, 0.0)
+
+    def update(self, *a, **k) -> None:  # pragma: no cover - not exercised here
+        pass
+
+    def set_loop_latency(self, seconds: float) -> None:  # pragma: no cover
+        pass
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._stop_event.wait(0.01)
+
+    def start(self) -> None:
+        self.started += 1
+        type(self)._events.append(f"start:{self.name}")
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._loop, name=f"spy-{self.name}", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self.stopped += 1
+        type(self)._events.append(f"stop:{self.name}")
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+
+class TestPtzRebuildLifecycle:
+    """Rebuilding the PTZ backend in pump mode must stop the OLD controller's
+    background loop (C1) before the new one starts — no leaked/extra thread."""
+
+    def _worker(self, monkeypatch, *, pump: bool, old_ctrl):
+        from autoptz.engine.camera_worker import CameraWorker
+
+        monkeypatch.setenv("AUTOPTZ_PTZ_PUMP", "1" if pump else "0")
+        worker = CameraWorker(
+            "ptzrebuild123",
+            _camera_config("ptzrebuild123"),
+            lambda _m: None,
+            frame_source=FakeFrameSource(),
+            ptz_controller=old_ctrl,
+        )
+        return worker
+
+    def test_rebuild_stops_old_controller_before_new_starts(self, monkeypatch) -> None:
+        _ThreadedSpyController._events = []
+        old = _ThreadedSpyController("old")
+        worker = self._worker(monkeypatch, pump=True, old_ctrl=old)
+        # We own the controller for the test so the rebuild treats it as ours and
+        # the stop path is exercised; mark it owned to mirror a built stack.
+        worker._ptz_owned = True
+
+        # The rebuild then constructs a fresh stack.  Stub it to install a second
+        # threaded spy as the NEW controller and start its pump, so we can assert
+        # ordering (old stop BEFORE new start) without a real backend/hardware.
+        new = _ThreadedSpyController("new")
+
+        def _build_new_stack() -> None:
+            worker._ptz = new
+            worker._ptz_owned = True
+
+        monkeypatch.setattr(worker, "_build_ptz_stack", _build_new_stack)
+
+        before = threading.active_count()
+        old.start()  # the old controller's loop is running, like a live pump
+        assert old._thread is not None and old._thread.is_alive()
+
+        worker._rebuild_ptz_backend()
+
+        # OLD controller's loop was stopped (its stop() called, thread joined)…
+        assert old.stopped == 1, "old controller was not stopped on rebuild (C1 leak)"
+        assert old._thread is None, "old controller's loop thread leaked"
+        # …and the NEW controller's pump was started.
+        assert new.started == 1, "new controller pump did not start after rebuild"
+        # Ordering: old stop strictly precedes new start (no two-senders window).
+        assert _ThreadedSpyController._events.index(
+            "stop:old"
+        ) < _ThreadedSpyController._events.index("start:new")
+        # No thread leak: the old loop is gone; the new spy's loop is the only add.
+        new.stop()
+        # Allow the joined threads to fully retire before counting.
+        deadline = time.monotonic() + 2.0
+        while threading.active_count() > before and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert threading.active_count() <= before, "rebuild leaked a controller loop thread"
+
+    def test_rebuild_off_mode_does_not_stop_controller(self, monkeypatch) -> None:
+        """OFF mode never runs a controller loop, so the rebuild must NOT call
+        stop() on the controller (no loop to stop; backend close path unchanged)."""
+        _ThreadedSpyController._events = []
+        old = _ThreadedSpyController("old")
+        worker = self._worker(monkeypatch, pump=False, old_ctrl=old)
+        worker._ptz_owned = True
+        monkeypatch.setattr(worker, "_build_ptz_stack", lambda: None)
+
+        worker._rebuild_ptz_backend()
+
+        assert old.stopped == 0, "OFF mode must not stop the controller on rebuild"
 
 
 class TestInferenceWakeTimeout:

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -726,6 +726,116 @@ class TestCameraWorker:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# CameraWorker — fixed-rate PTZ command pump flag (AUTOPTZ_PTZ_PUMP)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _SpyController:
+    """Stand-in PTZController recording step()/update()/start()/stop() calls.
+
+    Has ``step`` so the worker treats it as a controller (not a bare backend).
+    ``step`` returns a fixed command so the legacy inline path can mirror it.
+    """
+
+    def __init__(self) -> None:
+        self.steps: list[tuple] = []
+        self.updates: list[tuple] = []
+        self.started = 0
+        self.stopped = 0
+        self.latencies: list[float] = []
+
+    def step(self, error, velocity, subject_height, track_active, t=None):
+        self.steps.append((error, velocity, subject_height, track_active))
+        return (0.1, 0.2, 0.0)
+
+    def update(self, error, velocity, subject_height, track_active):
+        self.updates.append((error, velocity, subject_height, track_active))
+
+    def start(self) -> None:
+        self.started += 1
+
+    def stop(self) -> None:
+        self.stopped += 1
+
+    def set_loop_latency(self, seconds: float) -> None:
+        self.latencies.append(seconds)
+
+
+class TestPtzPumpFlag:
+    """AUTOPTZ_PTZ_PUMP gates the off-thread pump; OFF == legacy inline step()."""
+
+    def _worker(self, monkeypatch, *, pump: bool):
+        from autoptz.engine.camera_worker import CameraWorker
+
+        monkeypatch.setenv("AUTOPTZ_PTZ_PUMP", "1" if pump else "0")
+        ctrl = _SpyController()
+        worker = CameraWorker(
+            "ptzpump12345",
+            _camera_config("ptzpump12345"),
+            lambda _m: None,
+            frame_source=FakeFrameSource(),
+            ptz_controller=ctrl,
+        )
+        return worker, ctrl
+
+    def test_env_helper_parses(self, monkeypatch) -> None:
+        from autoptz.engine.camera_worker import _ptz_pump_enabled
+
+        for on in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("AUTOPTZ_PTZ_PUMP", on)
+            assert _ptz_pump_enabled() is True
+        for off in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("AUTOPTZ_PTZ_PUMP", off)
+            assert _ptz_pump_enabled() is False
+
+    def test_default_off(self, monkeypatch) -> None:
+        from autoptz.engine.camera_worker import _ptz_pump_enabled
+
+        monkeypatch.delenv("AUTOPTZ_PTZ_PUMP", raising=False)
+        assert _ptz_pump_enabled() is False
+
+    def test_publish_routes_to_update_when_pump_on(self, monkeypatch) -> None:
+        worker, ctrl = self._worker(monkeypatch, pump=True)
+        worker._publish_ptz(
+            ctrl, (0.3, 0.1), (0.0, 0.0), 0.45, track_active=True, now=0.0, log_label="auto"
+        )
+        assert ctrl.updates == [((0.3, 0.1), (0.0, 0.0), 0.45, True)]
+        assert ctrl.steps == [], "pump ON must not call step()"
+
+    def test_publish_routes_to_step_when_pump_off(self, monkeypatch) -> None:
+        worker, ctrl = self._worker(monkeypatch, pump=False)
+        worker._publish_ptz(
+            ctrl, (0.3, 0.1), (0.0, 0.0), 0.45, track_active=True, now=0.0, log_label="auto"
+        )
+        assert ctrl.steps == [((0.3, 0.1), (0.0, 0.0), 0.45, True)]
+        assert ctrl.updates == [], "pump OFF must not call update()"
+        # Legacy inline path mirrors the returned command.
+        assert worker._ptz_last_cmd == (0.1, 0.2, 0.0)
+
+    def test_maybe_start_pump_starts_controller_when_on(self, monkeypatch) -> None:
+        worker, ctrl = self._worker(monkeypatch, pump=True)
+        worker._maybe_start_ptz_pump()
+        assert ctrl.started == 1
+
+    def test_maybe_start_pump_noop_when_off(self, monkeypatch) -> None:
+        worker, ctrl = self._worker(monkeypatch, pump=False)
+        worker._maybe_start_ptz_pump()
+        assert ctrl.started == 0
+
+
+class TestInferenceWakeTimeout:
+    """The inference loop's frame-wait ceiling must stay small so commands drain
+    promptly when frames are sparse (C3: lower wake-latency ceiling)."""
+
+    def test_wake_timeout_is_small(self) -> None:
+        from autoptz.engine.camera_worker import _INFER_WAKE_TIMEOUT_S
+
+        # Tightened from the old 50 ms ceiling; a value check guards a regression.
+        assert _INFER_WAKE_TIMEOUT_S == pytest.approx(0.01)
+        assert _INFER_WAKE_TIMEOUT_S < 0.05
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # CameraWorker._track_error — region-aware aim point
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -778,6 +778,45 @@ class TestControllerPumpHeartbeat:
         ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=1.0)
         assert ctrl.state == ControllerState.TRACKING
 
+    def test_manual_hold_refreshes_recency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """note_manual_hold() stamps recency (pause the heartbeat) without
+        touching the tracking payload."""
+        import autoptz.engine.ptz.controller as ctrl_mod
+
+        ctrl = PTZController(MockBackend(), _cfg(kp=0.6), rate_hz=20.0)
+        seq_before = ctrl._payload.seq
+        monkeypatch.setattr(ctrl_mod.time, "monotonic", lambda: 456.0)
+        ctrl.note_manual_hold()
+        assert ctrl._last_update_t == pytest.approx(456.0)
+        assert ctrl._payload.seq == seq_before, "manual hold must not alter the payload"
+
+    def test_manual_hold_prevents_heartbeat_stop(self) -> None:
+        """I1: refreshing via note_manual_hold() each tick during a held nudge
+        keeps the background loop from halting the camera as 'stale'."""
+        backend = MockBackend()
+        ctrl = PTZController(backend, _cfg(kp=0.6), rate_hz=50.0)
+        ctrl._heartbeat_stale_s = 0.1
+        ctrl.start()
+        try:
+            # Drive once so we're TRACKING (the only state the heartbeat guards).
+            ctrl.update((0.5, 0.0), (0.0, 0.0), 0.45, True)
+            deadline = time.monotonic() + 2.0
+            while not backend.velocity_calls and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ctrl.state == ControllerState.TRACKING
+
+            # Now simulate a held manual nudge: no update() for well past the stale
+            # threshold, but note_manual_hold() each "tick".  The loop must NOT stop.
+            end = time.monotonic() + 0.5  # 5x the 0.1s threshold
+            while time.monotonic() < end:
+                ctrl.note_manual_hold()
+                time.sleep(0.01)
+            assert ctrl.state == ControllerState.TRACKING, (
+                "heartbeat fired during an active manual hold (I1)"
+            )
+        finally:
+            ctrl.stop()
+
 
 def ctrl_mod_floor() -> float:
     import autoptz.engine.ptz.controller as ctrl_mod

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -705,6 +705,87 @@ class TestControllerThread:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Controller — fixed-rate pump + stop-on-loss heartbeat
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestControllerPumpHeartbeat:
+    """The background loop drives the backend from update()s; a stale producer
+    (no fresh update() past the heartbeat threshold) makes the loop halt."""
+
+    def test_update_records_recency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """update() stamps the last-update monotonic time so the loop can gauge it."""
+        import autoptz.engine.ptz.controller as ctrl_mod
+
+        ctrl = PTZController(MockBackend(), _cfg(kp=0.6), rate_hz=20.0)
+        monkeypatch.setattr(ctrl_mod.time, "monotonic", lambda: 123.5)
+        ctrl.update((0.3, 0.0), (0.0, 0.0), 0.45, True)
+        assert ctrl._last_update_t == pytest.approx(123.5)
+
+    def test_heartbeat_threshold_floor(self) -> None:
+        """At a fast rate the threshold floors at the absolute minimum, not periods."""
+        ctrl = PTZController(MockBackend(), _cfg(), rate_hz=1000.0)
+        assert ctrl._heartbeat_stale_s == pytest.approx(ctrl_mod_floor())
+
+    def test_thread_drives_from_update(self) -> None:
+        """With start(), a fresh update(track_active=True) makes the loop drive."""
+        backend = MockBackend()
+        ctrl = PTZController(backend, _cfg(kp=0.6), rate_hz=50.0)
+        ctrl.start()
+        try:
+            ctrl.update((0.5, 0.0), (0.0, 0.0), 0.45, True)
+            deadline = time.monotonic() + 2.0
+            while not backend.velocity_calls and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert backend.velocity_calls, "loop did not drive backend from update()"
+            assert ctrl.state == ControllerState.TRACKING
+        finally:
+            ctrl.stop()
+
+    def test_stale_feed_halts_camera(self) -> None:
+        """Withholding update() past the stale threshold makes the loop stop()."""
+        backend = MockBackend()
+        # Short threshold so the test is quick but still well above a tick period.
+        ctrl = PTZController(backend, _cfg(kp=0.6), rate_hz=50.0)
+        ctrl._heartbeat_stale_s = 0.1
+        ctrl.start()
+        try:
+            ctrl.update((0.5, 0.0), (0.0, 0.0), 0.45, True)
+            deadline = time.monotonic() + 2.0
+            while not backend.velocity_calls and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert backend.velocity_calls, "loop never started driving"
+            stops_before = backend.stop_count
+            # Now go quiet: no further update() — the loop must halt and drop to IDLE.
+            deadline = time.monotonic() + 2.0
+            while ctrl.state != ControllerState.IDLE and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ctrl.state == ControllerState.IDLE, "stale feed did not halt the controller"
+            assert backend.stop_count > stops_before, "stale feed did not send a backend stop"
+        finally:
+            ctrl.stop()
+
+    def test_heartbeat_inactive_on_synchronous_step(self) -> None:
+        """The synchronous step() path never trips the heartbeat (loop not running).
+
+        step() refreshes the payload itself immediately before _tick, so even a
+        wall-clock gap between steps must not be treated as a stalled producer.
+        """
+        backend = MockBackend()
+        ctrl = PTZController(backend, _cfg(kp=0.6))
+        ctrl._heartbeat_stale_s = 0.0  # would trip instantly IF the gate were off
+        ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        ctrl.step((0.5, 0.0), (0.0, 0.0), 0.45, True, t=1.0)
+        assert ctrl.state == ControllerState.TRACKING
+
+
+def ctrl_mod_floor() -> float:
+    import autoptz.engine.ptz.controller as ctrl_mod
+
+    return ctrl_mod._HEARTBEAT_FLOOR_S
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Controller — rate-limit suppression
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Keystone change to **how PTZ commands are emitted**, gated behind `AUTOPTZ_PTZ_PUMP` (**default OFF** until real-camera validation). When OFF, behaviour is exactly today's inline `step()` path.

### C1 — Fixed-rate, off-thread command pump (flag-gated)
- `_ptz_pump_enabled()` reads `AUTOPTZ_PTZ_PUMP` (`1`/`true`/`yes`/`on` → ON), parsed next to the other `AUTOPTZ_*` env reads.
- **Pump ON:** `_maybe_start_ptz_pump()` starts the controller's own `_loop` so it emits at its fixed `rate_hz` (called from `_open_resources` after `_build_ptz_stack`, and again after `_rebuild_ptz_backend`). `_drive_ptz_auto` publishes the latest target via `ctrl.update(...)` — the loop sends, **off the inference hot path**. `set_loop_latency(...)` still runs each inference tick. Teardown/rebuild halt the loop through the existing `close()`/`stop()` (which send `backend.stop()`).
- **Pump OFF:** unchanged inline `ctrl.step(...)` drive. A single `_publish_ptz` helper branches on the flag; the OFF branch reproduces the prior active/idle behaviour exactly (including the active-only `_log_ptz_cmd` and `_ptz_last_cmd` mirror).
- Manual nudges, presets, home/menu are untouched — they use their own paths.

### C1-safety — stop-on-loss heartbeat (active in pump mode)
- The controller records the monotonic time of the last `update()`. The background loop halts a still-`TRACKING`/`COASTING` camera (drops to `IDLE` + sends a real `backend.stop()`) if no `update()` arrives for `> max(0.3s, 4 control periods)`. Gated on the loop running, so the synchronous `step()` path never trips it. Logged (throttled). Complements the backend-level transport-drop halt.

### C3 — Lower the inference wake-latency ceiling
- `_INFER_WAKE_TIMEOUT_S = 0.01` (named constant, was `0.05`): commands drain on the timeout fall-through ~5× more often; negligible CPU (the loop short-circuits when there's no new frame).

## Why

A steady command cadence sent off the inference thread decouples PTZ output from per-frame inference jitter; the heartbeat guarantees a stalled inference thread or dropped feed halts the camera instead of coasting on a frozen aim. Shipped **OFF by default** so the merge is safe — OFF is byte-for-byte today's behaviour. **The pump path needs real-camera validation before flipping the default.**

## Tests (TDD)

- Controller pump/heartbeat (fake backend): loop drives from `update()`; withholding `update()` past the stale threshold halts + drops to IDLE; recency tracked; synchronous `step()` never trips the heartbeat.
- Worker flag branch: pump ON routes auto-drive through `update()` and starts the loop; pump OFF uses `step()`; env parsing + default-OFF.
- Wake-timeout value check.
- All existing PTZ/controller/orchestration tests pass in both flag states.

## Gates (all green)
- `ruff check` ✓ · `ruff format --check` ✓ · `mypy autoptz/engine/runtime/ autoptz/config/` ✓
- `pytest tests/` → **1279 passed**
- `python -m autoptz --selftest` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)