### PR TITLE
fix(center-stage): zoom in on far subjects (per-framing min crop floor)

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -97,11 +97,17 @@ def _push_due(now: float, last: float, min_period: float) -> bool:
 # space above the head, while a full-body shot wants more margin so the subject
 # isn't jammed against the top. Closer shots → less headroom, wider shots → more.
 # The old fixed 0.10 is kept for ``upper_body`` as the midpoint.
-_CENTERSTAGE_FRAMING: dict[str, tuple[float, float, float]] = {
-    "face": (0.86, 0.50, 0.06),  # tight head/face closeup (~2.0x), minimal headroom
-    "head_shoulders": (0.80, 0.62, 0.08),  # head + shoulders (~1.6x)
-    "upper_body": (0.70, 0.74, 0.10),  # head + chest (~1.35x) — default midpoint
-    "full_body": (0.58, 0.94, 0.14),  # whole person, more margin above the head
+# (subject fill of crop, MIN crop frac, MAX crop frac, headroom). ``min_frac`` is
+# the tight-zoom floor: it must be small for closer framings or a FAR subject can
+# never be zoomed in (the crop floors out and the subject stays a speck). Tighter
+# framings allow a tighter crop; full_body stays conservative so a whole-person
+# shot doesn't over-zoom. True specks are already dropped upstream by
+# ``tracking.min_detection_size_frac``, so a low floor here is safe.
+_CENTERSTAGE_FRAMING: dict[str, tuple[float, float, float, float]] = {
+    "face": (0.86, 0.12, 0.50, 0.06),  # tight head/face closeup, zooms in on far faces
+    "head_shoulders": (0.80, 0.16, 0.62, 0.08),  # head + shoulders
+    "upper_body": (0.70, 0.22, 0.74, 0.10),  # head + chest — default midpoint
+    "full_body": (0.58, 0.34, 0.94, 0.14),  # whole person, conservative min zoom
 }
 
 _DEFAULT_TELEMETRY_HZ = 10.0
@@ -3503,7 +3509,7 @@ class CameraWorker:
         # Crop tightness AND shot-size-aware headroom follow the live "Framing"
         # dropdown (set live so a preset change re-composes without a restart).
         framing = getattr(self.config.tracking, "framing", "upper_body")
-        framer.fill, framer.max_frac, framer.headroom = _CENTERSTAGE_FRAMING.get(
+        framer.fill, framer.min_frac, framer.max_frac, framer.headroom = _CENTERSTAGE_FRAMING.get(
             framing, _CENTERSTAGE_FRAMING["upper_body"]
         )
         # Subtle digital lead-room ("nose room"): bias the crop toward the

--- a/tests/test_digital_framer.py
+++ b/tests/test_digital_framer.py
@@ -51,6 +51,30 @@ class TestDesiredCrop:
         )
         assert h >= 0.34 * 1080 - 1
 
+    def test_far_subject_zooms_tighter_with_lower_min_frac(self):
+        # The far-subject under-zoom fix: a person far from the camera (small in
+        # frame) must zoom in MORE when the framing allows a lower min_frac. With a
+        # tight-framing floor the crop is much smaller (subject appears larger).
+        far = (910, 500, 1010, 680)  # ~100x180 person, far in a 1080 frame
+        _, _, _, h_loose = desired_crop(
+            far, 1920, 1080, out_aspect=ASPECT, fill=0.70, min_frac=0.34, max_frac=0.78
+        )
+        _, _, _, h_tight = desired_crop(
+            far, 1920, 1080, out_aspect=ASPECT, fill=0.70, min_frac=0.16, max_frac=0.78
+        )
+        assert h_tight < h_loose  # lower floor → tighter crop → subject larger
+
+    def test_centerstage_framing_min_frac_ordering(self):
+        # Tighter framings must permit a tighter min crop than looser ones, else a
+        # far subject can't be zoomed in for closeups.
+        from autoptz.engine.camera_worker import _CENTERSTAGE_FRAMING
+
+        for key, vals in _CENTERSTAGE_FRAMING.items():
+            assert len(vals) == 4, f"{key} tuple must be (fill, min_frac, max_frac, headroom)"
+        face_min = _CENTERSTAGE_FRAMING["face"][1]
+        full_min = _CENTERSTAGE_FRAMING["full_body"][1]
+        assert face_min < full_min
+
 
 class TestDigitalFramer:
     def test_smoothing_converges_toward_target(self):


### PR DESCRIPTION
## Problem
In Center Stage, a subject far from the camera wasn't cropped tightly enough — they stayed small in the frame. The crop's minimum size (`min_frac`) was a fixed 0.34 of the frame for **all** framings, so a far person's natural tight crop (`subject_height / fill`) got floored back out.

## Fix
`min_frac` is now per-framing in `_CENTERSTAGE_FRAMING`: face 0.12 · head_shoulders 0.16 · upper_body 0.22 · full_body 0.34. Closer framings allow a tighter zoom so a far face / upper-body actually fills the crop; `full_body` stays conservative. True specks are still dropped upstream by `tracking.min_detection_size_frac`, so a low floor is safe.

Tests added for far-subject zoom + the framing-floor ordering.

**Follow-up (separate PR):** overlay detection/track boxes aren't yet transformed into the cropped preview's coordinate space (bug #2 from the report) — needs a telemetry crop-rect field + UI transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)