### PR TITLE
feat(center-stage): multi-person group framing + shot-size headroom + lead-room

### DIFF
--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -124,6 +124,19 @@ class TrackingConfig(BaseModel, frozen=True):
     # Never run the detector and the pose pass on the same inference frame, so a
     # heavy detect tick and a heavy pose tick don't stack into a 200ms frame.
     stage_spread: bool = True
+    # Center Stage multi-person *group framing* (digital crop path only). When ON
+    # and more than one confident person is present WITHOUT an explicit locked
+    # target, the digital framer frames the UNION of everyone's boxes (auto-widens
+    # to keep the group in shot) instead of a single subject. An explicitly locked
+    # target (by id or identity) always wins — it keeps following that one person.
+    # Off by default → no behaviour change.
+    group_framing: bool = False
+    # Subtle digital lead-room ("nose room") for the Center Stage crop: bias the
+    # crop centre toward the framed subject's motion so a walking subject sits a
+    # touch back-of-centre. The offset is this gain × the EMA subject-centre
+    # velocity, capped to a small fraction of the crop so it can't destabilise
+    # framing. Conservative default (0.0 = off / centred, exactly as before).
+    lead_room: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
 # Vertical aim point as a fraction of the person-box height measured from the TOP

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -88,15 +88,20 @@ def _push_due(now: float, last: float, min_period: float) -> bool:
 
 
 # Center Stage crop tightness per "Framing" preset → (subject fill of crop,
