### PR TITLE
feat(supervisor): auto-restart hung workers + permanent-failed state + stall observability

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -4918,6 +4918,17 @@ class CameraWorker:
             and (now - self._last_infer_t) > _INFER_STALL_S
         )
 
+    def _inference_stall_age(self, now: float) -> float:
+        """Seconds since the last inference tick while tracking is active.
+
+        Returns 0.0 when not applicable (no inferred frames yet, or tracking
+        disabled) and is clamped to >= 0.0 against clock skew.  Pure, side-effect
+        free; safe to call from the capture thread.
+        """
+        if self._frames_inferred <= 0 or not self._tracking_enabled:
+            return 0.0
+        return max(0.0, now - self._last_infer_t)
+
     def _apply_inference_watchdog(self, now: float) -> None:
         """Watchdog action — called once per telemetry tick from the capture thread.
 
@@ -4989,7 +5000,11 @@ class CameraWorker:
             pose=self._pose_overlay(),
             ptz=self._ptz_state(),
             tracking_status=self._tracking_status_info(tracks, time.monotonic()),
-            health=HealthInfo(state=health, last_error=last_error),
+            health=HealthInfo(
+                state=health,
+                last_error=last_error,
+                inference_stall_age_s=self._inference_stall_age(time.monotonic()),
+            ),
         )
         self._seq += 1
         try:

--- a/autoptz/engine/runtime/messages.py
+++ b/autoptz/engine/runtime/messages.py
@@ -97,6 +97,10 @@ class HealthState(str, Enum):
 class HealthInfo(BaseModel):
     state: HealthState = HealthState.OK
     last_error: str | None = None
+    # Observability: seconds since the last completed inference tick while
+    # tracking is active (0.0 when not applicable).  Additive — older UIs ignore
+    # it; diagnostics surface it next to the inference-stall watchdog state.
+    inference_stall_age_s: float = 0.0
 
 
 class RuntimeServiceInfo(BaseModel):

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -71,6 +71,16 @@ _HEALTH_SCAN_INTERVAL_S = 2.0  # how often tick() runs the health scan
 _BASE_BACKOFF_S = 1.0  # initial restart back-off
 _MAX_BACKOFF_S = 30.0  # maximum restart back-off (exponential cap)
 _MAX_RESTART_ATTEMPTS = 5  # give up after this many consecutive failures
+# A worker can be ALIVE yet HUNG (capture/inference threads stuck, no telemetry).
+# Treat it as unhealthy and respawn it through the same backoff path once its
+# telemetry is older than this.  Deliberately above the 2.0 s inference-stall
+# threshold so a transient stall (which the worker itself recovers from) does not
+# trigger a process-level restart.
+_WORKER_HANG_S = 5.0
+# Grace window after (re)spawn during which hang detection is suppressed: a fresh
+# worker is opening the camera + building models and legitimately emits no
+# telemetry for a few seconds.  Must exceed worst-case warmup-before-first-frame.
+_WORKER_WARMUP_GRACE_S = 8.0
 
 
 def _log_macos_capture_path() -> None:
@@ -471,6 +481,22 @@ class Supervisor:
 
     # ── worker health monitoring ─────────────────────────────────────────────────
 
+    def _worker_hung(self, cid: str, now: float) -> bool:
+        """True iff an alive worker has gone silent past the warmup grace window.
+
+        Pure predicate (no side effects).  A worker spawned less than
+        ``_WORKER_WARMUP_GRACE_S`` ago is never hung (it is still opening the
+        camera / building models).  Past warmup, the worker is hung iff its most
+        recent telemetry is older than ``_WORKER_HANG_S`` — and a worker that has
+        never reported telemetry at all is anchored to its spawn time, so a
+        worker that never starts streaming is eventually flagged.
+        """
+        spawn_t = self._spawn_t.get(cid)
+        if spawn_t is None or (now - spawn_t) < _WORKER_WARMUP_GRACE_S:
+            return False
+        last_seen = self._last_telemetry_t.get(cid, spawn_t)
+        return (now - last_seen) > _WORKER_HANG_S
+
     def _scan_worker_health(self, now: float) -> None:
         """Check every worker's liveness and restart any that have died.
 
