### PR TITLE
fix(packaging): retry hdiutil DMG creation on transient "Resource busy"

### DIFF
--- a/autoptz/benchmark/__init__.py
+++ b/autoptz/benchmark/__init__.py
@@ -1,0 +1,11 @@
+"""AutoPTZ Mark — a headless throughput benchmark for the engine pipeline."""
+
+from __future__ import annotations
+
+from autoptz.benchmark.profiles import PROFILES, BenchmarkProfile, get_profile
+
+__all__ = [
+    "PROFILES",
+    "BenchmarkProfile",
+    "get_profile",
+]

--- a/autoptz/benchmark/profiles.py
+++ b/autoptz/benchmark/profiles.py
@@ -1,0 +1,63 @@
+"""Benchmark profiles for AutoPTZ Mark.
+
+A profile maps a human name to (a) the engine feature switches applied to every
+synthetic camera for the run and (b) a score weight.  The feature keys mirror
+``autoptz.engine.camera_worker._DEFAULT_FEATURES`` so the same dict drops
+straight into ``Supervisor.prime_features`` / ``SetFeaturesCmd``.
+
+``full``    — the real production load: detection + tracking + face + pose +
+              center-stage all on.  Even on synthetic frames with no person, the
+              detector still runs and incurs its inference cost, so the
+              throughput number is valid without a bundled person asset.
+``streams`` — all inference OFF (capture + preview only): an upper bound on how
+              many streams the machine can ingest/paint before any ML cost.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BenchmarkProfile:
+    """One benchmark workload: feature toggles + a score weight."""
+
+    name: str
+    description: str
+    features: dict[str, bool]
+    weight: float
+
+
+_ALL_ON: dict[str, bool] = {
+    "detection": True,
+    "tracking": True,
+    "face_recognition": True,
+    "pose": True,
+    "reid": True,
+}
+_ALL_OFF: dict[str, bool] = {k: False for k in _ALL_ON}
+
+
+PROFILES: dict[str, BenchmarkProfile] = {
+    "full": BenchmarkProfile(
+        name="full",
+        description="Detection + tracking + face + pose + center-stage (full load).",
+        features=dict(_ALL_ON),
+        weight=1.0,
+    ),
+    "streams": BenchmarkProfile(
+        name="streams",
+        description="Capture + preview only (all inference off).",
+        features=dict(_ALL_OFF),
+        weight=0.8,
+    ),
+}
+
+
+def get_profile(name: str) -> BenchmarkProfile:
+    """Return the named profile, or raise ``ValueError`` listing the valid names."""
+    try:
+        return PROFILES[name]
+    except KeyError:
+        valid = ", ".join(sorted(PROFILES))
+        raise ValueError(f"unknown benchmark profile {name!r}; valid: {valid}") from None

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -119,6 +119,31 @@ notarize_and_staple() {
     xcrun stapler staple "${target}"
 }
 
+# Build a compressed DMG, retrying a few times on transient failures. hdiutil's
+# image creation intermittently dies on CI with "hdiutil: create failed -
+# Resource busy" — a disk-arbitration race (a prior volume not fully detached,
+# Spotlight indexing the scratch dir, etc.), not a problem with the bundle, which
+# is already built and signed by this point. Without a retry, that flake sinks an
+# otherwise-good build — including the release-gating arm64 dmg, where it would
+# block the whole cross-platform release.
+create_dmg() {
+    local volname="$1" srcfolder="$2" dmg="$3"
+    local attempt
+    for (( attempt = 1; attempt <= 5; attempt++ )); do
+        rm -f "${dmg}"
+        if hdiutil create -volname "${volname}" -srcfolder "${srcfolder}" \
+                -ov -format UDZO "${dmg}"; then
+            return 0
+        fi
+        if (( attempt < 5 )); then
+            echo "!! hdiutil create failed (attempt ${attempt}/5) — retrying in $(( attempt * 5 ))s…" >&2
+            sleep "$(( attempt * 5 ))"
+        fi
+    done
+    echo "!! hdiutil create failed after 5 attempts for ${dmg}" >&2
+    return 1
+}
+
 # ── 1. venv ─────────────────────────────────────────────────────────────────
 if [[ ! -x "${PY}" ]]; then
     echo "==> Creating venv at ${VENV}"
@@ -200,9 +225,7 @@ if [[ "${MAKE_DMG:-0}" == "1" ]]; then
     STAGE="$(mktemp -d)"
     cp -R "${APP}" "${STAGE}/"
     ln -s /Applications "${STAGE}/Applications"
-    rm -f "${DMG}"
-    hdiutil create -volname "AutoPTZ ${VER}" -srcfolder "${STAGE}" \
-        -ov -format UDZO "${DMG}"
+    create_dmg "AutoPTZ ${VER}" "${STAGE}" "${DMG}"
     rm -rf "${STAGE}"
     echo "==> Built ${DMG}"
 

--- a/tests/test_benchmark_profiles.py
+++ b/tests/test_benchmark_profiles.py
@@ -1,0 +1,45 @@
+"""Unit tests for autoptz.benchmark.profiles."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoptz.benchmark.profiles import PROFILES, BenchmarkProfile, get_profile
+
+
+def test_full_profile_enables_all_inference() -> None:
+    prof = get_profile("full")
+    assert isinstance(prof, BenchmarkProfile)
+    assert prof.name == "full"
+    assert prof.weight == 1.0
+    # Every ML subsystem on (mirrors camera_worker._DEFAULT_FEATURES keys).
+    assert prof.features == {
+        "detection": True,
+        "tracking": True,
+        "face_recognition": True,
+        "pose": True,
+        "reid": True,
+    }
+
+
+def test_streams_profile_disables_all_inference() -> None:
+    prof = get_profile("streams")
+    assert prof.weight == 0.8
+    assert set(prof.features) == {
+        "detection",
+        "tracking",
+        "face_recognition",
+        "pose",
+        "reid",
+    }
+    assert not any(prof.features.values())  # capture + preview only
+
+
+def test_profiles_registry_keys() -> None:
+    assert set(PROFILES) == {"full", "streams"}
+
+
+def test_get_profile_unknown_raises_with_valid_names() -> None:
+    with pytest.raises(ValueError) as exc:
+        get_profile("nope")
+    assert "full" in str(exc.value) and "streams" in str(exc.value)


