### PR TITLE
fix(center-stage): overlay boxes follow the digital crop (transform tracks/faces/pose/aim into crop space)

### DIFF
--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -624,6 +624,11 @@ class CameraWorker:
         # keeps the prior height-only sizing). Read by the Center Stage crop path.
         self._digital_target_is_group: bool = False
         self._cs_diag_t: float = 0.0  # throttle for the Center Stage diagnostic log
+        # The active Center-Stage digital crop (x, y, w, h) in full-frame pixels
+        # for the most recently framed output, or None when Center Stage is not
+        # driving the painted frame. Stamped onto each TelemetryMsg so the UI can
+        # re-normalize overlay boxes/aim into the cropped preview.
+        self._last_digital_crop_rect: tuple[int, int, int, int] | None = None
         self._detect: _DetectStack | None = None
         self._pooled_detector = False
         # True when the detector is the unified YOLO11-pose model (boxes+keypoints
@@ -3508,6 +3513,7 @@ class CameraWorker:
 
         backend = self._ptz_backend
         if not isinstance(backend, DigitalPTZBackend) or frame is None:
+            self._last_digital_crop_rect = None
             return frame
         import cv2
 
@@ -3537,6 +3543,9 @@ class CameraWorker:
             x, y, cw, ch = framer.frame_for(target, w, h, fit_width=self._digital_target_is_group)
         else:
             x, y, cw, ch = framer.full_frame(w, h)
+        # Record the crop active for THIS frame so telemetry can carry it and the
+        # UI can re-normalize overlays into the cropped preview.
+        self._last_digital_crop_rect = (int(x), int(y), int(cw), int(ch))
         nowm = time.monotonic()
         if nowm - self._cs_diag_t > 2.0:
             self._cs_diag_t = nowm
@@ -3552,6 +3561,7 @@ class CameraWorker:
             )
         crop = frame[y : y + ch, x : x + cw]
         if crop.size == 0:
+            self._last_digital_crop_rect = None
             return frame
         from autoptz.engine.pipeline.vcam import pick_interpolation
 
@@ -4992,6 +5002,7 @@ class CameraWorker:
             ep=self._ep,
             width=self._frame_w,
             height=self._frame_h,
+            digital_crop_rect=self._last_digital_crop_rect,
             dropped_frames=self._dropped_frames,
             latency_ms=self._latency_ms,
             ingest_ms=self._ingest_ms,

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -3543,9 +3543,6 @@ class CameraWorker:
             x, y, cw, ch = framer.frame_for(target, w, h, fit_width=self._digital_target_is_group)
         else:
             x, y, cw, ch = framer.full_frame(w, h)
-        # Record the crop active for THIS frame so telemetry can carry it and the
-        # UI can re-normalize overlays into the cropped preview.
-        self._last_digital_crop_rect = (int(x), int(y), int(cw), int(ch))
         nowm = time.monotonic()
         if nowm - self._cs_diag_t > 2.0:
             self._cs_diag_t = nowm
@@ -3568,7 +3565,12 @@ class CameraWorker:
         # The crop is almost always UPSCALED to the output → INTER_LINEAR looks
         # soft. Pick by scale factor: cubic up, area down, linear ~1:1.
         interp = pick_interpolation((int(crop.shape[1]), int(crop.shape[0])), (ow, oh))
