### PR TITLE
feat(process-per-camera): Path A hardening + fix the dead opt-in gate + cross-process identity relay

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -820,6 +820,20 @@ class CameraWorker:
         """
         self._injected_identity_service = service
 
+    def ingest_identity(self, record: Any) -> None:
+        """Index an identity relayed from another camera process (opt-in mode).
+
+        Best-effort: a missing identity service (identity features off) is a no-op.
+        Targets the injected gallery — the same object the face stack matches
+        against — so a face harvested on another camera becomes matchable here.
+        """
+        service = self._injected_identity_service
+        if service is not None and hasattr(service, "ingest_record"):
+            try:
+                service.ingest_record(record)
+            except Exception:  # noqa: BLE001
+                log.debug("camera_id=%s ingest_identity failed", self.camera_id, exc_info=True)
+
     def set_inference_pool(self, pool: Any | None) -> None:
         """Inject the process-wide shared inference pool (heavy models once).
 

--- a/autoptz/engine/identity/service.py
+++ b/autoptz/engine/identity/service.py
@@ -219,6 +219,25 @@ class IdentityService:
             self._bump()
         return rec
 
+    def ingest_record(self, record: IdentityRecord) -> bool:
+        """Index a pre-built identity from another process, in-memory + idempotent.
+
+        Used by the opt-in process-per-camera relay: an unlabeled "Person N"
+        harvested in one child is broadcast to the others so the same face is
+        matchable everywhere (labeled identities already converge via the shared
+        DB).  Preserves the record's id (cross-process identity) and bumps the
+        version so each worker's versioned reload picks it up.  Memory-only —
+        never persisted here (avoids double-writing labeled records the DB already
+        owns).  Returns True iff the gallery actually changed.
+        """
+        with self._lock:
+            held = self._records.get(record.id)
+            if held is not None and held.updated_at >= record.updated_at:
+                return False  # we already have this (or a newer) copy
+            self._index(record)
+            self._bump()
+            return True
+
     def add_embedding(
         self,
         identity_id: str,

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -345,12 +345,31 @@ class ProcessWorkerHandle:
         proc = self._proc
         if proc is not None:
             try:
+                # 1) Bounded graceful join: the child should exit on the _STOP sentinel.
                 proc.join(timeout=timeout)
+                # 2) Escalate to terminate() if it's still alive past the deadline.
                 if proc.is_alive():
+                    log.debug(
+                        "camera process %s did not stop on sentinel — terminating",
+                        self.camera_id,
+                    )
                     proc.terminate()
                     proc.join(timeout=2.0)
+                # 3) Truly unclean: survived terminate(). Surface it.
+                if proc.is_alive():
+                    log.warning(
+                        "camera process %s did not exit after terminate()", self.camera_id
+                    )
             except Exception:  # noqa: BLE001
                 log.debug("camera process %s join/terminate failed", self.camera_id, exc_info=True)
+        # Join the event-drain thread so it doesn't outlive the handle (best-effort).
+        drain = self._drain_thread
+        if drain is not None and drain is not threading.current_thread():
+            try:
+                drain.join(timeout=1.0)
+            except Exception:  # noqa: BLE001
+                pass
+        self._drain_thread = None
         self._proc = None
         self._started = False
 

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -267,6 +267,11 @@ class ProcessWorkerHandle:
     to the same callbacks the threaded path uses, via a small daemon drain thread.
     """
 
+    # Marks a worker as living in its own process so the supervisor's identity
+    # relay targets ONLY these (cross-process siblings) and stays a true no-op for
+    # the threaded default path, where every worker already shares one gallery.
+    _is_process_worker = True
+
     def __init__(
         self,
         camera_id: str,
@@ -402,6 +407,22 @@ class ProcessWorkerHandle:
                 drain.join(timeout=1.0)
             except Exception:  # noqa: BLE001
                 pass
+        # Release the queues now that nothing reads/writes them: each mp.Queue owns
+        # a background feeder thread + OS pipe FDs, so dropping the refs without
+        # close() leaks both until GC — which accumulates on a flapping camera that
+        # respawns a fresh handle each restart.  cancel_join_thread() first so close
+        # never blocks on an undelivered _STOP put when the child is already gone.
+        for q in (self._cmd_q, self._telemetry_q, self._identity_q):
+            if q is None:
+                continue
+            try:
+                q.cancel_join_thread()
+                q.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._cmd_q = None
+        self._telemetry_q = None
+        self._identity_q = None
         self._drain_thread = None
         self._proc = None
         self._started = False

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -26,6 +26,13 @@ via a parent-side relay: a "Person N" harvested in one child is forwarded over i
 ``ingest_identity`` command so the same face becomes matchable on every camera.
 Residual gap: a record harvested while a sibling is still spawning is dropped (it
 re-harvests on that sibling's next clean frame).
+Template-accrual gap: the relay fires on initial harvest and enroll
+(``_push_identity``) but NOT on ``add_embedding`` — additional templates accrued
+for an already-harvested Person N are not forwarded to siblings.  Siblings
+therefore hold only the initial template until they re-harvest that face
+independently.  This is a completeness gap, not a correctness bug: labeled
+identities converge via the shared SQLite DB, and unlabeled ones still match on
+the initial template.
 
 **RAM trade-off:** an ORT ``InferenceSession`` is not picklable, so each child
 builds **its own** inference pool — roughly one model set per camera.  That extra

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -104,6 +104,27 @@ def _safe_put(q: Any, item: Any) -> None:
         pass
 
 
+def _configure_child_logging() -> None:
+    """Make a child's WARNING+ logs visible to the operator (best-effort).
+
+    A spawned child does not inherit the parent's handlers, so its setup/crash
+    warnings would otherwise go nowhere.  Install a single stderr handler at
+    WARNING (the child's *telemetry*, not its logs, is the primary channel — but
+    a crash must still be visible somewhere) and leave the level at WARNING so the
+    child stays quiet on the hot path.
+    """
+    import sys
+
+    root = logging.getLogger()
+    root.setLevel(logging.WARNING)
+    if not root.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+        root.addHandler(handler)
+
+
 def run_camera_process(
     spec: WorkerSpec,
     cmd_q: Any,
@@ -116,10 +137,10 @@ def run_camera_process(
     re-raises — a child that fails to build should exit cleanly so the supervisor
     can surface/respawn it, not hang.
     """
-    # Quiet the child's root logger to WARNING (its telemetry, not its logs, is
-    # what the parent consumes); the parent owns the in-app log view.
+    # A child does not inherit the parent's handlers; install our own so setup /
+    # crash WARNINGs are visible, kept at WARNING so the hot path stays quiet.
     try:
-        logging.getLogger().setLevel(logging.WARNING)
+        _configure_child_logging()
     except Exception:  # noqa: BLE001
         pass
 
@@ -318,6 +339,10 @@ class ProcessWorkerHandle:
             name=f"camproc-{self.camera_id[:8]}",
             daemon=True,
         )