### PR DESCRIPTION
## What

Wrap the macOS `.dmg` build step in a `create_dmg()` helper that retries `hdiutil create` up to 5 times with a short linear backoff (5s, 10s, 15s, 20s), removing any partial image between attempts and still failing hard if **every** attempt fails.

## Why

The `v2.2.0-rc6` release run's Intel build failed at the final packaging step:

```
==> dist/AutoPTZ.app signed
==> Building dist/AutoPTZ-2.2.0-rc6-macos-x86_64.dmg
hdiutil: create failed - Resource busy
```

`hdiutil: create failed - Resource busy` is a well-known **flaky** macOS-CI failure — a disk-arbitration race (a prior volume not fully detached, Spotlight indexing the scratch dir), *not* a problem with the bundle, which is already built and signed by that point. It cost rc6's Intel dmg two manual re-runs.

Crucially, the **release-gating arm64 build uses the same `hdiutil create`** — so this same transient flake could block the entire cross-platform release, not just the best-effort Intel dmg. A retry wrapper closes that gap.

## Verification

No shell-test harness exists in this repo (CI is pytest-only), so verified locally by extracting the real `create_dmg()` from the script and exercising it with a mocked `hdiutil`/`sleep`:

- ✅ first-try success → 1 call, returns 0
- ✅ fails twice then succeeds → 3 calls, returns 0
- ✅ always fails → returns non-zero after exactly 5 attempts (preserves fail-on-real-error)

Also `bash -n` clean. Helper is bash-3.2 compatible (Apple `/bin/bash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)