-        return cv2.resize(crop, (ow, oh), interpolation=interp)
+        out = cv2.resize(crop, (ow, oh), interpolation=interp)
+        # Record the crop active for THIS frame — only AFTER a successful resize, so
+        # a resize exception leaves the rect at the last actually-painted frame. The
+        # UI re-normalizes overlays into the cropped preview using this rect.
+        self._last_digital_crop_rect = (int(x), int(y), int(cw), int(ch))
+        return out
 
     def _current_digital_target(self) -> tuple[float, float, float, float] | None:
         """The bbox (x1,y1,x2,y2) Center Stage should frame this tick, or None.

--- a/autoptz/engine/runtime/messages.py
+++ b/autoptz/engine/runtime/messages.py
@@ -183,6 +183,13 @@ class TelemetryMsg(BaseModel):
     # size) — fed to the UI's Camera Info panel.  0 until a frame is read.
     width: int = 0
     height: int = 0
+    # Active Center-Stage digital crop ``(x, y, w, h)`` in FULL-frame pixels, or
+    # None when Center Stage is not driving the painted preview this tick. The UI
+    # uses it to re-normalize overlay boxes/aim into the cropped+scaled preview
+    # so the detection/track/face/pose overlays follow the digital crop instead
+    # of floating over the full frame. None ⇒ overlays keep full-frame
+    # normalization (unchanged legacy behavior).
+    digital_crop_rect: tuple[int, int, int, int] | None = None
     # Cumulative count of frame read() misses / decode failures since start —
     # surfaced as "dropped frames" in Camera Info.
     dropped_frames: int = 0

--- a/autoptz/ui/list_models.py
+++ b/autoptz/ui/list_models.py
@@ -100,22 +100,70 @@ class CameraRecord:
             return 0.0
         return float(getattr(self.telemetry, "source_fps_cap", 0.0))
 
+    def _crop_norm(self) -> tuple[float, float, float, float] | None:
+        """Active digital-crop mapping params ``(cx, cy, cw, ch)`` in full-frame
+        pixels when Center Stage is driving the preview, else None.
+
+        When present, overlay coords normalized to the FULL frame must be
+        re-normalized into the CROPPED preview: a full-frame pixel ``px`` maps to
+        ``(px - c0) / clen`` along each axis. None ⇒ keep full-frame normalization
+        (legacy behavior, byte-identical).
+        """
+        if not self.telemetry:
+            return None
+        rect = getattr(self.telemetry, "digital_crop_rect", None)
+        if not rect:
+            return None
+        cx, cy, cw, ch = rect
+        if cw <= 0 or ch <= 0:
+            return None
+        return (float(cx), float(cy), float(cw), float(ch))
+
     def tracks_as_list(self) -> list[dict[str, Any]]:
         if not self.telemetry:
             return []
         # Detector produces pixel-space coords; the UI overlays expect normalized 0–1.
         w = max(1.0, float(self.telemetry.width or 1))
         h = max(1.0, float(self.telemetry.height or 1))
+        crop = self._crop_norm()
+        if crop is not None:
+            cx, cy, cw, ch = crop
+
+            def nx(px: float) -> float:
+                return max(0.0, min(1.0, (px - cx) / cw))
+
+            def ny(px: float) -> float:
+                return max(0.0, min(1.0, (px - cy) / ch))
+
+            def sx(dpx: float) -> float:  # delta (velocity): scale, no clamp
+                return dpx / cw
+
+            def sy(dpx: float) -> float:
+                return dpx / ch
+        else:
+
+            def nx(px: float) -> float:
+                return px / w
+
+            def ny(px: float) -> float:
+                return px / h
+
+            def sx(dpx: float) -> float:
+                return dpx / w
+
+            def sy(dpx: float) -> float:
+                return dpx / h
+
         result = []
         for t in self.telemetry.tracks:
             result.append(
                 {
                     "track_id": t.track_id,
                     "bbox": {
-                        "x1": t.bbox.x1 / w,
-                        "y1": t.bbox.y1 / h,
-                        "x2": t.bbox.x2 / w,
-                        "y2": t.bbox.y2 / h,
+                        "x1": nx(t.bbox.x1),
+                        "y1": ny(t.bbox.y1),
+                        "x2": nx(t.bbox.x2),
+                        "y2": ny(t.bbox.y2),
                     },
                     "identity": t.identity or "",
                     "identity_id": t.identity_id or "",
@@ -123,12 +171,22 @@ class CameraRecord:
                     "is_target": t.is_target,
                     "lost": bool(getattr(t, "lost", False)),
                     # Velocity normalized to frame fractions/frame for overlay drawing.
-                    "vx": getattr(t, "vx", 0.0) / w,
-                    "vy": getattr(t, "vy", 0.0) / h,
+                    "vx": sx(getattr(t, "vx", 0.0)),
+                    "vy": sy(getattr(t, "vy", 0.0)),
                     "aim": (
                         {
-                            "x": max(0.0, min(1.0, float(t.aim_x) / w)),
-                            "y": max(0.0, min(1.0, float(t.aim_y) / h)),
+                            # Aim is clamped to [0,1] in BOTH branches (legacy clamped
+                            # aim but not bbox); the crop nx/ny already clamp.
+                            "x": (
+                                nx(float(t.aim_x))
+                                if crop is not None
+                                else max(0.0, min(1.0, float(t.aim_x) / w))
+                            ),
+                            "y": (
+                                ny(float(t.aim_y))
+                                if crop is not None
+                                else max(0.0, min(1.0, float(t.aim_y) / h))
+                            ),
                             "source": t.aim_source or "",
                         }
                         if getattr(t, "aim_x", None) is not None

--- a/autoptz/ui/list_models.py
+++ b/autoptz/ui/list_models.py
@@ -203,13 +203,30 @@ class CameraRecord:
             return []
         w = max(1.0, float(self.telemetry.width or 1))
         h = max(1.0, float(self.telemetry.height or 1))
+        crop = self._crop_norm()
+        if crop is not None:
+            cx, cy, cw, ch = crop
+
+            def nx(px: float) -> float:
+                return max(0.0, min(1.0, (px - cx) / cw))
+
+            def ny(px: float) -> float:
+                return max(0.0, min(1.0, (px - cy) / ch))
+        else:
+
+            def nx(px: float) -> float:
+                return px / w
+
+            def ny(px: float) -> float:
+                return px / h
+
         return [
             {
                 "bbox": {
-                    "x1": f.bbox.x1 / w,
-                    "y1": f.bbox.y1 / h,
-                    "x2": f.bbox.x2 / w,
-                    "y2": f.bbox.y2 / h,
+                    "x1": nx(f.bbox.x1),
+                    "y1": ny(f.bbox.y1),
+                    "x2": nx(f.bbox.x2),
+                    "y2": ny(f.bbox.y2),
                 },
                 "identity": f.identity or "",
                 "score": f.score,
@@ -223,6 +240,17 @@ class CameraRecord:
             return []
         w = max(1.0, float(self.telemetry.width or 1))
         h = max(1.0, float(self.telemetry.height or 1))
+        crop = self._crop_norm()
+        if crop is not None:
+            cx, cy, cw, ch = crop
+            return [
+                {
+                    "x": max(0.0, min(1.0, (k.x - cx) / cw)),
+                    "y": max(0.0, min(1.0, (k.y - cy) / ch)),
+                    "conf": k.conf,
+                }
+                for k in getattr(self.telemetry, "pose", []) or []
+            ]
         return [
             {"x": k.x / w, "y": k.y / h, "conf": k.conf}
             for k in getattr(self.telemetry, "pose", []) or []

--- a/tests/test_camera_worker_framing.py
+++ b/tests/test_camera_worker_framing.py
@@ -1,0 +1,58 @@
+"""CameraWorker Center-Stage crop-rect telemetry wiring.
+
+Verifies _framed_output records the active digital crop into
+_last_digital_crop_rect (and clears it when Center Stage is inactive), and that
+the rect is carried on the emitted TelemetryMsg.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _bare_worker():
+    """A CameraWorker instance with only the attributes _framed_output touches,
+    built without running the capture thread (we never call .start())."""
+    from autoptz.config.models import CameraConfig
+    from autoptz.engine.camera_worker import CameraWorker
+
+    cfg = CameraConfig(id="cam-fr", name="Cam FR")
+    return CameraWorker("cam-fr", cfg, on_telemetry=lambda m: None)
+
+
+def test_framed_output_records_none_without_digital_backend() -> None:
+    w = _bare_worker()
+    w._ptz_backend = None  # no Center Stage
+    w._last_digital_crop_rect = (1, 2, 3, 4)  # stale value must be cleared
+    frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+    out = w._framed_output(frame)
+    assert out is frame  # passthrough unchanged
+    assert w._last_digital_crop_rect is None
+
+
+def test_framed_output_records_crop_rect_when_center_stage_active() -> None:
+    from autoptz.engine.ptz.digital import DigitalPTZBackend
+
+    w = _bare_worker()
+    w._ptz_backend = DigitalPTZBackend()  # digital crop active
+    # No target locked → framer eases toward the full frame on the first tick,
+    # but _framed_output STILL applies (crops/scales) and records a rect.
+    frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+    w._framed_output(frame)
+    rect = w._last_digital_crop_rect
+    assert rect is not None
+    x, y, cw, ch = rect
+    assert 0 <= x and 0 <= y
+    assert 0 < cw <= 1920 and 0 < ch <= 1080
+
+
+def test_telemetry_carries_last_digital_crop_rect() -> None:
+    from autoptz.engine.runtime.messages import HealthState, TelemetryMsg
+
+    w = _bare_worker()
+    w._last_digital_crop_rect = (100, 50, 600, 400)
+    # The emit helper builds a TelemetryMsg; assert the field is wired through.
+    captured: list[TelemetryMsg] = []
+    w._on_telemetry = captured.append
+    w._emit_telemetry(tracks=[], health=HealthState.OK, last_error=None)
+    assert captured and captured[0].digital_crop_rect == (100, 50, 600, 400)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -114,6 +114,31 @@ class TestTelemetryMsg:
         assert restored.height == 1080
         assert restored.dropped_frames == 7
 