@@ -491,12 +517,19 @@ class Supervisor:
             except Exception:  # noqa: BLE001
                 log.debug("camera_id=%s is_alive() raised", cid, exc_info=True)
 
-            if alive:
+            hung = alive and self._worker_hung(cid, now)
+            if alive and not hung:
                 # Worker is healthy — clear any stale restart state.
                 self._restart_state.pop(cid, None)
                 continue
+            if hung:
+                log.warning(
+                    "camera_id=%s alive but telemetry stale (>%.1fs) — treating as hung",
+                    cid,
+                    _WORKER_HANG_S,
+                )
 
-            # Worker appears dead.  Check back-off state.
+            # Worker appears dead (or hung).  Check back-off state.
             attempts, next_allowed_t = self._restart_state.get(cid, (0, 0.0))
 
             if attempts >= _MAX_RESTART_ATTEMPTS:

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -33,6 +33,7 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from autoptz.engine.camera_worker import _PREVIEW_H, _PREVIEW_W, CameraWorker
@@ -951,7 +952,7 @@ class Supervisor:
             camera_count,
         )
 
-    def _make_telemetry_callback(self, camera_id: str) -> Any:
+    def _make_telemetry_callback(self, camera_id: str) -> Callable[[Any], None]:
         """Wrap push_telemetry so the supervisor records a per-camera last-seen time.
 
         The wrapper stamps a monotonic timestamp into ``_last_telemetry_t`` on
@@ -1021,6 +1022,7 @@ class Supervisor:
                 return
             self._workers[camera_id] = worker
             self._spawn_t[camera_id] = time.monotonic()
+            self._last_telemetry_t.pop(camera_id, None)
             worker_count = len(self._workers)
         log.info(
             "spawned worker camera_id=%s name=%s (workers=%d)",

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -163,9 +163,10 @@ class Supervisor:
         self._last_pump_warn_t = 0.0
 
         # ── worker health monitoring + auto-restart ──────────────────────────────
-        # Per-camera backoff state: cid → (attempts, next_allowed_t).
-        # Cleared when a worker is healthy again or the camera is removed.
-        self._restart_state: dict[str, tuple[int, float]] = {}
+        # Per-camera restart state: cid → (attempts, next_allowed_t, failed).
+        # ``failed`` latches True when attempts hit _MAX_RESTART_ATTEMPTS so the
+        # UI can show a permanent-failure badge.  Cleared on recovery or removal.
+        self._restart_state: dict[str, tuple[int, float, bool]] = {}
         # Monotonic timestamp of the last health scan (throttled to
         # _HEALTH_SCAN_INTERVAL_S so tick() doesn't scan every 50 ms).
         self._last_health_scan_t: float = 0.0
@@ -530,12 +531,12 @@ class Supervisor:
                 )
 
             # Worker appears dead (or hung).  Check back-off state.
-            attempts, next_allowed_t = self._restart_state.get(cid, (0, 0.0))
+            attempts, next_allowed_t, _failed = self._restart_state.get(cid, (0, 0.0, False))
 
             if attempts >= _MAX_RESTART_ATTEMPTS:
-                # Already gave up — log once (when attempts first hits the cap
-                # the counter was bumped; subsequent scans see == cap, skip).
-                # The "log once" is enforced by the sentinel value stored below.
+                # Already gave up — the permanent-failure ERROR was logged once
+                # when attempts first hit the cap (see the cap branch below); the
+                # latched ``failed`` flag keeps subsequent scans silent.
                 continue
 
             if now < next_allowed_t:
@@ -568,16 +569,23 @@ class Supervisor:
 
             new_attempts = attempts + 1
             backoff = min(_MAX_BACKOFF_S, _BASE_BACKOFF_S * (2 ** (new_attempts - 1)))
-            self._restart_state[cid] = (new_attempts, now + backoff)
 
             if new_attempts >= _MAX_RESTART_ATTEMPTS:
-                log.warning(
-                    "camera_id=%s worker failed %d times — giving up on auto-restart",
+                # Latch the permanent-failure flag so is_camera_failed()/the UI can
+                # surface it, and log a single clear ERROR (future scans hit the
+                # "already gave up" guard above and stay silent).
+                self._restart_state[cid] = (new_attempts, now + backoff, True)
+                log.error(
+                    "camera_id=%s permanently failed: %d auto-restart attempts "
+                    "exhausted — giving up (camera will not be relaunched until "
+                    "removed/re-added)",
                     cid,
                     new_attempts,
                 )
                 # Don't respawn; keep the sentinel so future scans skip this camera.
                 continue
+
+            self._restart_state[cid] = (new_attempts, now + backoff, False)
 
             try:
                 self._spawn_worker(cid)
@@ -1084,6 +1092,15 @@ class Supervisor:
             return None
         with self._lock:
             return self._workers.get(camera_id)
+
+    def is_camera_failed(self, camera_id: str) -> bool:
+        """True iff auto-restart has permanently given up on this camera."""
+        state = self._restart_state.get(camera_id)
+        return bool(state is not None and state[2])
+
+    def failed_cameras(self) -> list[str]:
+        """Camera ids that auto-restart has permanently given up on."""
+        return [cid for cid, st in self._restart_state.items() if st[2]]
 
     def _default_worker_factory(
         self,

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -159,6 +159,13 @@ class Supervisor:
         # Monotonic timestamp of the last health scan (throttled to
         # _HEALTH_SCAN_INTERVAL_S so tick() doesn't scan every 50 ms).
         self._last_health_scan_t: float = 0.0
+        # Per-camera monotonic timestamp of the most recent telemetry message,
+        # stamped by the wrapped on_telemetry callback (_make_telemetry_callback).
+        # Used by the health scan to detect a HUNG worker (alive but silent).
+        self._last_telemetry_t: dict[str, float] = {}
+        # Per-camera monotonic spawn timestamp, used to grant a warmup grace
+        # window before hang detection arms (model build emits no telemetry).
+        self._spawn_t: dict[str, float] = {}
 
     # ── lifecycle ───────────────────────────────────────────────────────────────
 
@@ -241,6 +248,9 @@ class Supervisor:
 
             workers = list(self._workers.items())
             self._workers.clear()
+            self._restart_state.clear()
+            self._last_telemetry_t.clear()
+            self._spawn_t.clear()
 
         # Join the pump outside the lock (it may call tick→lock).
         if pump is not None and pump is not threading.current_thread():
@@ -589,6 +599,8 @@ class Supervisor:
             worker = self._workers.pop(cid, None)
         # Clear any pending restart state so a removed camera isn't resurrected.
         self._restart_state.pop(cid, None)
+        self._last_telemetry_t.pop(cid, None)
+        self._spawn_t.pop(cid, None)
         if worker is not None:
             try:
                 worker.stop()
@@ -898,6 +910,22 @@ class Supervisor:
             camera_count,
         )
 
+    def _make_telemetry_callback(self, camera_id: str) -> Any:
+        """Wrap push_telemetry so the supervisor records a per-camera last-seen time.
+
+        The wrapper stamps a monotonic timestamp into ``_last_telemetry_t`` on
+        every message, then forwards to the UI-facing ``push_telemetry`` unchanged.
+        This keeps the 3-arg worker_factory contract and ``push_telemetry`` itself
+        untouched while giving the health scan a hang signal for BOTH worker types.
+        """
+        push = self._client.push_telemetry
+
+        def _cb(msg: Any) -> None:
+            self._last_telemetry_t[camera_id] = time.monotonic()
+            push(msg)
+
+        return _cb
+
     def _make_worker(self, camera_id: str, config: CameraConfig) -> Any:
         """Build a camera worker — a thread-based one, or (opt-in) a child process.
 