-# max crop as a fraction of the frame). A smaller ``max_frac`` forces a tighter
-# zoom even on a close subject that already fills the sensor; the live "Framing"
-# dropdown (tracking.framing) picks the preset, so the user dials the shot
-# without a restart. ``upper_body`` is the default head-and-shoulders look.
-_CENTERSTAGE_FRAMING: dict[str, tuple[float, float]] = {
-    "face": (0.86, 0.50),  # tight head/face closeup (~2.0x on a close subject)
-    "head_shoulders": (0.80, 0.62),  # head + shoulders (~1.6x)
-    "upper_body": (0.70, 0.74),  # head + chest (~1.35x) — default
-    "full_body": (0.58, 0.94),  # whole person, gentle crop
+# max crop as a fraction of the frame, headroom). A smaller ``max_frac`` forces a
+# tighter zoom even on a close subject that already fills the sensor; the live
+# "Framing" dropdown (tracking.framing) picks the preset, so the user dials the
+# shot without a restart. ``upper_body`` is the default head-and-shoulders look.
+#
+# ``headroom`` is shot-size-aware: a tight face/closeup wants only a sliver of
+# space above the head, while a full-body shot wants more margin so the subject
+# isn't jammed against the top. Closer shots → less headroom, wider shots → more.
+# The old fixed 0.10 is kept for ``upper_body`` as the midpoint.
+_CENTERSTAGE_FRAMING: dict[str, tuple[float, float, float]] = {
+    "face": (0.86, 0.50, 0.06),  # tight head/face closeup (~2.0x), minimal headroom
+    "head_shoulders": (0.80, 0.62, 0.08),  # head + shoulders (~1.6x)
+    "upper_body": (0.70, 0.74, 0.10),  # head + chest (~1.35x) — default midpoint
+    "full_body": (0.58, 0.94, 0.14),  # whole person, more margin above the head
 }
 
 _DEFAULT_TELEMETRY_HZ = 10.0
@@ -3491,11 +3496,15 @@ class CameraWorker:
             from autoptz.engine.pipeline.digital_framer import DigitalFramer
 
             framer = self._digital_framer = DigitalFramer(out_aspect=aspect)
-        # Crop tightness follows the live "Framing" dropdown.
+        # Crop tightness AND shot-size-aware headroom follow the live "Framing"
+        # dropdown (set live so a preset change re-composes without a restart).
         framing = getattr(self.config.tracking, "framing", "upper_body")
-        framer.fill, framer.max_frac = _CENTERSTAGE_FRAMING.get(
+        framer.fill, framer.max_frac, framer.headroom = _CENTERSTAGE_FRAMING.get(
             framing, _CENTERSTAGE_FRAMING["upper_body"]
         )
+        # Subtle digital lead-room ("nose room"): bias the crop toward the
+        # subject's motion. Conservative default; 0 reproduces centred framing.
+        framer.lead = float(getattr(self.config.tracking, "lead_room", 0.0))
         target = self._current_digital_target()
         if target is not None:
             x, y, cw, ch = framer.frame_for(target, w, h)
@@ -3525,15 +3534,27 @@ class CameraWorker:
         return cv2.resize(crop, (ow, oh), interpolation=interp)
 
     def _current_digital_target(self) -> tuple[float, float, float, float] | None:
-        """The selected target's bbox (x1,y1,x2,y2) for Center Stage, or None.
+        """The bbox (x1,y1,x2,y2) Center Stage should frame this tick, or None.
 
         Runs on the capture thread; a slightly stale box is fine for smooth
-        framing. Prefers the live track for the current target id, but falls back
-        to the maintained *trusted* target box so Center Stage keeps framing
-        through track-id churn / identity re-binding (when ``_target_track_id``
-        momentarily points at a track not in the latest ``_last_tracks``).
+        framing.
+
+        **Explicit lock wins.** When the user has locked a specific person (by
+        track id OR by configured identity), Center Stage follows *that* single
+        person even with group framing on — explicit selection always beats the
+        crowd. It prefers the live track for the current id but falls back to the
+        maintained *trusted* box so the crop holds through track-id churn /
+        identity re-binding (when ``_target_track_id`` momentarily points at a
+        track not in the latest ``_last_tracks``).
+
+        **Group framing** (``tracking.group_framing``, default off) only applies
+        when NO explicit target is locked: with more than one confident, non-lost
+        person present the crop frames the UNION of their boxes (auto-widening,
+        capped by ``max_frac``). One person, or the toggle off, is the single
+        target's box exactly as before.
         """
         tid = self._target_track_id
+        explicit_lock = tid is not None or self._target_identity_id is not None
         if tid is not None:
             for t in self._last_tracks or ():
                 if (
@@ -3545,11 +3566,37 @@ class CameraWorker:
                     return (bb.x1, bb.y1, bb.x2, bb.y2)
         # Fallback: the last trusted target box (set whenever a target is locked,
         # by track id OR by identity), so the crop holds through brief track gaps.
-        if self._target_track_id is not None or self._target_identity_id is not None:
+        if explicit_lock:
             tb = getattr(self._target_lock, "trusted_bbox", None)
             if tb is not None:
                 return (tb.x1, tb.y1, tb.x2, tb.y2)
+
+        # No explicit lock: optionally frame the whole confident group as a union.
+        if bool(getattr(self.config.tracking, "group_framing", False)):
+            return self._group_union_bbox(self._last_tracks)
         return None
+
+    @staticmethod
+    def _group_union_bbox(
+        tracks: list[TrackInfo],
+    ) -> tuple[float, float, float, float] | None:
+        """Union of every confident, non-lost person box in *tracks*, or None.
+
+        Pure (no instance state) so it's unit-testable directly. Returns None when
+        fewer than one usable person is present so the caller falls back to the
+        full-frame path; a single usable person yields just that person's box.
+        """
+        from autoptz.engine.pipeline.digital_framer import union_bbox
+
+        boxes: list[tuple[float, float, float, float]] = []
+        for t in tracks or ():
+            if getattr(t, "lost", False):
+                continue
+            bb = getattr(t, "bbox", None)
+            if bb is None:
+                continue
+            boxes.append((bb.x1, bb.y1, bb.x2, bb.y2))
+        return union_bbox(boxes)
 
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -613,6 +613,10 @@ class CameraWorker:
         self._shm: ShmWriter | None = None
         self._vcam: Any | None = None  # VirtualCamSink (lazily created when vcam_out enabled)
         self._digital_framer: Any | None = None  # Center Stage auto-framer (lazy)
+        # True when the last _current_digital_target() returned a multi-person group
+        # UNION box (which must fit-width); False for a single locked person (which
+        # keeps the prior height-only sizing). Read by the Center Stage crop path.
+        self._digital_target_is_group: bool = False
         self._cs_diag_t: float = 0.0  # throttle for the Center Stage diagnostic log
         self._detect: _DetectStack | None = None
         self._pooled_detector = False
@@ -3507,7 +3511,10 @@ class CameraWorker:
         framer.lead = float(getattr(self.config.tracking, "lead_room", 0.0))
         target = self._current_digital_target()
         if target is not None:
-            x, y, cw, ch = framer.frame_for(target, w, h)
+            # fit_width only for a multi-person group UNION (so it auto-widens to
+            # keep everyone in shot); a single locked/standalone person stays on
+            # the prior height-only sizing.
+            x, y, cw, ch = framer.frame_for(target, w, h, fit_width=self._digital_target_is_group)
         else:
             x, y, cw, ch = framer.full_frame(w, h)
         nowm = time.monotonic()
@@ -3553,6 +3560,7 @@ class CameraWorker:
         capped by ``max_frac``). One person, or the toggle off, is the single
         target's box exactly as before.
         """
+        self._digital_target_is_group = False
         tid = self._target_track_id
         explicit_lock = tid is not None or self._target_identity_id is not None
         if tid is not None:
@@ -3570,11 +3578,39 @@ class CameraWorker:
             tb = getattr(self._target_lock, "trusted_bbox", None)
             if tb is not None:
                 return (tb.x1, tb.y1, tb.x2, tb.y2)
+            # An explicit lock ALWAYS wins: never fall through to the group union
+            # just because the locked track is momentarily absent (transient — e.g.
+            # the first frame(s) after selecting a target, before trusted_bbox is
+            # populated). Returning None holds the prior crop / full frame instead.
+            return None
 
         # No explicit lock: optionally frame the whole confident group as a union.
         if bool(getattr(self.config.tracking, "group_framing", False)):
-            return self._group_union_bbox(self._last_tracks)
+            boxes = self._confident_person_boxes(self._last_tracks)
+            if not boxes:
+                return None
+            # fit-width only when the union actually spans MORE THAN ONE person; a
+            # single confident person keeps the prior height-only single-target feel.
+            self._digital_target_is_group = len(boxes) > 1
+            from autoptz.engine.pipeline.digital_framer import union_bbox
+
+            return union_bbox(boxes)
         return None
+
+    @staticmethod
+    def _confident_person_boxes(
+        tracks: list[TrackInfo],
+    ) -> list[tuple[float, float, float, float]]:
+        """Every confident, non-lost person box in *tracks* (pure, testable)."""
+        boxes: list[tuple[float, float, float, float]] = []
+        for t in tracks or ():
+            if getattr(t, "lost", False):
+                continue
+            bb = getattr(t, "bbox", None)
+            if bb is None:
+                continue
+            boxes.append((bb.x1, bb.y1, bb.x2, bb.y2))
+        return boxes
 
     @staticmethod
     def _group_union_bbox(
@@ -3588,15 +3624,7 @@ class CameraWorker:
         """
         from autoptz.engine.pipeline.digital_framer import union_bbox
 
-        boxes: list[tuple[float, float, float, float]] = []
-        for t in tracks or ():
-            if getattr(t, "lost", False):
-                continue
-            bb = getattr(t, "bbox", None)
-            if bb is None:
-                continue
-            boxes.append((bb.x1, bb.y1, bb.x2, bb.y2))
-        return union_bbox(boxes)
+        return union_bbox(CameraWorker._confident_person_boxes(tracks))
 
     def _push_frame(self, frame: NDArray[np.uint8]) -> None:
         if self._shm is None:

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -50,6 +50,7 @@ def desired_crop(
     min_frac: float,
     max_frac: float,
     headroom: float = 0.10,
+    fit_width: bool = False,
 ) -> tuple[float, float, float, float]:
     """The crop ``(x, y, w, h)`` (pixels) that frames *bbox*.
 
@@ -60,12 +61,13 @@ def desired_crop(
     the crop matching the output so the resize doesn't distort. ``headroom`` lifts
     the centre so the head sits a little below the top.
 
-    The crop is sized so the subject fits both *vertically* (``fill`` of the
-    height) and *horizontally* (the same ``fill`` margin on the width): a tall
-    single person stays height-driven exactly as before, but a WIDE box — e.g. the
-    union of several people in *group framing* — forces the crop to widen
-    (auto-zoom out) so everyone stays in shot, still aspect-locked and capped at
-    ``max_frac``.
+    By default the crop is sized *height-only* from the subject height (a tall
+    single person frames exactly as before, and an arms-spread / T-pose single box
+    is NOT zoomed out). ``fit_width=True`` additionally grows the crop so its
+    aspect-locked width covers the subject *width* too — used only for the
+    multi-person *group framing* union, so the crop auto-widens to keep everyone
+    in shot (still aspect-locked and capped at ``max_frac``). Single-person /
+    non-group framing keeps ``fit_width=False`` for byte-identical prior behaviour.
     """
     bx1, by1, bx2, by2 = (float(v) for v in bbox)
     subj_h = max(1.0, by2 - by1)
@@ -75,13 +77,15 @@ def desired_crop(
     fw, fh = float(frame_w), float(frame_h)
 
     # Size the crop to the subject, then constrain it to a window of the frame.
-    # Height from the subject height; but if the subject is WIDER than that crop
-    # would hold (a wide group union), grow the crop height so its aspect-locked
-    # width covers the subject width too. ``max_frac`` then caps the result.
+    # Height from the subject height. Only when ``fit_width`` is set (the group
+    # union path) do we ALSO grow the crop height so its aspect-locked width covers
+    # a wide subject — the single-person default stays strictly height-driven so it
+    # never zooms out more than before. ``max_frac`` then caps the result.
     fill_c = _clamp(fill, 0.1, 1.0)
     ch = subj_h / fill_c
-    ch_for_width = (subj_w / fill_c) / out_aspect
-    ch = max(ch, ch_for_width)
+    if fit_width:
+        ch_for_width = (subj_w / fill_c) / out_aspect
+        ch = max(ch, ch_for_width)
     ch = _clamp(ch, min_frac * fh, max_frac * fh)
     cw = ch * out_aspect
     # If that is wider than the frame, cap width (keeps aspect; only happens for
@@ -152,9 +156,18 @@ class DigitalFramer:
         self._subj_vel = (0.0, 0.0)
 
     def frame_for(
-        self, bbox: tuple[float, float, float, float], frame_w: int, frame_h: int
+        self,
+        bbox: tuple[float, float, float, float],
+        frame_w: int,
+        frame_h: int,
+        *,
+        fit_width: bool = False,
     ) -> tuple[int, int, int, int]:
-        """Smoothed integer crop framing *bbox*."""
+        """Smoothed integer crop framing *bbox*.
+
+        ``fit_width=True`` widens the crop to cover a wide subject (the group-union
+        box); the default keeps the prior height-only sizing for single people.
+        """
         tgt = desired_crop(
             bbox,
             frame_w,
@@ -164,6 +177,7 @@ class DigitalFramer:
             min_frac=self.min_frac,
             max_frac=self.max_frac,
             headroom=self.headroom,
+            fit_width=fit_width,
         )
         tgt = self._apply_lead(bbox, tgt, frame_w, frame_h)
         return self._step(tgt)

--- a/autoptz/engine/pipeline/digital_framer.py
+++ b/autoptz/engine/pipeline/digital_framer.py
@@ -21,6 +21,25 @@ def _clamp(v: float, lo: float, hi: float) -> float:
     return lo if v < lo else hi if v > hi else v
 
 
+def union_bbox(
+    boxes: list[tuple[float, float, float, float]],
+) -> tuple[float, float, float, float] | None:
+    """The smallest ``(x1, y1, x2, y2)`` box covering every box in *boxes*.
+
+    Used for multi-person *group framing*: pass the bboxes of the confident
+    people and frame the union so the auto-zoom widens to keep everyone in shot.
+    Returns ``None`` for an empty list (the caller falls back to the single
+    target / full-frame path). A single box round-trips unchanged.
+    """
+    if not boxes:
+        return None
+    x1 = min(b[0] for b in boxes)
+    y1 = min(b[1] for b in boxes)
+    x2 = max(b[2] for b in boxes)
+    y2 = max(b[3] for b in boxes)
+    return (float(x1), float(y1), float(x2), float(y2))
+
+
 def desired_crop(
     bbox: tuple[float, float, float, float],
     frame_w: int,
@@ -40,15 +59,29 @@ def desired_crop(
     window (never the whole frame) and never an extreme zoom. ``out_aspect`` keeps
     the crop matching the output so the resize doesn't distort. ``headroom`` lifts
     the centre so the head sits a little below the top.
+
+    The crop is sized so the subject fits both *vertically* (``fill`` of the
+    height) and *horizontally* (the same ``fill`` margin on the width): a tall
+    single person stays height-driven exactly as before, but a WIDE box — e.g. the
+    union of several people in *group framing* — forces the crop to widen
+    (auto-zoom out) so everyone stays in shot, still aspect-locked and capped at
+    ``max_frac``.
     """
     bx1, by1, bx2, by2 = (float(v) for v in bbox)
     subj_h = max(1.0, by2 - by1)
+    subj_w = max(1.0, bx2 - bx1)
     cx = (bx1 + bx2) * 0.5
     cy = (by1 + by2) * 0.5
     fw, fh = float(frame_w), float(frame_h)
 
     # Size the crop to the subject, then constrain it to a window of the frame.
-    ch = subj_h / _clamp(fill, 0.1, 1.0)
+    # Height from the subject height; but if the subject is WIDER than that crop
+    # would hold (a wide group union), grow the crop height so its aspect-locked
+    # width covers the subject width too. ``max_frac`` then caps the result.
+    fill_c = _clamp(fill, 0.1, 1.0)
+    ch = subj_h / fill_c
+    ch_for_width = (subj_w / fill_c) / out_aspect
+    ch = max(ch, ch_for_width)
     ch = _clamp(ch, min_frac * fh, max_frac * fh)
     cw = ch * out_aspect
     # If that is wider than the frame, cap width (keeps aspect; only happens for
@@ -93,16 +126,30 @@ class DigitalFramer:
     deadzone: float = 0.04  # hold centre while desired moves < this frac of crop w/h
     size_deadband: float = 0.03  # ignore size changes under this fraction
     headroom: float = 0.10
+    # Digital lead-room ("nose room"): bias the crop CENTRE in the direction of the
+    # subject's motion so a walking subject sits a touch back-of-centre rather than
+    # trailing the edge. The offset is ``lead`` × the EMA subject-centre velocity
+    # (px/frame), capped to ``_LEAD_MAX_FRAC`` of the crop so it can never
+    # destabilise framing. ``lead=0.0`` reproduces the prior centred behaviour.
+    lead: float = 0.0  # default OFF/very subtle; 0 = no lead-room
+    lead_smooth: float = 0.2  # EMA weight for the subject-centre velocity estimate
     _crop: tuple[float, float, float, float] | None = None
     _following: bool = False  # hysteresis: True once the centre is being tracked
+    _prev_subj_c: tuple[float, float] | None = None  # last subject centre (for velocity)
+    _subj_vel: tuple[float, float] = (0.0, 0.0)  # EMA of subject-centre velocity
 
     # Once moving, keep following until the desired centre is back inside this
     # (tighter) fraction of the dead-zone band — prevents boundary chatter.
     _INNER_BAND_FRAC: float = 0.5
+    # Lead-room offset is capped to this fraction of the crop width/height so a
+    # fast subject can never shove the framing more than a gentle nudge off-centre.
+    _LEAD_MAX_FRAC: float = 0.12
 
     def reset(self) -> None:
         self._crop = None
         self._following = False
+        self._prev_subj_c = None
+        self._subj_vel = (0.0, 0.0)
 
     def frame_for(
         self, bbox: tuple[float, float, float, float], frame_w: int, frame_h: int
@@ -118,11 +165,54 @@ class DigitalFramer:
             max_frac=self.max_frac,
             headroom=self.headroom,
         )
+        tgt = self._apply_lead(bbox, tgt, frame_w, frame_h)
         return self._step(tgt)
 
     def full_frame(self, frame_w: int, frame_h: int) -> tuple[int, int, int, int]:
         """Ease the crop back toward the whole frame (no target to follow)."""
+        # No subject to lead — forget the velocity so the next acquisition starts
+        # clean instead of carrying stale motion.
+        self._prev_subj_c = None
+        self._subj_vel = (0.0, 0.0)
         return self._step((0.0, 0.0, float(frame_w), float(frame_h)))
+
+    def _apply_lead(
+        self,
+        bbox: tuple[float, float, float, float],
+        tgt: tuple[float, float, float, float],
+        frame_w: int,
+        frame_h: int,
+    ) -> tuple[float, float, float, float]:
+        """Offset the desired crop centre toward the subject's motion (nose room).
+
+        Tracks an EMA of the subject-centre velocity (px/frame) and shifts the
+        crop's top-left by ``lead × velocity``, capped to ``_LEAD_MAX_FRAC`` of the
+        crop and re-clamped inside the frame. ``lead == 0`` is a no-op (returns
+        *tgt* unchanged), so prior behaviour is exactly reproduced.
+        """
+        bx1, by1, bx2, by2 = bbox
+        subj_c = ((bx1 + bx2) * 0.5, (by1 + by2) * 0.5)
+        if self._prev_subj_c is not None:
+            dx = subj_c[0] - self._prev_subj_c[0]
+            dy = subj_c[1] - self._prev_subj_c[1]
+            a = _clamp(self.lead_smooth, 0.0, 1.0)
+            self._subj_vel = (
+                self._subj_vel[0] + a * (dx - self._subj_vel[0]),
+                self._subj_vel[1] + a * (dy - self._subj_vel[1]),
+            )
+        self._prev_subj_c = subj_c
+        if self.lead <= 0.0:
+            return tgt
+        x, y, w, h = tgt
+        ox = _clamp(
+            self.lead * self._subj_vel[0], -self._LEAD_MAX_FRAC * w, self._LEAD_MAX_FRAC * w
+        )
+        oy = _clamp(
+            self.lead * self._subj_vel[1], -self._LEAD_MAX_FRAC * h, self._LEAD_MAX_FRAC * h
+        )
+        x = _clamp(x + ox, 0.0, max(0.0, float(frame_w) - w))
+        y = _clamp(y + oy, 0.0, max(0.0, float(frame_h) - h))
+        return (x, y, w, h)
 
     def _step(self, tgt: tuple[float, float, float, float]) -> tuple[int, int, int, int]:
         if self._crop is None:

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -3,7 +3,11 @@ bbox (not the velocity controller, which never zoomed)."""
 
 from __future__ import annotations
 
-from autoptz.engine.pipeline.digital_framer import DigitalFramer, desired_crop
+from autoptz.engine.pipeline.digital_framer import (
+    DigitalFramer,
+    desired_crop,
+    union_bbox,
+)
 
 ASPECT = 16.0 / 9.0
 
@@ -199,3 +203,143 @@ class TestSizeSmoothing:
             max(1, int(round(exp[2]))),
             max(1, int(round(exp[3]))),
         )
+
+
+class TestUnionBbox:
+    """D1 — multi-person group framing: the union of several person boxes."""
+
+    def test_union_of_one_box_is_itself(self):
+        assert union_bbox([(10, 20, 30, 40)]) == (10.0, 20.0, 30.0, 40.0)
+
+    def test_union_covers_all_boxes(self):
+        boxes = [(100, 200, 300, 500), (700, 150, 900, 600), (400, 300, 500, 450)]
+        u = union_bbox(boxes)
+        # The union's corners are the extremes across all boxes.
+        assert u == (100.0, 150.0, 900.0, 600.0)
+        # Every input box is contained inside the union.
+        for x1, y1, x2, y2 in boxes:
+            assert u[0] <= x1 and u[1] <= y1
+            assert u[2] >= x2 and u[3] >= y2
+
+    def test_union_wider_than_any_single_box(self):
+        boxes = [(300, 400, 500, 670), (1400, 400, 1600, 670)]
+        u = union_bbox(boxes)
+        u_w = u[2] - u[0]
+        for x1, _, x2, _ in boxes:
+            assert u_w > (x2 - x1)
+
+    def test_empty_returns_none(self):
+        assert union_bbox([]) is None
+
+    def test_group_crop_frames_all_people(self):
+        # Two people on opposite sides of the frame: the group crop (framing the
+        # union) must be wider than either single-person crop, and cover both.
+        left = (300, 400, 500, 670)
+        right = (1400, 400, 1600, 670)
+        u = union_bbox([left, right])
+        assert u is not None
+        group = desired_crop(
+            u, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.94
+        )
+        single = desired_crop(
+            left, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.94
+        )
+        assert group[2] > single[2]  # group crop is wider
+        # Both subjects fall inside the group crop horizontally.
+        gx, gw = group[0], group[2]
+        assert gx <= left[0] and (gx + gw) >= right[2]
+
+
+class TestHeadroomByPreset:
+    """D2 — shot-size-aware headroom: the applied headroom comes from the preset."""
+
+    def test_more_headroom_lifts_center_higher(self):
+        bbox = (860, 400, 1060, 670)  # centre y = 535
+        _, y_lo, _, h_lo = desired_crop(
+            bbox,
+            1920,
+            1080,
+            out_aspect=ASPECT,
+            fill=0.62,
+            min_frac=0.34,
+            max_frac=0.78,
+            headroom=0.0,
+        )
+        _, y_hi, _, h_hi = desired_crop(
+            bbox,
+            1920,
+            1080,
+            out_aspect=ASPECT,
+            fill=0.62,
+            min_frac=0.34,
+            max_frac=0.78,
+            headroom=0.2,
+        )
+        # More headroom raises the subject (smaller y, crop pulled up).
+        assert y_hi < y_lo
+
+    def test_framer_headroom_field_is_applied(self):
+        # Two framers identical but for headroom must produce different crop y.
+        low = DigitalFramer(out_aspect=ASPECT, smooth=1.0, headroom=0.0)
+        high = DigitalFramer(out_aspect=ASPECT, smooth=1.0, headroom=0.25)
+        bbox = (860, 400, 1060, 670)
+        ylow = low.frame_for(bbox, 1920, 1080)[1]
+        yhigh = high.frame_for(bbox, 1920, 1080)[1]
+        assert yhigh < ylow
+
+
+class TestLeadRoom:
+    """D2 — subtle motion lead-room: bias the crop centre in the direction of
+    motion so a walking subject sits back-of-centre."""
+
+    def test_lead_zero_centers_as_before(self):
+        # lead=0 must reproduce the prior centred behaviour for a moving subject.
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.0, size_smooth=1.0, lead=0.0)
+        f.frame_for((300, 400, 500, 670), 1920, 1080)
+        x, _, w, _ = f.frame_for((600, 400, 800, 670), 1920, 1080)
+        ref = desired_crop(
+            (600, 400, 800, 670),
+            1920,
+            1080,
+            out_aspect=ASPECT,
+            fill=f.fill,
+            min_frac=f.min_frac,
+            max_frac=f.max_frac,
+            headroom=f.headroom,
+        )
+        assert x == int(round(ref[0]))
+
+    def test_subject_moving_right_shifts_crop_right(self):
+        # A subject moving steadily right: with lead-room the crop centre sits to
+        # the RIGHT of the bbox centre (nose room ahead of the motion).
+        lead = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.0, size_smooth=1.0, lead=0.5)
+        no_lead = DigitalFramer(
+            out_aspect=ASPECT, smooth=1.0, deadzone=0.0, size_smooth=1.0, lead=0.0
+        )
+        # Walk the subject right across several frames so velocity builds up.
+        bx = 300
+        cx_lead = cx_no = 0.0
+        for _ in range(12):
+            box = (bx, 400, bx + 200, 670)
+            cl = lead.frame_for(box, 1920, 1080)
+            cn = no_lead.frame_for(box, 1920, 1080)
+            cx_lead = cl[0] + cl[2] / 2
+            cx_no = cn[0] + cn[2] / 2
+            bx += 60
+        # Lead-room pushes the crop centre ahead (to the right) of the no-lead one.
+        assert cx_lead > cx_no
+
+    def test_lead_default_is_subtle(self):
+        # The default lead must be conservative (small): a moving subject is not
+        # pushed more than a small fraction of the crop width off-centre.
+        f = DigitalFramer(out_aspect=ASPECT, smooth=1.0, deadzone=0.0, size_smooth=1.0)
+        bx = 300
+        offset = 0.0
+        for _ in range(12):
+            box = (bx, 400, bx + 200, 670)
+            x, _, w, _ = f.frame_for(box, 1920, 1080)
+            bbox_cx = bx + 100
+            crop_cx = x + w / 2
+            offset = abs(crop_cx - bbox_cx)
+            bx += 60
+        assert offset <= 0.15 * w  # small bias, can't destabilise framing

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -233,13 +233,21 @@ class TestUnionBbox:
 
     def test_group_crop_frames_all_people(self):
         # Two people on opposite sides of the frame: the group crop (framing the
-        # union) must be wider than either single-person crop, and cover both.
+        # union, fit_width=True) must be wider than either single-person crop, and
+        # cover both.
         left = (300, 400, 500, 670)
         right = (1400, 400, 1600, 670)
         u = union_bbox([left, right])
         assert u is not None
         group = desired_crop(
-            u, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.94
+            u,
+            1920,
+            1080,
+            out_aspect=ASPECT,
+            fill=0.62,
+            min_frac=0.34,
+            max_frac=0.94,
+            fit_width=True,
         )
         single = desired_crop(
             left, 1920, 1080, out_aspect=ASPECT, fill=0.62, min_frac=0.34, max_frac=0.94
@@ -248,6 +256,22 @@ class TestUnionBbox:
         # Both subjects fall inside the group crop horizontally.
         gx, gw = group[0], group[2]
         assert gx <= left[0] and (gx + gw) >= right[2]
+
+    def test_fit_width_default_off_keeps_height_only_for_wide_box(self):
+        # A box WIDER than the output aspect (arms spread / T-pose: w/h=2.5 > 16:9)
+        # must NOT zoom out on the default path (fit_width=False) — the crop matches
+        # a same-height normal box. fit_width=True (group union only) widens it.
+        wide = (600, 400, 1400, 720)  # w=800, h=320 → w/h=2.5
+        narrow = (900, 400, 1100, 720)  # same height, normal width
+        kw = {"out_aspect": ASPECT, "fill": 0.62, "min_frac": 0.34, "max_frac": 0.94}
+        wide_default = desired_crop(wide, 1920, 1080, **kw)
+        narrow_default = desired_crop(narrow, 1920, 1080, **kw)
+        # Same height → same crop size on the default (height-only) path.
+        assert wide_default[2] == narrow_default[2]
+        assert wide_default[3] == narrow_default[3]
+        # Opting into fit_width widens the crop for the wide box.
+        wide_fit = desired_crop(wide, 1920, 1080, fit_width=True, **kw)
+        assert wide_fit[2] > wide_default[2]
 
 
 class TestHeadroomByPreset:

--- a/tests/test_group_framing_worker.py
+++ b/tests/test_group_framing_worker.py
@@ -106,3 +106,39 @@ class TestExplicitLockWins:
         w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
         target = w._current_digital_target()
         assert target == (900.0, 420.0, 1100.0, 720.0)  # the locked identity, not the union
+
+    def test_lock_with_no_live_track_and_no_trusted_does_not_leak_to_group(self):
+        # The transient corner case (first frame(s) after selecting a target):
+        # explicit lock set, but the locked track isn't in _last_tracks yet AND no
+        # trusted_bbox exists. Group framing on + other people present must NOT
+        # leak the union — explicit lock always wins, so the target is None (hold).
+        w = _make_worker(group_framing=True)
+        w._target_track_id = 99  # locked, but absent from _last_tracks
+        w._target_lock = _TargetLockState()  # trusted_bbox defaults to None
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        assert w._current_digital_target() is None
+
+
+class TestGroupFlag:
+    """``_digital_target_is_group`` gates fit-width: True only for a real union."""
+
+    def test_flag_true_for_multi_person_union(self):
+        w = _make_worker(group_framing=True)
+        w._target_track_id = None
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        w._current_digital_target()
+        assert w._digital_target_is_group is True
+
+    def test_flag_false_for_single_person(self):
+        w = _make_worker(group_framing=True)
+        w._target_track_id = None
+        w._last_tracks = [_track(7, 800, 400, 1000, 700)]
+        w._current_digital_target()
+        assert w._digital_target_is_group is False
+
+    def test_flag_false_for_explicit_lock(self):
+        w = _make_worker(group_framing=True)
+        w._target_track_id = 2
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        w._current_digital_target()
+        assert w._digital_target_is_group is False

--- a/tests/test_group_framing_worker.py
+++ b/tests/test_group_framing_worker.py
@@ -1,0 +1,108 @@
+"""Center Stage group-framing wiring in CameraWorker (digital crop path only).
+
+Covers the D1 group-vs-explicit-lock rule and the union helper that
+``_current_digital_target`` uses:
+
+  * group framing OFF → single-target behaviour (unchanged);
+  * group framing ON, no explicit lock, several people → the UNION of their
+    boxes (wider than any single one);
+  * group framing ON, one person → just that person's box;
+  * an explicitly locked target (by id or identity) ALWAYS wins, even with
+    group framing on.
+"""
+
+from __future__ import annotations
+
+from autoptz.config.models import CameraConfig, SourceConfig, TrackingConfig
+from autoptz.engine.camera_worker import CameraWorker, _TargetLockState
+from autoptz.engine.runtime.messages import BBox, TrackInfo
+
+
+def _make_worker(*, group_framing: bool = False, identity_id: str | None = None) -> CameraWorker:
+    config = CameraConfig(
+        id="test-cam-group12345",
+        name="Test",
+        source=SourceConfig(type="usb", address="usb://0"),
+        tracking=TrackingConfig(group_framing=group_framing),
+    )
+    if identity_id is not None:
+        config = config.model_copy(
+            update={"target": config.target.model_copy(update={"identity_id": identity_id})}
+        )
+    return CameraWorker("test-cam-group12345", config, on_telemetry=lambda m: None)
+
+
+def _track(track_id: int, x1: float, y1: float, x2: float, y2: float) -> TrackInfo:
+    return TrackInfo(track_id=track_id, bbox=BBox(x1=x1, y1=y1, x2=x2, y2=y2))
+
+
+class TestGroupUnionHelper:
+    """``_group_union_bbox`` is pure — test it directly."""
+
+    def test_none_for_no_people(self):
+        assert CameraWorker._group_union_bbox([]) is None
+
+    def test_single_person_is_that_box(self):
+        tracks = [_track(1, 300, 400, 500, 670)]
+        assert CameraWorker._group_union_bbox(tracks) == (300.0, 400.0, 500.0, 670.0)
+
+    def test_union_of_several_people(self):
+        tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        u = CameraWorker._group_union_bbox(tracks)
+        assert u == (300.0, 380.0, 1600.0, 690.0)
+
+    def test_lost_people_are_ignored(self):
+        live = _track(1, 300, 400, 500, 670)
+        lost = _track(2, 1400, 380, 1600, 690)
+        lost.lost = True
+        u = CameraWorker._group_union_bbox([live, lost])
+        # The lost person drops out → union is just the live one.
+        assert u == (300.0, 400.0, 500.0, 670.0)
+
+
+class TestGroupFramingOff:
+    def test_off_with_no_lock_returns_none(self):
+        w = _make_worker(group_framing=False)
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        # No explicit lock and group framing off → no digital target (full frame).
+        assert w._current_digital_target() is None
+
+
+class TestGroupFramingOn:
+    def test_union_when_no_lock_and_multiple_people(self):
+        w = _make_worker(group_framing=True)
+        w._target_track_id = None
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        target = w._current_digital_target()
+        assert target == (300.0, 380.0, 1600.0, 690.0)
+        # Wider than either single person box.
+        assert (target[2] - target[0]) > (500 - 300)
+        assert (target[2] - target[0]) > (1600 - 1400)
+
+    def test_single_person_is_single_box(self):
+        w = _make_worker(group_framing=True)
+        w._target_track_id = None
+        w._last_tracks = [_track(7, 800, 400, 1000, 700)]
+        assert w._current_digital_target() == (800.0, 400.0, 1000.0, 700.0)
+
+
+class TestExplicitLockWins:
+    def test_locked_track_id_beats_group(self):
+        # Group framing ON, but an explicit track id is locked → follow that one
+        # person, NOT the union.
+        w = _make_worker(group_framing=True)
+        w._target_track_id = 2
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        target = w._current_digital_target()
+        assert target == (1400.0, 380.0, 1600.0, 690.0)  # just the locked person
+
+    def test_locked_identity_beats_group_via_trusted_bbox(self):
+        # Identity locked but its live track has churned out of _last_tracks: the
+        # explicit-lock path falls back to the trusted bbox, NOT the group union.
+        w = _make_worker(group_framing=True, identity_id="person-abc")
+        w._target_track_id = None
+        w._target_lock = _TargetLockState()
+        w._target_lock.trusted_bbox = BBox(x1=900, y1=420, x2=1100, y2=720)
+        w._last_tracks = [_track(1, 300, 400, 500, 670), _track(2, 1400, 380, 1600, 690)]
+        target = w._current_digital_target()
+        assert target == (900.0, 420.0, 1100.0, 720.0)  # the locked identity, not the union


### PR DESCRIPTION
## What & why

Adds the marquee Center-Stage feature AutoPTZ lacked — **multi-person framing** — plus two composition-polish knobs, all in the **digital framer path** (no physical-PTZ controller changes). Every default reproduces prior behaviour exactly.

### D1 — Multi-person group framing (union bbox)
- New `tracking.group_framing: bool = False` toggle (off → no behaviour change).
- `union_bbox()` pure helper in `digital_framer.py` + `CameraWorker._group_union_bbox()` over the live confident, non-lost `TrackInfo` boxes.
- `desired_crop` now sizes the crop to fit the subject **both vertically and horizontally**, so a WIDE union auto-widens (zoom out) to keep everyone in shot — still aspect-locked and capped by `max_frac`. Tall single-person boxes stay height-driven exactly as before.
- **Group-vs-explicit-lock rule:** an explicitly locked target (by track id OR configured identity) *always wins* — Center Stage keeps following that one person even with group mode on. Group framing applies only when **no** explicit target is locked. The existing `trusted_bbox` fallback for single-target churn is preserved.

### D2 — Shot-size-aware headroom
- `_CENTERSTAGE_FRAMING` carries a per-preset headroom: `face 0.06 → head_shoulders 0.08 → upper_body 0.10 (unchanged midpoint) → full_body 0.14`. Closer shots get less margin above the head, full-body more.
- `_framed_output` sets `DigitalFramer.headroom` from the active preset, the same way `fill`/`max_frac` are already wired (live, no restart).

### D2 — Subtle digital lead-room ("nose room")
- New `tracking.lead_room: float = 0.0` gain (default **off / centred**, `lead=0` reproduces prior framing).
- `DigitalFramer` tracks an EMA of the framed subject's centre velocity and offsets the crop centre toward the motion, **capped to 12% of the crop** so it can't destabilise framing.

## Tests
- `union_bbox` / `_group_union_bbox` (pure) tested directly; group crop frames the UNION and is wider than any single box; lost people ignored.
- Explicit-lock-wins rule tested (locked id and locked identity-via-trusted-bbox both beat the group union).
- Headroom-by-preset: more headroom lifts the crop; framer field is applied.
- Lead-room: subject moving right shifts the crop centre right; `lead=0` → centred as before; default stays subtle.
- All existing `digital_framer` tests (dead-zone hold, aspect lock, split size smoothing) preserved.

## Gates
- `ruff check` / `ruff format --check`: clean
- `mypy autoptz/engine/runtime/ autoptz/config/` (strict): clean
- `pytest tests/`: **1325 passed**
- `python -m autoptz --selftest`: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)