+    def test_digital_crop_rect_defaults_none(self) -> None:
+        msg = TelemetryMsg(camera_id="c", seq=0)
+        assert msg.digital_crop_rect is None
+
+    def test_digital_crop_rect_round_trip(self) -> None:
+        # Center Stage active: an Optional tuple must survive msgpack + pydantic.
+        msg = TelemetryMsg(
+            camera_id="c",
+            seq=1,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+        )
+        restored = TelemetryMsg.from_msgpack(msg.to_msgpack())
+        assert restored.digital_crop_rect == (100, 50, 600, 400)
+        # msgpack decodes sequences as lists; pydantic must coerce back to a
+        # 4-int tuple so the UI can unpack (cx, cy, cw, ch) directly.
+        assert isinstance(restored.digital_crop_rect, tuple)
+        assert all(isinstance(v, int) for v in restored.digital_crop_rect)
+
+    def test_digital_crop_rect_none_round_trip(self) -> None:
+        msg = TelemetryMsg(camera_id="c", seq=2)
+        restored = TelemetryMsg.from_msgpack(msg.to_msgpack())
+        assert restored.digital_crop_rect is None
+
     def test_stage_timings_default_zero(self) -> None:
         msg = TelemetryMsg(camera_id="c", seq=0)
         assert msg.face_ms == 0.0

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -545,6 +545,77 @@ class TestCameraRecord:
         # vy_norm_full = 4/1080; crop-space = (4/1080)*(1080/400) = 4/400 = 0.01
         assert t["vy"] == pytest.approx(4.0 / 400.0)
 