+        # Ensure the child's stderr is line-unbuffered so a crash log isn't lost
+        # in the pipe buffer when it exits abnormally (opt-in mode only). Spawn
+        # inherits the env at fork time.
+        os.environ.setdefault("PYTHONUNBUFFERED", "1")
         self._proc.start()
         self._started = True
         self._drain_stop.clear()

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -418,6 +418,10 @@ class ProcessWorkerHandle:
     def set_target_identity(self, identity_id: Any) -> None:
         self._send("set_target_identity", (identity_id,))
 
+    def ingest_identity(self, record: Any) -> None:
+        """Relay an identity harvested in another process into this child's gallery."""
+        self._send("ingest_identity", (record,))
+
     def enroll_track(self, *args: Any) -> None:
         self._send("enroll_track", args)
 

--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -20,11 +20,23 @@ How the boundary is crossed (the scaffolding the engine was designed around):
   opt-in rather than the default.
 
 **Identity:** labeled identities converge through the shared SQLite DB (each child
-opens its own connection).  Live cross-process propagation of *unlabeled* harvested
-faces is not implemented in this mode yet.
+opens its own connection).  *Unlabeled* auto-harvested faces are propagated live
+via a parent-side relay: a "Person N" harvested in one child is forwarded over its
+``identity_q`` to the parent, which re-broadcasts it to every other child as an
+``ingest_identity`` command so the same face becomes matchable on every camera.
+Residual gap: a record harvested while a sibling is still spawning is dropped (it
+re-harvests on that sibling's next clean frame).
 
-**Status — EXPERIMENTAL.** The IPC + lifecycle plumbing here is unit-tested with a
-synthetic source, but the throughput / RAM / real-camera + PTZ behaviour needs
+**RAM trade-off:** an ORT ``InferenceSession`` is not picklable, so each child
+builds **its own** inference pool — roughly one model set per camera.  That extra
+RAM is the whole reason this mode is opt-in rather than the default: it buys true
+multi-core parallelism (GIL bypass) at the cost of duplicated model memory.
+
+**Status — EXPERIMENTAL.** The IPC + lifecycle plumbing here is hardened and
+unit-tested with a synthetic source: child liveness drives the supervisor's
+auto-restart, ``stop()`` escalates join → terminate → log cleanly, child
+setup/crash logs surface to the operator, and unlabeled identities relay across
+children.  The throughput / RAM / real-camera + PTZ behaviour still needs
 validation on a real multi-camera rig before this is anything more than opt-in.
 """
 
@@ -119,9 +131,7 @@ def _configure_child_logging() -> None:
     root.setLevel(logging.WARNING)
     if not root.handlers:
         handler = logging.StreamHandler(sys.stderr)
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
-        )
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
         root.addHandler(handler)
 
 
@@ -382,9 +392,7 @@ class ProcessWorkerHandle:
                     proc.join(timeout=2.0)
                 # 3) Truly unclean: survived terminate(). Surface it.
                 if proc.is_alive():
-                    log.warning(
-                        "camera process %s did not exit after terminate()", self.camera_id
-                    )
+                    log.warning("camera process %s did not exit after terminate()", self.camera_id)
             except Exception:  # noqa: BLE001
                 log.debug("camera process %s join/terminate failed", self.camera_id, exc_info=True)
         # Join the event-drain thread so it doesn't outlive the handle (best-effort).

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -971,13 +971,21 @@ class Supervisor:
     def _relay_identity_to_siblings(self, source_cid: str, record: Any) -> None:
         """Broadcast a harvested identity to every OTHER process worker.
 
-        No-op outside opt-in process-per-camera mode: threaded workers share one
-        in-process gallery (so they already see the record) and don't expose
-        ``ingest_identity``.  Best-effort per sibling; one failing relay never
-        blocks the others.
+        True no-op outside opt-in process-per-camera mode: threaded workers share
+        one in-process gallery (so a harvested record is already visible to every
+        sibling), so we only relay to workers flagged ``_is_process_worker`` —
+        ``ProcessWorkerHandle``s whose child holds a *separate* gallery.  Threaded
+        ``CameraWorker``s also expose ``ingest_identity`` but are deliberately
+        skipped here, keeping the default path free of any cross-thread supervisor
+        -lock traffic.  Best-effort per sibling; one failing relay never blocks the
+        others.
         """
         with self._lock:
-            siblings = [(cid, w) for cid, w in self._workers.items() if cid != source_cid]
+            siblings = [
+                (cid, w)
+                for cid, w in self._workers.items()
+                if cid != source_cid and getattr(w, "_is_process_worker", False)
+            ]
         for cid, worker in siblings:
             relay = getattr(worker, "ingest_identity", None)
             if callable(relay):

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -999,8 +999,13 @@ class Supervisor:
             process_per_camera_enabled,
         )
 
+        # ``==`` (not ``is``): ``self._default_worker_factory`` is a bound method, and
+        # Python mints a fresh bound-method object on every attribute access, so an
+        # ``is`` check here is ALWAYS False — which silently disabled the entire
+        # opt-in process path.  Bound methods compare equal by (instance, function),
+        # so ``==`` is True only when no custom/test factory was injected.
         use_process = (
-            self._worker_factory is self._default_worker_factory and process_per_camera_enabled()
+            self._worker_factory == self._default_worker_factory and process_per_camera_enabled()
         )
         if not use_process:
             return self._worker_factory(camera_id, config, on_telemetry)
@@ -1018,6 +1023,16 @@ class Supervisor:
         except Exception:  # noqa: BLE001
             db_path = ""
         log.info("spawning camera %s as its own PROCESS (experimental)", camera_id)
+        try:
+            camera_count = len(self._client.cameraModel.camera_ids())
+        except Exception:  # noqa: BLE001
+            camera_count = 0
+        if camera_count >= 4:
+            log.info(
+                "process-per-camera active with %d cameras — each child rebuilds its "
+                "own model set (more RAM) in exchange for GIL relief across cores.",
+                camera_count,
+            )
         return ProcessWorkerHandle(
             camera_id,
             config,

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -968,6 +968,24 @@ class Supervisor:
 
         return _cb
 
+    def _relay_identity_to_siblings(self, source_cid: str, record: Any) -> None:
+        """Broadcast a harvested identity to every OTHER process worker.
+
+        No-op outside opt-in process-per-camera mode: threaded workers share one
+        in-process gallery (so they already see the record) and don't expose
+        ``ingest_identity``.  Best-effort per sibling; one failing relay never
+        blocks the others.
+        """
+        with self._lock:
+            siblings = [(cid, w) for cid, w in self._workers.items() if cid != source_cid]
+        for cid, worker in siblings:
+            relay = getattr(worker, "ingest_identity", None)
+            if callable(relay):
+                try:
+                    relay(record)
+                except Exception:  # noqa: BLE001
+                    log.debug("identity relay to %s failed", cid, exc_info=True)
+
     def _make_worker(self, camera_id: str, config: CameraConfig) -> Any:
         """Build a camera worker — a thread-based one, or (opt-in) a child process.
 
@@ -1041,7 +1059,17 @@ class Supervisor:
             self._client,
             "push_identity",
         ):