@@ -905,7 +933,7 @@ class Supervisor:
         AND no test/custom worker factory was injected, so the default and all
         tests keep the in-process threaded worker.
         """
-        on_telemetry = self._client.push_telemetry
+        on_telemetry = self._make_telemetry_callback(camera_id)
         from autoptz.engine.process_worker import (
             ProcessWorkerHandle,
             process_per_camera_enabled,
@@ -951,6 +979,7 @@ class Supervisor:
             if not self._running or camera_id in self._workers:
                 return
             self._workers[camera_id] = worker
+            self._spawn_t[camera_id] = time.monotonic()
             worker_count = len(self._workers)
         log.info(
             "spawned worker camera_id=%s name=%s (workers=%d)",

--- a/tests/test_inference_watchdog.py
+++ b/tests/test_inference_watchdog.py
@@ -147,6 +147,48 @@ class TestInferenceStalled:
         assert w._inference_stalled(now=now) is False
 
 
+class TestInferenceStallAge:
+    def _worker(self, **kw: Any):
+        return _make_worker(**kw)
+
+    def test_zero_when_no_inferred_frames(self) -> None:
+        w = self._worker()
+        w._frames_inferred = 0
+        w._last_infer_t = 0.0
+        assert w._inference_stall_age(now=100.0) == 0.0
+
+    def test_zero_when_tracking_disabled(self) -> None:
+        w = self._worker(tracking_on=False)
+        w._frames_inferred = 10
+        w._last_infer_t = 0.0
+        assert w._inference_stall_age(now=100.0) == 0.0
+
+    def test_reports_age_when_running(self) -> None:
+        w = self._worker()
+        w._frames_inferred = 5
+        w._last_infer_t = 90.0
+        assert abs(w._inference_stall_age(now=100.0) - 10.0) < 1e-6
+
+    def test_never_negative(self) -> None:
+        w = self._worker()
+        w._frames_inferred = 5
+        w._last_infer_t = 105.0  # clock skew / future heartbeat
+        assert w._inference_stall_age(now=100.0) == 0.0
+
+
+def test_healthinfo_field_defaults_and_round_trips() -> None:
+    from autoptz.engine.runtime.messages import HealthInfo, TelemetryMsg
+
+    assert HealthInfo().inference_stall_age_s == 0.0
+    msg = TelemetryMsg(
+        camera_id="c1",
+        seq=0,
+        health=HealthInfo(inference_stall_age_s=3.5),
+    )
+    restored = TelemetryMsg.from_msgpack(msg.to_msgpack())
+    assert restored.health.inference_stall_age_s == 3.5
+
+
 # ── _apply_inference_watchdog action tests ────────────────────────────────────
 
 

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -127,6 +127,46 @@ class TestHandleProxy:
         assert h.shm_name == f"cam_{cid[:8]}_preview"
 
 
+class TestHandleIsAlive:
+    """is_alive() must mirror the child process's liveness for the health scan."""
+
+    def _handle(self) -> ProcessWorkerHandle:
+        cid = "proc-" + uuid.uuid4().hex[:8]
+        return ProcessWorkerHandle(cid, _config(cid), on_telemetry=lambda _m: None, db_path="")
+
+    def test_false_before_start(self) -> None:
+        h = self._handle()
+        assert h._proc is None
+        assert h.is_alive() is False
+
+    def test_true_when_proc_alive(self) -> None:
+        class _FakeProc:
+            def is_alive(self) -> bool:
+                return True
+
+        h = self._handle()
+        h._proc = _FakeProc()
+        assert h.is_alive() is True
+
+    def test_false_when_proc_dead(self) -> None:
+        class _FakeProc:
+            def is_alive(self) -> bool:
+                return False
+
+        h = self._handle()
+        h._proc = _FakeProc()
+        assert h.is_alive() is False
+
+    def test_is_running_mirrors_is_alive(self) -> None:
+        class _FakeProc:
+            def is_alive(self) -> bool:
+                return True
+
+        h = self._handle()
+        h._proc = _FakeProc()
+        assert h.is_running is True
+
+
 class TestEndToEndSpawn:
     """Spawn a real child process with a synthetic source (no camera, no models):
     frames must reach shared memory and telemetry must flow back, then stop cleanly."""