+    def test_faces_unchanged_without_crop_rect(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import BBox, FaceBox, TelemetryMsg
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            faces=[FaceBox(bbox=BBox(x1=220, y1=130, x2=400, y2=290), identity="A", score=0.7)],
+        )
+        b = rec.faces_as_list()[0]["bbox"]
+        assert b["x1"] == pytest.approx(220 / 1920)
+        assert b["y2"] == pytest.approx(290 / 1080)
+
+    def test_faces_mapped_into_crop_space(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import BBox, FaceBox, TelemetryMsg
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            faces=[FaceBox(bbox=BBox(x1=220, y1=130, x2=400, y2=290), identity="A", score=0.7)],
+        )
+        b = rec.faces_as_list()[0]["bbox"]
+        assert b["x1"] == pytest.approx(0.2)
+        assert b["y1"] == pytest.approx(0.2)
+        assert b["x2"] == pytest.approx(0.5)
+        assert b["y2"] == pytest.approx(0.6)
+
+    def test_pose_unchanged_without_crop_rect(self, qapp) -> None:
+        from autoptz.engine.runtime.messages import PoseKeypoint, TelemetryMsg
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            pose=[PoseKeypoint(x=310.0, y=210.0, conf=0.9)],
+        )
+        k = rec.pose_as_list()[0]
+        assert k["x"] == pytest.approx(310 / 1920)
+        assert k["y"] == pytest.approx(210 / 1080)
+        assert k["conf"] == pytest.approx(0.9)
+
+    def test_pose_mapped_into_crop_space(self, qapp) -> None:
+        # keypoint pixel (310,210) in 1920x1080, crop (100,50,600,400) → (0.35,0.4).
+        from autoptz.engine.runtime.messages import PoseKeypoint, TelemetryMsg
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            pose=[PoseKeypoint(x=310.0, y=210.0, conf=0.9)],
+        )
+        k = rec.pose_as_list()[0]
+        assert k["x"] == pytest.approx(0.35)
+        assert k["y"] == pytest.approx(0.4)
+        assert k["conf"] == pytest.approx(0.9)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CameraListModel

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -432,6 +432,119 @@ class TestCameraRecord:
         aim = rec.tracks_as_list()[0]["aim"]
         assert aim == {"x": pytest.approx(0.25), "y": pytest.approx(0.25), "source": "pose"}
 