-            worker.set_identity_callback(self._client.push_identity)
+            push = self._client.push_identity
+
+            def _identity_cb(record: Any, _cid: str = camera_id) -> None:
+                # UI surfacing (unchanged), then fan-out to sibling processes so an
+                # unlabeled face harvested here becomes matchable on every camera.
+                try:
+                    push(record)
+                finally:
+                    self._relay_identity_to_siblings(_cid, record)
+
+            worker.set_identity_callback(_identity_cb)
 
         # Inject the shared inference pool (heavy models loaded once for all
         # cameras) and the current global feature switches.

--- a/autoptz/engine/supervisor.py
+++ b/autoptz/engine/supervisor.py
@@ -979,7 +979,15 @@ class Supervisor:
         skipped here, keeping the default path free of any cross-thread supervisor
         -lock traffic.  Best-effort per sibling; one failing relay never blocks the
         others.
+
+        The early-return on the disabled path is intentionally lock-free: when
+        process-per-camera is off every worker shares the same in-process gallery
+        and no relay is necessary, so we avoid touching the supervisor RLock at all.
         """
+        from autoptz.engine.process_worker import process_per_camera_enabled
+
+        if not process_per_camera_enabled():
+            return
         with self._lock:
             siblings = [
                 (cid, w)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -335,6 +335,33 @@ class TestIdentityServiceCRUD:
         assert rec.enabled is True
         assert rec in service.labeled_identities()
 
+    def test_ingest_record_adds_unlabeled_and_is_idempotent(self) -> None:
+        import numpy as np
+
+        from autoptz.engine.identity.service import IdentityService
+
+        svc = IdentityService()  # no store -> pure in-memory
+        emb = np.ones(512, dtype=np.float32)
+        rec = IdentityRecord(
+            name="Person 7",
+            embeddings=[embedding_to_bytes(emb)],
+            enabled=False,
+            labeled=False,
+        )
+        v0 = svc.version
+
+        assert svc.ingest_record(rec) is True
+        got = svc.get(rec.id)
+        assert got is not None and got.name == "Person 7"
+        # Template indexed -> the record is matchable.
+        assert any(r.id == rec.id for r in svc.matchable_identities())
+        assert svc.version > v0
+
+        # Idempotent: re-ingesting the same record changes nothing.
+        v1 = svc.version
+        assert svc.ingest_record(rec) is False
+        assert svc.version == v1
+
     def test_add_unlabeled_is_memory_only(self):
         service, _ = _make_service()
         rec = service.add_unlabeled(_vec(11), thumbnail=b"png")

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -167,6 +167,69 @@ class TestHandleIsAlive:
         assert h.is_running is True
 
 
+class TestHandleStop:
+    """stop() must escalate join -> terminate -> join and log an unclean exit."""
+
+    def _handle(self):  # noqa: ANN202
+        cid = "proc-" + uuid.uuid4().hex[:8]
+        return ProcessWorkerHandle(cid, _config(cid), on_telemetry=lambda _m: None, db_path="")
+
+    def test_stop_terminates_when_join_times_out(self) -> None:
+        h = self._handle()
+
+        class _StuckProc:
+            """Joins never finish; terminate() makes it die."""
+
+            def __init__(self) -> None:
+                self.alive = True
+                self.terminated = False
+
+            def is_alive(self) -> bool:
+                return self.alive
+
+            def join(self, timeout=None) -> None:  # noqa: ANN001
+                return None  # never transitions on its own
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.alive = False
+
+        proc = _StuckProc()
+        h._proc = proc  # type: ignore[assignment]
+        h._cmd_q = None  # exercise the no-queue branch
+        h._started = True
+
+        h.stop(timeout=0.01)
+
+        assert proc.terminated, "a child that won't join must be terminated"
+        assert h._proc is None
+        assert h._started is False
+
+    def test_stop_warns_when_child_survives_terminate(self, caplog) -> None:  # noqa: ANN001
+        h = self._handle()
+
+        class _ZombieProc:
+            def is_alive(self) -> bool:
+                return True  # never dies, even after terminate
+
+            def join(self, timeout=None) -> None:  # noqa: ANN001
+                return None
+
+            def terminate(self) -> None:
+                return None
+
+        h._proc = _ZombieProc()  # type: ignore[assignment]
+        h._started = True
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            h.stop(timeout=0.01)
+        assert any("did not exit" in r.message.lower() for r in caplog.records), (
+            "an unclean child exit must surface as a WARNING"
+        )
+        assert h._proc is None
+
+
 class TestEndToEndSpawn:
     """Spawn a real child process with a synthetic source (no camera, no models):
     frames must reach shared memory and telemetry must flow back, then stop cleanly."""

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -327,6 +327,27 @@ class TestIdentityRelay:
             sup.stop()
 
 
+class TestMakeWorkerGuidance:
+    def test_guidance_log_at_four_cameras(self, qapp, monkeypatch, caplog) -> None:  # noqa: ANN001
+        import logging
+
+        from autoptz.engine.supervisor import Supervisor
+        from autoptz.ui.engine_client import EngineClient
+
+        monkeypatch.setenv("AUTOPTZ_PROCESS_PER_CAMERA", "1")
+        client = EngineClient()
+        cids = [client.addCamera("usb://0", f"Guide{i}") for i in range(4)]
+        client.drain_commands()
+        sup = Supervisor(client, store=None)  # default factory -> process path is eligible
+
+        with caplog.at_level(logging.INFO):
+            sup._make_worker(cids[0], _config(cids[0]))
+        assert any(
+            "gil" in r.message.lower() or "process-per-camera" in r.message.lower()
+            for r in caplog.records
+        ), "expected a GIL-relief guidance log at >=4 cameras"
+
+
 class TestChildLogging:
     def test_child_log_setup_installs_warning_handler(self) -> None:
         import logging

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -281,6 +281,52 @@ def test_child_drain_routes_ingest_identity() -> None:
     assert ingested == [rec.id]
 
 
+class TestIdentityRelay:
+    def test_harvested_identity_relays_to_sibling_not_source(self, qapp) -> None:  # noqa: ANN001
+        from autoptz.config.models import IdentityRecord
+        from autoptz.engine.supervisor import Supervisor
+        from autoptz.ui.engine_client import EngineClient
+
+        ingested: dict[str, list[str]] = {}
+
+        class _FakeHandle:
+            def __init__(self, camera_id, config, on_telemetry) -> None:  # noqa: ANN001
+                self.camera_id = camera_id
+                self.shm_name = f"cam_{camera_id[:8]}_preview"
+                self._cb = None
+                ingested[camera_id] = []
+
+            def is_alive(self) -> bool:
+                return True
+
+            def set_identity_service(self, _s) -> None: ...  # noqa: ANN001
+            def set_identity_callback(self, cb) -> None:  # noqa: ANN001
+                self._cb = cb
+
+            def set_inference_pool(self, _p) -> None: ...  # noqa: ANN001
+            def set_features(self, _f) -> None: ...  # noqa: ANN001
+            def ingest_identity(self, record) -> None:  # noqa: ANN001
+                ingested[self.camera_id].append(record.id)
+
+            def start(self) -> None: ...
+            def stop(self) -> None: ...
+
+        client = EngineClient()
+        cid_a = client.addCamera("usb://0", "RelayA")
+        cid_b = client.addCamera("usb://0", "RelayB")
+        client.drain_commands()
+        sup = Supervisor(client, store=None, worker_factory=_FakeHandle)
+        sup.start()
+        try:
+            src = sup._workers[cid_a]
+            rec = IdentityRecord(name="Person 1", enabled=False, labeled=False)
+            src._cb(rec)  # child A harvested -> parent callback fires
+            assert ingested[cid_b] == [rec.id], "sibling must receive the relay"
+            assert ingested[cid_a] == [], "source must NOT receive its own relay"
+        finally:
+            sup.stop()
+
+
 class TestChildLogging:
     def test_child_log_setup_installs_warning_handler(self) -> None:
         import logging

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -74,6 +74,68 @@ class TestEnabledFlag:
             assert process_per_camera_enabled() is True
 
 
+class TestRelayIdentityLockFree:
+    """_relay_identity_to_siblings must be a lock-free no-op in threaded (default) mode."""
+
+    def _make_supervisor(self, qapp):  # noqa: ANN001
+        from autoptz.engine.supervisor import Supervisor
+        from autoptz.ui.engine_client import EngineClient
+
+        client = EngineClient()
+        sup = Supervisor(client, store=None)
+        sup._ensure_identity_service = lambda: None  # type: ignore[method-assign]
+        sup._ensure_inference_pool = lambda: None  # type: ignore[method-assign]
+        return sup
+
+    def test_relay_is_noop_when_disabled(self, qapp, monkeypatch) -> None:
+        """With AUTOPTZ_PROCESS_PER_CAMERA unset the relay returns immediately without
+        touching any worker, confirming the lock-free early-return path."""
+        from unittest.mock import MagicMock, patch
+
+        monkeypatch.delenv("AUTOPTZ_PROCESS_PER_CAMERA", raising=False)
+        sup = self._make_supervisor(qapp)
+
+        # Add a fake process worker so we can confirm it is never called.
+        fake_worker = MagicMock()
+        fake_worker._is_process_worker = True
+        sup._workers["cam-other"] = fake_worker
+
+        sentinel = object()
+        # Patch at the source module so the local import inside the method picks up the mock.
+        with patch(
+            "autoptz.engine.process_worker.process_per_camera_enabled",
+            return_value=False,
+        ) as mock_gate:
+            sup._relay_identity_to_siblings("cam-source", sentinel)
+            mock_gate.assert_called_once()
+
+        # The fake worker must never have been touched.
+        fake_worker.ingest_identity.assert_not_called()
+
+    def test_relay_skips_threaded_workers(self, qapp, monkeypatch) -> None:
+        """Even if process-per-camera is enabled, threaded CameraWorkers are skipped
+        (they have no ``_is_process_worker`` flag) — relay is a structural no-op for them."""
+        monkeypatch.setenv("AUTOPTZ_PROCESS_PER_CAMERA", "1")
+        sup = self._make_supervisor(qapp)
+
+        # Install a fake threaded worker (no _is_process_worker attr).
+        class _FakeThreadedWorker:
+            ingest_calls: list = []
+
+            def ingest_identity(self, record):  # noqa: ANN001
+                self.ingest_calls.append(record)
+
+        fake = _FakeThreadedWorker()
+        sup._workers["cam-other"] = fake
+
+        sentinel = object()
+        sup._relay_identity_to_siblings("cam-source", sentinel)
+        # Threaded worker must NOT have received the relay.
+        assert fake.ingest_calls == [], (
+            "relay incorrectly forwarded identity to a threaded CameraWorker"
+        )
+
+
 class TestHandleProxy:
     """The handle must serialize each supervisor method call onto the command queue
     (post-start), and buffer pre-start feature/defer config into the spec."""
@@ -319,10 +381,13 @@ def test_child_drain_routes_ingest_identity() -> None:
 
 
 class TestIdentityRelay:
-    def test_harvested_identity_relays_to_sibling_not_source(self, qapp) -> None:  # noqa: ANN001
+    def test_harvested_identity_relays_to_sibling_not_source(self, qapp, monkeypatch) -> None:  # noqa: ANN001
         from autoptz.config.models import IdentityRecord
         from autoptz.engine.supervisor import Supervisor
         from autoptz.ui.engine_client import EngineClient
+
+        # Process-per-camera must be enabled so the relay's early-return guard passes.
+        monkeypatch.setenv("AUTOPTZ_PROCESS_PER_CAMERA", "1")
 
         ingested: dict[str, list[str]] = {}
 

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -230,6 +230,25 @@ class TestHandleStop:
         assert h._proc is None
 
 
+class TestChildLogging:
+    def test_child_log_setup_installs_warning_handler(self) -> None:
+        import logging
+
+        from autoptz.engine.process_worker import _configure_child_logging
+
+        root = logging.getLogger()
+        saved_handlers = list(root.handlers)
+        saved_level = root.level
+        try:
+            root.handlers = []
+            _configure_child_logging()
+            assert root.handlers, "child must install at least one log handler"
+            assert root.level <= logging.WARNING
+        finally:
+            root.handlers = saved_handlers
+            root.setLevel(saved_level)
+
+
 class TestEndToEndSpawn:
     """Spawn a real child process with a synthetic source (no camera, no models):
     frames must reach shared memory and telemetry must flow back, then stop cleanly."""

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -230,6 +230,57 @@ class TestHandleStop:
         assert h._proc is None
 
 
+class TestIngestIdentityProxy:
+    def test_ingest_identity_enqueues_command(self) -> None:
+        cid = "proc-" + uuid.uuid4().hex[:8]
+        h = ProcessWorkerHandle(cid, _config(cid), on_telemetry=lambda _m: None, db_path="")
+
+        class _FakeQ:
+            def __init__(self) -> None:
+                self.items: list = []
+
+            def put(self, item) -> None:  # noqa: ANN001
+                self.items.append(item)
+
+        q = _FakeQ()
+        h._cmd_q = q
+        h._started = True
+
+        from autoptz.config.models import IdentityRecord
+
+        rec = IdentityRecord(name="Person 3", enabled=False, labeled=False)
+        h.ingest_identity(rec)
+        assert any(name == "ingest_identity" for (name, _a, _k) in q.items)
+
+    def test_ingest_identity_noop_before_start(self) -> None:
+        cid = "proc-" + uuid.uuid4().hex[:8]
+        h = ProcessWorkerHandle(cid, _config(cid), on_telemetry=lambda _m: None, db_path="")
+        from autoptz.config.models import IdentityRecord
+
+        # No queue yet -> must not raise.
+        h.ingest_identity(IdentityRecord(name="Person 4", enabled=False, labeled=False))
+
+
+def test_child_drain_routes_ingest_identity() -> None:
+    import queue as _queue
+
+    from autoptz.config.models import IdentityRecord
+    from autoptz.engine.process_worker import _STOP, _drain_commands
+
+    ingested: list = []
+
+    class _FakeWorker:
+        def ingest_identity(self, record) -> None:  # noqa: ANN001
+            ingested.append(record.id)
+
+    rec = IdentityRecord(name="Person 9", enabled=False, labeled=False)
+    q: _queue.Queue = _queue.Queue()
+    q.put(("ingest_identity", (rec,), {}))
+    q.put((_STOP, (), {}))
+    _drain_commands(_FakeWorker(), q)
+    assert ingested == [rec.id]
+
+
 class TestChildLogging:
     def test_child_log_setup_installs_warning_handler(self) -> None:
         import logging

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -229,6 +229,43 @@ class TestHandleStop:
         )
         assert h._proc is None
 
+    def test_stop_closes_queues_and_drops_refs(self) -> None:
+        """stop() must release the three mp.Queues (close + cancel feeder join) and
+        drop the references, so a respawned/flapping camera doesn't leak feeder
+        threads + pipe FDs on every restart.
+        """
+        h = self._handle()
+
+        class _FakeQ:
+            def __init__(self) -> None:
+                self.closed = False
+                self.cancelled = False
+
+            def put(self, _item) -> None:  # noqa: ANN001
+                return None
+
+            def cancel_join_thread(self) -> None:
+                self.cancelled = True
+
+            def close(self) -> None:
+                self.closed = True
+
+        cmd_q, tel_q, ident_q = _FakeQ(), _FakeQ(), _FakeQ()
+        h._cmd_q = cmd_q  # type: ignore[assignment]
+        h._telemetry_q = tel_q  # type: ignore[assignment]
+        h._identity_q = ident_q  # type: ignore[assignment]
+        h._proc = None  # no child to join
+        h._started = True
+
+        h.stop(timeout=0.01)
+
+        for q in (cmd_q, tel_q, ident_q):
+            assert q.cancelled, "each queue's feeder-join must be cancelled"
+            assert q.closed, "each queue must be closed to release its pipe FDs"
+        assert h._cmd_q is None
+        assert h._telemetry_q is None
+        assert h._identity_q is None
+
 
 class TestIngestIdentityProxy:
     def test_ingest_identity_enqueues_command(self) -> None:
@@ -290,6 +327,10 @@ class TestIdentityRelay:
         ingested: dict[str, list[str]] = {}
 
         class _FakeHandle:
+            # Marks this as a process worker so the relay treats it like a real
+            # ProcessWorkerHandle (cross-process sibling), not a threaded worker.
+            _is_process_worker = True
+
             def __init__(self, camera_id, config, on_telemetry) -> None:  # noqa: ANN001
                 self.camera_id = camera_id
                 self.shm_name = f"cam_{camera_id[:8]}_preview"
@@ -322,6 +363,57 @@ class TestIdentityRelay:
             rec = IdentityRecord(name="Person 1", enabled=False, labeled=False)
             src._cb(rec)  # child A harvested -> parent callback fires
             assert ingested[cid_b] == [rec.id], "sibling must receive the relay"
+            assert ingested[cid_a] == [], "source must NOT receive its own relay"
+        finally:
+            sup.stop()
+
+    def test_threaded_default_path_does_not_relay(self, qapp) -> None:  # noqa: ANN001
+        """Threaded (in-process) workers share one gallery, so the relay must be a
+        true no-op for them — even though ``CameraWorker`` now exposes
+        ``ingest_identity``.  Relaying would needlessly take the supervisor lock and
+        re-ingest a record every sibling already sees.
+        """
+        from autoptz.config.models import IdentityRecord
+        from autoptz.engine.supervisor import Supervisor
+        from autoptz.ui.engine_client import EngineClient
+
+        ingested: dict[str, list[str]] = {}
+
+        class _FakeThreadedWorker:
+            """Mimics the threaded ``CameraWorker`` surface (no process marker)."""
+
+            def __init__(self, camera_id, config, on_telemetry) -> None:  # noqa: ANN001
+                self.camera_id = camera_id
+                self.shm_name = f"cam_{camera_id[:8]}_preview"
+                self._cb = None
+                ingested[camera_id] = []
+
+            def is_alive(self) -> bool:
+                return True
+
+            def set_identity_service(self, _s) -> None: ...  # noqa: ANN001
+            def set_identity_callback(self, cb) -> None:  # noqa: ANN001
+                self._cb = cb
+
+            def set_inference_pool(self, _p) -> None: ...  # noqa: ANN001
+            def set_features(self, _f) -> None: ...  # noqa: ANN001
+            def ingest_identity(self, record) -> None:  # noqa: ANN001
+                ingested[self.camera_id].append(record.id)
+
+            def start(self) -> None: ...
+            def stop(self) -> None: ...
+
+        client = EngineClient()
+        cid_a = client.addCamera("usb://0", "ThreadA")
+        cid_b = client.addCamera("usb://0", "ThreadB")
+        client.drain_commands()
+        sup = Supervisor(client, store=None, worker_factory=_FakeThreadedWorker)
+        sup.start()
+        try:
+            src = sup._workers[cid_a]
+            rec = IdentityRecord(name="Person 2", enabled=False, labeled=False)
+            src._cb(rec)  # threaded worker harvested -> parent callback fires
+            assert ingested[cid_b] == [], "threaded sibling must NOT be relayed to"
             assert ingested[cid_a] == [], "source must NOT receive its own relay"
         finally:
             sup.stop()

--- a/tests/test_worker_crash_safety.py
+++ b/tests/test_worker_crash_safety.py
@@ -354,3 +354,55 @@ def test_inference_loop_fatal_exit_surfaces_error_for_capture_telemetry() -> Non
         "the camera went box-blind"
     )
     assert "inference thread stopped" in w._infer_last_error
+
+
+# ── process handle composes with the supervisor's auto-restart ────────────────
+
+
+def test_supervisor_restarts_dead_process_handle(qapp) -> None:  # noqa: ANN001
+    """A handle whose is_alive() goes False is torn down and respawned via the
+    backoff path — the same path a dead child process travels in opt-in mode.
+
+    The process-per-camera handle (ProcessWorkerHandle) only adds a different
+    factory; the supervisor's health scan calls ``worker.is_alive()`` for BOTH
+    worker types and respawns through the shared backoff path. This proves a
+    process-style handle (is_alive() flips False) composes with that path.
+    """
+    from autoptz.engine.supervisor import Supervisor
+    from autoptz.ui.engine_client import EngineClient
+
+    built: list[str] = []
+
+    class _FakeHandle:
+        def __init__(self, camera_id, config, on_telemetry) -> None:  # noqa: ANN001
+            self.camera_id = camera_id
+            self.shm_name = f"cam_{camera_id[:8]}_preview"
+            self._alive = True
+            built.append(camera_id)
+
+        def is_alive(self) -> bool:
+            return self._alive
+
+        def set_identity_service(self, _s) -> None: ...  # noqa: ANN001
+        def set_identity_callback(self, _c) -> None: ...  # noqa: ANN001
+        def set_inference_pool(self, _p) -> None: ...  # noqa: ANN001
+        def set_features(self, _f) -> None: ...  # noqa: ANN001
+        def start(self) -> None: ...
+        def stop(self) -> None:
+            self._alive = False
+
+    client = EngineClient()
+    cid = client.addCamera("usb://0", "ProcRestart")
+    client.drain_commands()  # clear the AddCameraCmd so it isn't double-spawned
+    sup = Supervisor(client, store=None, worker_factory=_FakeHandle)
+    sup.start()
+    try:
+        handle = sup._workers[cid]
+        handle._alive = False  # simulate the child process dying
+        # Drive the health scan past its throttle window.
+        sup._last_health_scan_t = 0.0
+        sup._scan_worker_health(now=1000.0)
+        assert built.count(cid) == 2, "supervisor should have respawned the dead handle"
+        assert sup._restart_state.get(cid, (0, 0.0, False))[0] == 1
+    finally:
+        sup.stop()


### PR DESCRIPTION
## Summary
Hardens the **opt-in** process-per-camera mode (`AUTOPTZ_PROCESS_PER_CAMERA`) to be production-safe. Default stays threaded — no behavior change unless the flag is set.

## Headline: the opt-in was completely dead
`Supervisor._make_worker` gated the process branch on `self._worker_factory is self._default_worker_factory`. Bound methods mint a fresh object on every attribute access, so `is` was **always False** — the process-per-camera branch never ran, even with `AUTOPTZ_PROCESS_PER_CAMERA=1`. Changed to `==` (instance+function equality). Verified the 66 threaded-orchestration tests (all using custom factories → still threaded) are unaffected. **This is what makes the feature actually function.**

## What's included
- **Lifecycle:** `ProcessWorkerHandle.is_alive()` composes with the supervisor's auto-restart (a dead child respawns via the existing backoff path — test added). Hardened `stop()` escalation: bounded join → terminate → join → warn only on truly unclean exit; queues freed on stop.
- **Observability:** child stderr/setup/crash logs surfaced to the parent (`PYTHONUNBUFFERED=1` + a stderr handler).
- **Cross-process identity:** unlabeled harvested identities now propagate across child processes — `IdentityService.ingest_record()` (idempotent, version-bumping seam) + a child-side `ingest_identity` command proxy + a parent-side relay that fans a child's harvested record to the **other** children. Labeled identities still converge via the shared SQLite DB. The relay early-returns before taking any lock when process-per-camera is off, so the **default threaded path stays strictly lock-free**.
- **Guidance:** an info log when process-per-camera is active with ≥4 cameras (GIL-relief). RAM trade-off (each child rebuilds its own model set) documented.

## Scope / residual gaps (documented, accepted)
- Stays **opt-in**; no default flip (per memory: duplicating models is worst when memory-bound). Default-on at ≥N cameras is a real-hardware decision left to the user.
- Residual: a record harvested while a sibling is still spawning is dropped (re-harvests next clean frame); template accrual via `add_embedding` isn't relayed (siblings keep the initial template). Both documented in the module docstring.
- **Path B** (one shared inference-pool process over shm — escapes the GIL while bounding RAM) is documented as the future direction, not built here.

## Verification
All 5 CI gates green locally (`.venv`, offscreen env): ruff, ruff format, mypy (engine/runtime + config), pytest **1413 passed**, `--selftest`. Throughput (threaded vs process-per-camera) can now be measured headlessly with the AutoPTZ Mark benchmark (#127).

Plan: `docs/superpowers/plans/2026-06-26-process-per-camera-gil.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)