### PR TITLE
fix(install): deterministic accelerator auto-select (fixes ubuntu CI red)

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from tools.install import SystemInfo, _auto_accelerator, _resolve_accelerator, plan_install
@@ -208,29 +206,23 @@ def test_linux_pci_8086_matches_intel_gpu() -> None:
 
 
 def test_linux_intel_cpu_only_auto_uses_openvino() -> None:
-    """Intel CPU with no GPU listed → OpenVINO via /proc/cpuinfo probe."""
-    system = SystemInfo("Linux", "x86_64", ())  # no GPU name detected
-
-    with patch(
-        "tools.install._run_command_lines",
-        return_value=("model name : Intel(R) Core(TM) i7-1165G7 @ 2.80GHz",),
-    ):
-        result = _auto_accelerator(system)
-
-    assert result == "openvino"
+    """Intel CPU with no GPU listed → OpenVINO (from SystemInfo.cpu_brand)."""
+    system = SystemInfo("Linux", "x86_64", (), "Intel(R) Core(TM) i7-1165G7 @ 2.80GHz")
+    assert _auto_accelerator(system) == "openvino"
 
 
 def test_linux_amd_cpu_no_gpu_falls_through_to_none() -> None:
     """AMD/unknown CPU with no GPU → None (base CPU EP)."""
-    system = SystemInfo("Linux", "x86_64", ())
+    system = SystemInfo("Linux", "x86_64", (), "AMD Ryzen 9 5950X")
+    assert _auto_accelerator(system) is None
 
-    with patch(
-        "tools.install._run_command_lines",
-        return_value=("model name : AMD Ryzen 9 5950X",),
-    ):
-        result = _auto_accelerator(system)
 
-    assert result is None
+def test_plan_install_is_deterministic_without_cpu_probe() -> None:
+    """plan_install must not re-probe the host: no cpu_brand → no openvino, on any OS."""
+    system = SystemInfo("Linux", "x86_64", ())  # nothing detected
+    assert _auto_accelerator(system) is None
+    plan = plan_install(system, full=True)
+    assert plan.profiles == ("base", "tracking", "export")
 
 
 def test_linux_nvidia_beats_intel_when_both_present() -> None:

--- a/tools/install.py
+++ b/tools/install.py
@@ -38,6 +38,7 @@ class SystemInfo:
     os_name: str
     machine: str
     gpu_names: tuple[str, ...] = ()
+    cpu_brand: str = ""
 
     @property
     def is_macos(self) -> bool:
@@ -67,6 +68,11 @@ class SystemInfo:
         """
         _INTEL_TOKENS = ("intel", "arc", "iris", "uhd", "8086")
         return any(any(tok in name.lower() for tok in _INTEL_TOKENS) for name in self.gpu_names)
+
+    @property
+    def has_intel_cpu(self) -> bool:
+        """True when the detected CPU brand string is Intel."""
+        return "intel" in self.cpu_brand.lower()
 
     @property
     def has_discrete_non_intel_gpu(self) -> bool:
@@ -184,13 +190,29 @@ def _detect_gpu_names(os_name: str) -> tuple[str, ...]:
     return _dedupe(names)
 
 
+def _detect_cpu_brand(os_name: str) -> str:
+    """Best-effort CPU brand string (for Intel-CPU accelerator selection)."""
+    if os_name == "Linux":
+        for line in _run_command_lines(("grep", "-m1", "model name", "/proc/cpuinfo")):
+            return line.split(":", 1)[1].strip() if ":" in line else line
+        return ""
+    if os_name == "Darwin":
+        out = _run_command_lines(("sysctl", "-n", "machdep.cpu.brand_string"))
+        return out[0] if out else ""
+    if os_name == "Windows":
+        # platform.processor() returns the brand on Windows (e.g. "Intel64 Family ...").
+        return platform.processor() or ""
+    return ""
+
+
 def detect_system() -> SystemInfo:
-    """Inspect OS, architecture, and best-effort GPU names for install planning."""
+    """Inspect OS, architecture, and best-effort GPU/CPU names for install planning."""
     os_name = platform.system()
     return SystemInfo(
         os_name=os_name,
         machine=platform.machine(),
         gpu_names=_detect_gpu_names(os_name),
+        cpu_brand=_detect_cpu_brand(os_name),
     )
 
 
@@ -218,10 +240,10 @@ def _auto_accelerator(system: SystemInfo) -> Accelerator | None:
         return "openvino"
     # Linux Intel CPU with no discrete GPU → OpenVINO beats the stock CPU EP.
     # (Windows CPU-only boxes already get DirectML below, which is the existing behaviour.)
-    if system.is_linux and not system.has_discrete_non_intel_gpu:
-        cpu_info = _run_command_lines(("grep", "-m1", "model name", "/proc/cpuinfo"))
-        if any("intel" in line.lower() for line in cpu_info):
-            return "openvino"
+    # Reads the CPU brand captured in SystemInfo (probed once at detect_system) so
+    # plan_install stays deterministic from its inputs instead of re-probing the host.
+    if system.is_linux and not system.has_discrete_non_intel_gpu and system.has_intel_cpu:
+        return "openvino"
     if system.is_windows:
         return "directml"
     return None


### PR DESCRIPTION
## Problem
`test_install.py::test_full_install_adds_both_extras` fails on **ubuntu CI only** (green on macOS) and has been red on `main` since #119. Root cause: `_auto_accelerator()` shelled out to the live host `/proc/cpuinfo` to detect an Intel CPU, so `plan_install()` was not deterministic from its `SystemInfo` input. On Intel Linux runners it appended an `openvino` profile the macOS runners never produced.

## Fix
Probe the CPU brand once in `detect_system()` → `SystemInfo.cpu_brand`; `_auto_accelerator()` reads `system.has_intel_cpu`. The planner is now a pure function of `SystemInfo`. Real-world selection is unchanged (same brand string → same result). Affected tests set `cpu_brand` instead of patching the probe; added a determinism regression test.

All 1337 tests pass; ruff + mypy + format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)