+    def test_tracks_unchanged_without_crop_rect(self, qapp) -> None:
+        # Regression guard: digital_crop_rect=None ⇒ identical full-frame norm.
+        from autoptz.engine.runtime.messages import BBox, TelemetryMsg, TrackInfo
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            tracks=[TrackInfo(track_id=1, bbox=BBox(x1=220, y1=130, x2=400, y2=290))],
+        )
+        b = rec.tracks_as_list()[0]["bbox"]
+        assert b["x1"] == pytest.approx(220 / 1920)
+        assert b["y2"] == pytest.approx(290 / 1080)
+
+    def test_tracks_mapped_into_crop_space(self, qapp) -> None:
+        # 1920x1080 full frame, crop (x=100,y=50,w=600,h=400). A full-frame bbox
+        # at pixels (220,130)-(400,290) lands at crop-norm (0.2,0.2)-(0.5,0.6).
+        from autoptz.engine.runtime.messages import BBox, TelemetryMsg, TrackInfo
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            tracks=[TrackInfo(track_id=1, bbox=BBox(x1=220, y1=130, x2=400, y2=290))],
+        )
+        b = rec.tracks_as_list()[0]["bbox"]
+        assert b["x1"] == pytest.approx(0.2)
+        assert b["y1"] == pytest.approx(0.2)
+        assert b["x2"] == pytest.approx(0.5)
+        assert b["y2"] == pytest.approx(0.6)
+
+    def test_track_outside_crop_is_clamped(self, qapp) -> None:
+        # A bbox left of the crop maps to negative x and must clamp to 0..1.
+        from autoptz.engine.runtime.messages import BBox, TelemetryMsg, TrackInfo
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            tracks=[TrackInfo(track_id=1, bbox=BBox(x1=0, y1=0, x2=40, y2=30))],
+        )
+        b = rec.tracks_as_list()[0]["bbox"]
+        assert b["x1"] == pytest.approx(0.0)
+        assert b["x2"] == pytest.approx(0.0)  # 40px is left of crop start (100) → clamps to 0
+        assert b["y1"] == pytest.approx(0.0)
+
+    def test_track_aim_mapped_into_crop_space(self, qapp) -> None:
+        # aim pixel (310,210) in 1920x1080, crop (100,50,600,400) → (0.35, 0.4).
+        from autoptz.engine.runtime.messages import BBox, TelemetryMsg, TrackInfo
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            tracks=[
+                TrackInfo(
+                    track_id=1,
+                    bbox=BBox(x1=220, y1=130, x2=400, y2=290),
+                    is_target=True,
+                    aim_x=310,
+                    aim_y=210,
+                    aim_source="pose",
+                )
+            ],
+        )
+        aim = rec.tracks_as_list()[0]["aim"]
+        assert aim["x"] == pytest.approx(0.35)
+        assert aim["y"] == pytest.approx(0.4)
+        assert aim["source"] == "pose"
+
+    def test_track_velocity_scaled_into_crop_space(self, qapp) -> None:
+        # vx/vy are deltas: scaled by full_w/cw and full_h/ch, NOT clamped.
+        # full_w/cw = 1920/600 = 3.2 ; full_h/ch = 1080/400 = 2.7.
+        from autoptz.engine.runtime.messages import BBox, TelemetryMsg, TrackInfo
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "usb://0", "Cam")
+        rec.telemetry = TelemetryMsg(
+            camera_id="id1",
+            seq=0,
+            width=1920,
+            height=1080,
+            digital_crop_rect=(100, 50, 600, 400),
+            tracks=[
+                TrackInfo(
+                    track_id=1,
+                    bbox=BBox(x1=220, y1=130, x2=400, y2=290),
+                    vx=6.0,
+                    vy=4.0,
+                )
+            ],
+        )
+        t = rec.tracks_as_list()[0]
+        # vx_norm_full = 6/1920; crop-space = (6/1920)*(1920/600) = 6/600 = 0.01
+        assert t["vx"] == pytest.approx(6.0 / 600.0)
+        # vy_norm_full = 4/1080; crop-space = (4/1080)*(1080/400) = 4/400 = 0.01
+        assert t["vy"] == pytest.approx(4.0 / 400.0)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # CameraListModel