--- a/tests/test_supervisor_health.py
+++ b/tests/test_supervisor_health.py
@@ -12,6 +12,8 @@ from autoptz.engine.supervisor import (
     _BASE_BACKOFF_S,
     _MAX_BACKOFF_S,
     _MAX_RESTART_ATTEMPTS,
+    _WORKER_HANG_S,
+    _WORKER_WARMUP_GRACE_S,
 )
 
 # ── helpers / fakes ──────────────────────────────────────────────────────────
@@ -303,5 +305,64 @@ class TestWorkerTelemetryTracking:
             sup._on_remove_camera(RemoveCameraCmd(camera_id=cid))
             assert cid not in sup._last_telemetry_t
             assert cid not in sup._spawn_t
+        finally:
+            sup.stop()
+
+
+class TestHangDetection:
+    def test_no_hang_within_warmup_grace(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            # Spawn just happened; telemetry never arrived. Within warmup → not hung.
+            spawn_t = sup._spawn_t[cid]
+            assert sup._worker_hung(cid, spawn_t + _WORKER_WARMUP_GRACE_S - 0.1) is False
+        finally:
+            sup.stop()
+
+    def test_hung_when_no_telemetry_past_warmup(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            spawn_t = sup._spawn_t[cid]
+            # Past warmup, still no telemetry → hung.
+            now = spawn_t + _WORKER_WARMUP_GRACE_S + _WORKER_HANG_S + 0.1
+            assert sup._worker_hung(cid, now) is True
+        finally:
+            sup.stop()
+
+    def test_hung_when_telemetry_goes_stale(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            spawn_t = sup._spawn_t[cid]
+            past_warmup = spawn_t + _WORKER_WARMUP_GRACE_S + 1.0
+            sup._last_telemetry_t[cid] = past_warmup  # fresh telemetry arrives
+            assert sup._worker_hung(cid, past_warmup + _WORKER_HANG_S - 0.1) is False
+            assert sup._worker_hung(cid, past_warmup + _WORKER_HANG_S + 0.1) is True
+        finally:
+            sup.stop()
+
+    def test_alive_but_hung_worker_is_respawned(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            original = factory_log[0]
+            assert original._alive is True  # alive, not dead
+            # Force "past warmup, telemetry stale".
+            sup._spawn_t[cid] = 0.0
+            sup._last_telemetry_t[cid] = 0.0
+            now = _WORKER_WARMUP_GRACE_S + _WORKER_HANG_S + 100.0
+            sup._scan_worker_health(now)
+            assert len(factory_log) == 2  # respawned despite being alive
+            assert original.stop_calls == 1  # old (hung) worker was stopped
+            assert sup._workers[cid] is factory_log[1]
+        finally:
+            sup.stop()
+
+    def test_healthy_streaming_worker_not_respawned(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            sup._spawn_t[cid] = 0.0
+            now = _WORKER_WARMUP_GRACE_S + 100.0
+            sup._last_telemetry_t[cid] = now - 0.05  # fresh telemetry
+            sup._scan_worker_health(now)
+            assert len(factory_log) == 1  # untouched
         finally:
             sup.stop()

--- a/tests/test_supervisor_health.py
+++ b/tests/test_supervisor_health.py
@@ -197,7 +197,7 @@ class TestScanWorkerHealth:
         sup, client, factory_log, cid = _build(qapp)
         try:
             # Seed some restart state.
-            sup._restart_state[cid] = (2, 9999.0)
+            sup._restart_state[cid] = (2, 9999.0, False)
             # Route a RemoveCamera command.
             sup._on_remove_camera(RemoveCameraCmd(camera_id=cid))
             assert cid not in sup._restart_state
@@ -215,7 +215,7 @@ class TestScanWorkerHealth:
                 # Advance well past previous back-off so this attempt always fires.
                 now += _MAX_BACKOFF_S + 1.0
                 sup._scan_worker_health(now)
-                attempts, next_t = sup._restart_state.get(cid, (0, now))
+                attempts, next_t, _f = sup._restart_state.get(cid, (0, now, False))
                 expected_backoff = min(_MAX_BACKOFF_S, _BASE_BACKOFF_S * (2**i))
                 assert abs((next_t - now) - expected_backoff) < 0.01, (
                     f"attempt {i + 1}: expected backoff {expected_backoff}, got {next_t - now}"
@@ -259,7 +259,7 @@ class TestScanWorkerHealth:
             sup._workers[cid]._alive = False
             t_crash = now + 2.0
             sup._scan_worker_health(t_crash)  # attempt 1 fresh start
-            attempts, next_allowed_t = sup._restart_state[cid]
+            attempts, next_allowed_t, _failed = sup._restart_state[cid]
             assert attempts == 1
             # next_allowed_t should reflect _BASE_BACKOFF_S (1 s), not a 2^2 delay.
             assert abs((next_allowed_t - t_crash) - _BASE_BACKOFF_S) < 0.01, (
@@ -364,5 +364,47 @@ class TestHangDetection:
             sup._last_telemetry_t[cid] = now - 0.05  # fresh telemetry
             sup._scan_worker_health(now)
             assert len(factory_log) == 1  # untouched
+        finally:
+            sup.stop()
+
+
+class TestPermanentFailed:
+    def test_failed_flag_and_accessor_set_at_cap(self, qapp, caplog) -> None:
+        import logging
+
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            now = 1000.0
+            with caplog.at_level(logging.ERROR):
+                for _ in range(_MAX_RESTART_ATTEMPTS):
+                    sup._workers[cid]._alive = False
+                    now += _MAX_BACKOFF_S + 1.0
+                    sup._scan_worker_health(now)
+            assert sup.is_camera_failed(cid) is True
+            assert cid in sup.failed_cameras()
+            # Exactly one clear permanent-failure ERROR log (not per-scan spam).
+            errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+            assert any("permanently failed" in r.getMessage().lower() for r in errors)
+        finally:
+            sup.stop()
+
+    def test_not_failed_before_cap(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            sup._workers[cid]._alive = False
+            sup._scan_worker_health(1000.0)  # attempt 1 only
+            assert sup.is_camera_failed(cid) is False
+            assert sup.failed_cameras() == []
+        finally:
+            sup.stop()
+
+    def test_remove_clears_failed_state(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import RemoveCameraCmd
+
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            sup._restart_state[cid] = (_MAX_RESTART_ATTEMPTS, 9999.0, True)
+            sup._on_remove_camera(RemoveCameraCmd(camera_id=cid))
+            assert sup.is_camera_failed(cid) is False
         finally:
             sup.stop()

--- a/tests/test_supervisor_health.py
+++ b/tests/test_supervisor_health.py
@@ -266,3 +266,42 @@ class TestScanWorkerHealth:
             )
         finally:
             sup.stop()
+
+
+class TestWorkerTelemetryTracking:
+    def test_telemetry_callback_stamps_last_seen_and_forwards(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            # The wrapped callback the factory received is the supervisor's wrapper,
+            # not push_telemetry directly.
+            wrapped = factory_log[0].on_telemetry
+            before = sup._last_telemetry_t.get(cid)
+            # push_telemetry needs a real TelemetryMsg; build a minimal one.
+            from autoptz.engine.runtime.messages import TelemetryMsg
+
+            wrapped(TelemetryMsg(camera_id=cid, seq=0))
+            after = sup._last_telemetry_t.get(cid)
+            assert before is None
+            assert after is not None and after > 0.0
+        finally:
+            sup.stop()
+
+    def test_spawn_records_spawn_time(self, qapp) -> None:
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            assert cid in sup._spawn_t
+            assert sup._spawn_t[cid] > 0.0
+        finally:
+            sup.stop()
+
+    def test_remove_camera_clears_telemetry_and_spawn_state(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import RemoveCameraCmd
+
+        sup, client, factory_log, cid = _build(qapp)
+        try:
+            sup._last_telemetry_t[cid] = 123.0
+            sup._on_remove_camera(RemoveCameraCmd(camera_id=cid))
+            assert cid not in sup._last_telemetry_t
+            assert cid not in sup._spawn_t
+        finally:
+            sup.stop()

--- a/tests/test_supervisor_health.py
+++ b/tests/test_supervisor_health.py
@@ -353,6 +353,16 @@ class TestHangDetection:
             assert len(factory_log) == 2  # respawned despite being alive
             assert original.stop_calls == 1  # old (hung) worker was stopped
             assert sup._workers[cid] is factory_log[1]
+
+            # Guard: a freshly-respawned worker must NOT be immediately re-hung.
+            # Simulate the new worker emitting telemetry so it looks healthy, then
+            # run one more scan a small delta later (still within the warmup grace
+            # window) — no third spawn should occur.
+            sup._last_telemetry_t[cid] = now  # fresh telemetry from the new worker
+            sup._scan_worker_health(now + 0.5)
+            assert len(factory_log) == 2, (
+                "New worker was immediately re-respawned — hang-detection thrash detected"
+            )
         finally:
             sup.stop()
 
@@ -385,6 +395,18 @@ class TestPermanentFailed:
             # Exactly one clear permanent-failure ERROR log (not per-scan spam).
             errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
             assert any("permanently failed" in r.getMessage().lower() for r in errors)
+            # Run additional scans (still dead, past backoff) — the ERROR must NOT
+            # fire again; exactly one "permanently failed" record across all scans.
+            now += _MAX_BACKOFF_S + 1.0
+            sup._scan_worker_health(now)
+            now += _MAX_BACKOFF_S + 1.0
+            sup._scan_worker_health(now)
+            perm_logs = [
+                r for r in caplog.records if "permanently failed" in r.getMessage().lower()
+            ]
+            assert len(perm_logs) == 1, (
+                f"Expected exactly 1 'permanently failed' log, got {len(perm_logs)}"
+            )
         finally:
             sup.stop()
 


### PR DESCRIPTION
## Summary
Extends the existing worker-health/auto-restart machinery to recover **hung (alive-but-silent)** workers, support process workers, surface a **permanent-failed** state at the restart cap, and expose inference-stall age.

## What's included
- **Hang detection:** supervisor tracks per-camera last-telemetry + spawn time (via a single `_make_telemetry_callback` wrapper — the sole producer, so both threaded and process workers are covered). `_worker_hung()` flags a worker whose telemetry age exceeds `_WORKER_HANG_S` (5.0s) after a warmup grace (8.0s); hung workers route through the **existing** exponential-backoff respawn path.
- **Permanent-failed state:** `_restart_state` widened to `(attempts, next_allowed_t, failed)`; at the restart cap the camera latches `failed=True`, logs ONE clear error (not per-scan), and exposes `is_camera_failed(cid)` / `failed_cameras()`. The whole app is **not** auto-restarted (deliberately bounded).
- **Process workers:** `ProcessWorkerHandle.is_alive()` (already child-process-backed) locked in by regression test, so the same scan path restarts dead child processes.
- **Observability:** additive optional `HealthInfo.inference_stall_age_s` (computed on the capture thread, clamped ≥0).
- Review-hardening: respawn clears stale `_last_telemetry_t` (honest spawn-time anchor); tests now lock "log fires once" and "no respawn→re-hung loop".

## Verification
All 5 CI gates green locally (`.venv`, offscreen env): ruff, ruff format, mypy (engine/runtime + config), pytest **1399 passed**, `--selftest`. No motion/PTZ behavior changed; new thresholds are conservative. Headless-testable (simulated stale telemetry / dead worker).

Plan: `docs/superpowers/plans/2026-06-26-engine-auto-restart.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)