### PR TITLE
fix(ui): identify USB cameras by unique_id (fixes wrong-camera delete/disable)

### DIFF
--- a/autoptz/ui/widgets/main_window.py
+++ b/autoptz/ui/widgets/main_window.py
@@ -684,17 +684,22 @@ class MainWindow(QMainWindow):
 
     def _find_camera(self, uri: str, unique_id: str) -> str | None:
         model = self._client.cameraModel
+        cameras: list[tuple[str, str, str, str]] = []
         for cid in _safe(lambda: model.camera_ids(), []) or []:
             rec = model.get_record(cid)
             cfg = getattr(rec, "camera_config", None)
             src = getattr(cfg, "source", None)
             if src is None:
                 continue
-            if unique_id and getattr(src, "unique_id", None) == unique_id:
-                return cid
-            if getattr(src, "address", None) == uri:
-                return cid
-        return None
+            cameras.append(
+                (
+                    cid,
+                    str(getattr(src, "type", "") or ""),
+                    str(getattr(src, "unique_id", "") or ""),
+                    str(getattr(src, "address", "") or ""),
+                )
+            )
+        return _match_camera_id(cameras, uri, unique_id)
 
     def _run_scan(self, label: str, work: Any, on_done: Any) -> None:
         """Run a blocking discovery ``work()`` off the GUI thread with a busy dialog.
@@ -1365,3 +1370,40 @@ def _safe(fn: Any, default: Any) -> Any:
         return fn()
     except Exception:  # noqa: BLE001
         return default
+
+
+def _match_camera_id(
+    cameras: list[tuple[str, str, str, str]],
+    uri: str,
+    unique_id: str,
+) -> str | None:
+    """Resolve a scanned device → the matching camera id, or None.
+
+    ``cameras`` is ``(camera_id, source_type, source_unique_id, source_address)``.
+
+    USB cameras are identified **only by their stable ``unique_id``**: the
+    ``usb://<index>`` address is volatile (it shifts when a device is replugged or
+    another camera is added), so matching USB by address could resolve to — and
+    then disable/delete — the *wrong* camera after enumeration changes (the
+    reported bug).  As a last resort, an id-less USB device matches another id-less
+    USB camera at the same address, but never one that carries a different known id.
+
+    Network sources (rtsp/onvif/ndi) keep address matching — their address (URL /
+    NDI name) *is* their stable identity.
+    """
+    # unique_id match first (works for any source type).
+    if unique_id:
+        for cid, _stype, suid, _addr in cameras:
+            if suid and suid == unique_id:
+                return cid
+    # Address fallback, scoped by source type.
+    for cid, stype, suid, addr in cameras:
+        if addr != uri:
+            continue
+        if stype == "usb":
+            # Only when BOTH sides lack a stable id (never override a known id).
+            if not unique_id and not suid:
+                return cid
+        else:
+            return cid
+    return None

--- a/tests/test_camera_identity.py
+++ b/tests/test_camera_identity.py
@@ -1,0 +1,59 @@
+"""Tests for USB/network camera identity matching (the wrong-camera bug).
+
+USB cameras must be matched by stable unique_id, never by the volatile
+usb://<index> address — otherwise toggling/deleting one camera after the USB
+enumeration order shifts could hit the wrong camera.
+"""
+
+from __future__ import annotations
+
+from autoptz.ui.widgets.main_window import _match_camera_id
+
+
+def test_usb_matches_by_unique_id_not_address() -> None:
+    # Two USB cameras whose addresses have SHIFTED so cam B now sits at usb://0
+    # (the address cam A was originally added under).
+    cameras = [
+        ("camA", "usb", "uid-A", "usb://1"),
+        ("camB", "usb", "uid-B", "usb://0"),
+    ]
+    # Removing cam A (its real unique_id) must resolve to camA, never camB,
+    # even though camB's address now collides with cam A's old usb://0 uri.
+    assert _match_camera_id(cameras, "usb://0", "uid-A") == "camA"
+
+
+def test_usb_does_not_fall_back_to_address_when_id_known_elsewhere() -> None:
+    # A scanned device with no unique_id must NOT match a USB camera that has a
+    # *different* known id at that address (the wrong-camera-delete scenario).
+    cameras = [("camB", "usb", "uid-B", "usb://0")]
+    assert _match_camera_id(cameras, "usb://0", "") is None
+
+
+def test_usb_idless_matches_idless_at_same_uri() -> None:
+    # When the device genuinely has no unique_id, an id-less USB camera at the
+    # same uri is a safe match (no ambiguity with id-bearing cameras).
+    cameras = [("camX", "usb", "", "usb://2")]
+    assert _match_camera_id(cameras, "usb://2", "") == "camX"
+
+
+def test_network_matches_by_address() -> None:
+    cameras = [
+        ("ndi1", "ndi", "", "ndi://STUDIO (CAM 1)"),
+        ("rtsp1", "rtsp", "", "rtsp://10.0.0.5/stream"),
+    ]
+    assert _match_camera_id(cameras, "ndi://STUDIO (CAM 1)", "") == "ndi1"
+    assert _match_camera_id(cameras, "rtsp://10.0.0.5/stream", "") == "rtsp1"
+
+
+def test_no_match_returns_none() -> None:
+    cameras = [("camA", "usb", "uid-A", "usb://0")]
+    assert _match_camera_id(cameras, "usb://9", "uid-Z") is None
+
+
+def test_unique_id_wins_over_address_collision() -> None:
+    # unique_id match takes priority even if another camera shares the address.
+    cameras = [
+        ("camA", "usb", "uid-A", "usb://0"),
+        ("camB", "usb", "uid-B", "usb://0"),  # stale collision
+    ]
+    assert _match_camera_id(cameras, "usb://0", "uid-B") == "camB"


### PR DESCRIPTION
## Problem
User report: enabling/disabling or deleting a USB camera "occasionally deletes the wrong camera." `_find_camera()` matched on `source.address`, but a USB camera's address is `usb://<enumeration-index>` — volatile across replug / adding another camera. After the index shifts, the stale URI resolves to a *different* physical camera, so remove/disable hits the wrong one.

## Fix
Extracted a pure, tested `_match_camera_id()`:
- **USB** → matched **only by stable `unique_id`**. The index URI is a last resort used solely between two id-less USB entries, never overriding a camera that carries a known id.
- **Network (rtsp/onvif/ndi)** → keep address matching (URL/NDI name is the stable identity).

All four `_find_camera` callers (USB/NDI checkmarks + toggles) remain correct.

`tests/test_camera_identity.py` (6 tests) covers the shift-collision and id-less scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)