### PR DESCRIPTION
## Summary
Fixes Center-Stage bug #2: when Center Stage is active, the preview shows the **cropped** frame but detection/track/face/pose overlay boxes were normalized to the **full** frame, so they floated off the subject. Now the active crop rect rides on telemetry and the UI re-normalizes every overlay into crop space.

## ⚠️ Needs your visual sign-off before merge
The coordinate math is fully unit-tested, but **on-screen overlay alignment must be confirmed on a real Center-Stage camera** (per the project's test-on-real-cameras policy). I did **not** merge this — it's here for your validation.

## What's included
- `TelemetryMsg.digital_crop_rect: tuple[int,int,int,int] | None = None` (full-frame px; `None` = Center Stage inactive). msgpack/pydantic round-trip tested.
- `CameraWorker._framed_output` records the crop rect for the frame it actually paints (stamped **after** a successful resize, so a resize exception leaves the rect at the last painted frame), cleared to `None` on every non-crop path; stamped onto telemetry at the emit site.
- `CameraRecord._crop_norm()` — one shared helper used by `tracks_as_list`/`faces_as_list`/`pose_as_list` so tracks, faces, pose **and** the aim point all map identically: `x_crop=(px-cx)/cw` clamped [0,1]; velocities scaled by `1/cw,1/ch` unclamped.

## Backward-compat (verified)
When `digital_crop_rect is None` (the common non-Center-Stage path), overlay output is **byte-identical to before** — explicit `*_unchanged_without_crop_rect` regression tests plus the existing overlay tests all pass. Only the crop branch transforms.

## Verification
All 5 CI gates green locally (`.venv`, offscreen env): ruff, ruff format, mypy (engine/runtime + config), pytest **1458 passed**, `--selftest`. Exercise it with a synthetic Center-Stage camera or your real one.

Plan: `docs/superpowers/plans/2026-06-26-centerstage-box-transform.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)