### PR TITLE
fix(ui+perf): colored/resizable logs, experimental Apply feedback+restart, per-process CPU accounting

### DIFF
--- a/autoptz/engine/process_worker.py
+++ b/autoptz/engine/process_worker.py
@@ -123,6 +123,28 @@ def _safe_put(q: Any, item: Any) -> None:
         pass
 
 
+def _apply_child_thread_caps() -> None:
+    """Re-apply the supervisor's per-camera thread budget inside this child process.
+
+    A spawned child inherits the published ``AUTOPTZ_*`` / ``OMP_*`` env (so a
+    library imported here reads the cap at import), but ``cv2.setNumThreads`` and
+    ``torch.set_num_threads`` are *runtime* calls no env performs.  Without them
+    each camera process runs OpenCV/torch at cores-wide, and several of them
+    oversubscribe the CPU — the "each new process eats a lot of CPU" headroom.
+    Best-effort: a thread-cap hint must never break the child.
+    """
+    from autoptz.engine.runtime.flags import apply_opencv_thread_cap, apply_thread_caps
+
+    apply_opencv_thread_cap()
+    raw = os.environ.get("AUTOPTZ_ORT_INTRA_THREADS", "").strip()
+    if not raw:
+        return
+    try:
+        apply_thread_caps(max(1, int(raw)))
+    except ValueError:
+        pass
+
+
 def _configure_child_logging() -> None:
     """Make a child's WARNING+ logs visible to the operator (best-effort).
 
@@ -161,11 +183,11 @@ def run_camera_process(
     except Exception:  # noqa: BLE001
         pass
 
-    # Re-apply the OpenCV thread cap in this child (it inherited AUTOPTZ_CV2_THREADS
-    # from the parent but not the in-process cv2.setNumThreads call).
-    from autoptz.engine.runtime.flags import apply_opencv_thread_cap
-
-    apply_opencv_thread_cap()
+    # Re-apply the full per-camera thread budget in this child.  It inherited the
+    # supervisor's env, but the OpenCV and torch caps are *runtime* calls no env
+    # performs — so each camera process must do them itself or it imports cv2/torch
+    # at cores-wide and several of them oversubscribe the machine.
+    _apply_child_thread_caps()
 
     worker = None
     try:

--- a/autoptz/engine/runtime/diagnostics.py
+++ b/autoptz/engine/runtime/diagnostics.py
@@ -270,6 +270,14 @@ def collect_services(*, engine_running: bool, engine_ep: str) -> list[dict[str, 
 _PROC: Any | None = None
 _PRIMED = False
 
+# Child processes whose CPU/RAM belong to the app's real footprint but live outside
+# this PID: the experimental process-per-camera workers (one OS process per camera)
+# and the go2rtc helper.  ``cpu_percent`` state lives on each psutil.Process object,
+# so we cache + prime them once and reuse the SAME instances across polls — sampling
+# only the GUI PID made "App CPU" undercount badly ("not accounting for the new
+# process").  Keyed by pid; pruned as children die.
+_CHILD_PROCS: dict[int, Any] = {}
+
 # A short snapshot cache so multiple callers in the same beat share ONE sample.
 # ``psutil.cpu_percent(interval=None)`` returns the load since the *previous*
 # call, so when the status bar and the Services panel each call this on their own
@@ -290,10 +298,13 @@ _CACHE_TTL_S = 1.0
 _RUSAGE_INFO_V2 = 2
 
 
-def _app_memory_bytes(proc: Any) -> int:
-    """Honest process memory: macOS phys_footprint, else RSS.
+def _proc_memory_bytes(pid: int, proc: Any) -> int:
+    """Honest per-process memory: macOS phys_footprint for *pid*, else RSS.
 
-    *proc* is a ``psutil.Process`` used for the cross-platform RSS fallback.
+    *pid* selects which process the macOS ``proc_pid_rusage`` reads (so a child
+    camera process reports its OWN footprint, not the parent's); *proc* is a
+    ``psutil.Process`` used for the cross-platform RSS fallback and when the rusage
+    call fails (e.g. an unreadable / vanished pid).
     """
     if sys.platform == "darwin":
         try:
@@ -310,13 +321,61 @@ def _app_memory_bytes(proc: Any) -> int:
             libc = ctypes.CDLL("/usr/lib/libSystem.dylib")
             buf = _RUsageV2()
             rc = libc.proc_pid_rusage(
-                ctypes.c_int(os.getpid()), ctypes.c_int(_RUSAGE_INFO_V2), ctypes.byref(buf)
+                ctypes.c_int(int(pid)), ctypes.c_int(_RUSAGE_INFO_V2), ctypes.byref(buf)
             )
             if rc == 0:
                 return int(buf._f7)  # ri_phys_footprint
         except Exception:  # noqa: BLE001 — fall back to RSS on any failure
             pass
-    return int(proc.memory_info().rss)
+    try:
+        return int(proc.memory_info().rss)
+    except Exception:  # noqa: BLE001 — a vanished child must not break the sample
+        return 0
+
+
+def _app_tree_cpu(parent: Any) -> float:
+    """Total ``cpu_percent`` of *parent*'s tracked descendants (each read once).
+
+    Keeps :data:`_CHILD_PROCS` in sync with the live descendant set: a descendant
+    seen for the FIRST time is *primed* (its first read establishes the 0 baseline)
+    and contributes 0 this call; from the next call on it contributes real CPU —
+    exactly how the main process is primed.  Real reads always come from the cached
+    (primed) instance, because ``children()`` mints a fresh psutil.Process per call
+    and a fresh object's ``cpu_percent`` baseline would reset to ~0 every time.
+    Dead descendants are pruned.  The parent's own CPU is added by the caller.
+    """
+    try:
+        live = list(parent.children(recursive=True))  # listed ONCE per call
+    except Exception:  # noqa: BLE001 — psutil may briefly fail mid-teardown
+        return _sum_primed_cpu(list(_CHILD_PROCS.values()))
+    live_pids = {c.pid for c in live}
+    newcomers = [c for c in live if c.pid not in _CHILD_PROCS]
+
+    for pid in [p for p in _CHILD_PROCS if p not in live_pids]:
+        _CHILD_PROCS.pop(pid, None)
+
+    total = _sum_primed_cpu(list(_CHILD_PROCS.values()))
+    for child in newcomers:
+        try:
+            child.cpu_percent(interval=None)  # prime only — 0 baseline, not summed yet
+            _CHILD_PROCS[child.pid] = child
+        except Exception:  # noqa: BLE001 — child vanished between listing and priming
+            _CHILD_PROCS.pop(child.pid, None)
+    return total
+
+
+def _sum_primed_cpu(procs: list[Any]) -> float:
+    """Sum ``cpu_percent(interval=None)`` over already-primed procs, skipping any
+    that raise (a child that died between discovery and this sample)."""
+    total = 0.0
+    for proc in procs:
+        try:
+            total += float(proc.cpu_percent(interval=None))
+        except Exception:  # noqa: BLE001 — drop the vanished child from the cache
+            pid = getattr(proc, "pid", None)
+            if pid is not None:
+                _CHILD_PROCS.pop(pid, None)
+    return total
 
 
 def system_metrics() -> dict[str, Any]:
@@ -363,14 +422,18 @@ def system_metrics() -> dict[str, Any]:
         out["cpu_percent"] = round(float(psutil.cpu_percent(interval=None)), 1)
         vm = psutil.virtual_memory()
         out["mem_percent"] = round(float(vm.percent), 1)
+        # "App CPU/Mem" spans the whole app process tree, not just this PID: the
+        # experimental process-per-camera workers (and go2rtc) run in their OWN
+        # processes, so sampling only os.getpid() made App CPU read tiny while the
+        # machine was busy.  Sum the GUI process + its live descendants.
         # Process CPU can exceed 100% across cores; normalise to the whole machine.
-        out["app_cpu_percent"] = round(
-            float(_PROC.cpu_percent(interval=None)) / float(ncpu),
-            1,
-        )
+        app_cpu = float(_PROC.cpu_percent(interval=None)) + _app_tree_cpu(_PROC)
+        out["app_cpu_percent"] = round(app_cpu / float(ncpu), 1)
         # Honest "App Mem" — phys_footprint on macOS (matches Activity Monitor),
-        # not the RSS that mmap'd model files inflate.
-        app_mem = _app_memory_bytes(_PROC)
+        # not the RSS that mmap'd model files inflate — summed over the same tree.
+        app_mem = _proc_memory_bytes(_PROC.pid, _PROC)
+        for pid, child in list(_CHILD_PROCS.items()):
+            app_mem += _proc_memory_bytes(pid, child)
         out["app_rss_mb"] = round(app_mem / (1 << 20), 1)
         total = max(1, int(getattr(vm, "total", 0) or 0))
         out["app_mem_percent"] = round((float(app_mem) / float(total)) * 100.0, 1)

--- a/autoptz/ui/widgets/dialogs/experimental.py
+++ b/autoptz/ui/widgets/dialogs/experimental.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QScrollArea,
     QVBoxLayout,
     QWidget,
@@ -122,12 +123,15 @@ class ExperimentalFeaturesDialog(QDialog):
             "Restore defaults", QDialogButtonBox.ButtonRole.ResetRole
         )
         close_btn = buttons.addButton("Close", QDialogButtonBox.ButtonRole.RejectRole)
-        self._apply_btn.clicked.connect(self._apply)
+        self._apply_btn.clicked.connect(self._on_apply)
         self._restore_btn.clicked.connect(self._restore_defaults)
         close_btn.clicked.connect(self.reject)
         outer.addWidget(buttons)
 
         self._load()
+        # Baseline for "did the user change anything since this was last applied?"
+        # — drives whether Apply offers a restart (no nag when nothing changed).
+        self._applied_snapshot = self._collect()
 
     # ── row builders ─────────────────────────────────────────────────────────
 
@@ -212,7 +216,71 @@ class ExperimentalFeaturesDialog(QDialog):
         return out
 
     def _apply(self) -> None:
+        """Persist the current selection.  Pure — no UI side effects (callers/tests
+        rely on this), the visible feedback + restart prompt live in `_on_apply`."""
         _safe(lambda: self._client.setSetting("experimental_features", self._collect()), None)
+
+    def _on_apply(self) -> None:
+        """Apply button handler: persist, acknowledge the click, then — only if the
+        user actually changed something since the last apply — offer a restart."""
+        new = self._collect()
+        changed = new != self._applied_snapshot
+        self._apply()
+        self._applied_snapshot = new
+        self._flash_applied()
+        if changed and self._confirm_restart():
+            self._do_restart()
+
+    def _flash_applied(self) -> None:
+        """Briefly show "Applied ✓" on the button so the click reads as effective."""
+        self._apply_btn.setText("Applied ✓")
+        self._apply_btn.setEnabled(False)
+        QTimer.singleShot(1500, self._reset_apply_button)
+
+    def _reset_apply_button(self) -> None:
+        self._apply_btn.setText("Apply")
+        self._apply_btn.setEnabled(True)
+
+    def _confirm_restart(self) -> bool:
+        """Ask the operator whether to restart the app now.  Returns True for yes.
+
+        Isolated (and overridden in tests) so the rest of the Apply flow stays
+        free of a blocking modal.
+        """
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Information)
+        box.setWindowTitle("Restart required")
+        box.setText("Experimental settings saved.")
+        box.setInformativeText(
+            "AutoPTZ needs to restart for these changes to take effect. Restart now?"
+        )
+        restart_btn = box.addButton("Restart Now", QMessageBox.ButtonRole.AcceptRole)
+        box.addButton("Later", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(restart_btn)
+        box.exec()
+        return box.clickedButton() is restart_btn
+
+    def _do_restart(self) -> None:
+        """Relaunch the application so every flag is re-read from a clean process.
+
+        A full relaunch (not just an engine restart) is the honest apply: several
+        flags bind library thread pools / env at *import* time, which only a fresh
+        process resets.  Isolated (and overridden in tests) so it never fires there.
+        """
+        import sys
+
+        from PySide6.QtCore import QCoreApplication, QProcess
+
+        self.accept()
+        if getattr(sys, "frozen", False):
+            program, args = sys.executable, sys.argv[1:]
+        else:
+            program, args = sys.executable, ["-m", "autoptz", *sys.argv[1:]]
+        try:
+            QProcess.startDetached(program, args)
+        except Exception:  # noqa: BLE001 — relaunch is best-effort; still quit so the
+            log.warning("relaunch spawn failed; quitting anyway", exc_info=True)
+        QTimer.singleShot(0, QCoreApplication.quit)
 
     def _restore_defaults(self) -> None:
         for flag in EXPERIMENTAL_FLAGS:
@@ -224,3 +292,4 @@ class ExperimentalFeaturesDialog(QDialog):
         for name, _label, _desc, default in TRACKING_DEFAULT_FIELDS:
             self._tracking_boxes[name].setChecked(bool(default))
         self._apply()
+        self._applied_snapshot = self._collect()

--- a/autoptz/ui/widgets/logs_panel.py
+++ b/autoptz/ui/widgets/logs_panel.py
@@ -14,7 +14,7 @@ import re
 from typing import Any
 
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt
-from PySide6.QtGui import QColor, QKeySequence, QPainter, QShortcut
+from PySide6.QtGui import QColor, QKeySequence, QPainter, QPalette, QShortcut
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -25,6 +25,8 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMenu,
     QPushButton,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
     QTableView,
     QVBoxLayout,
     QWidget,
@@ -195,6 +197,28 @@ class LogTableModel(QAbstractTableModel):
         self.endResetModel()
 
 
+class LogItemDelegate(QStyledItemDelegate):
+    """Paint each cell in its model ``ForegroundRole`` color.
+
+    Qt's style-sheet engine treats ``QTableView::item { color: … }`` as an
+    *override* of the model's per-row :data:`Qt.ForegroundRole`, so the moment the
+    panel set a flat item color for theming, every log line rendered monochrome —
+    the per-level (red/amber) and per-camera tints never reached the screen.
+
+    Copying the role into the style option's palette here colors the text through
+    the painter instead of the stylesheet, so it survives the view's stylesheet
+    and shows whether or not the row is selected (``Text`` for normal rows,
+    ``HighlightedText`` for the selected one).
+    """
+
+    def initStyleOption(self, option: QStyleOptionViewItem, index: QModelIndex) -> None:  # noqa: N802
+        super().initStyleOption(option, index)
+        color = index.data(Qt.ItemDataRole.ForegroundRole)
+        if isinstance(color, QColor):
+            option.palette.setColor(QPalette.ColorRole.Text, color)
+            option.palette.setColor(QPalette.ColorRole.HighlightedText, color)
+
+
 class LogsPanel(QWidget):
     """Filterable log console bound to the shared LogListModel."""
 
@@ -281,11 +305,22 @@ class LogsPanel(QWidget):
         mono.setFamily("Menlo")
         mono.setPixelSize(11)
         self._table.setFont(mono)
+        # Per-row coloring goes through a delegate so the view stylesheet can't
+        # clobber the model's ForegroundRole (see LogItemDelegate).
+        self._table.setItemDelegate(LogItemDelegate(self._table))
         hh = self._table.horizontalHeader()
-        hh.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        hh.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
-        hh.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
-        hh.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
+        # Draggable columns: Time / Level / Logger are independently resizable;
+        # Message stretches to fill the remainder (and is resized by dragging the
+        # divider to its left).  Sections are also reorderable.
+        for col in range(4):
+            hh.setSectionResizeMode(col, QHeaderView.ResizeMode.Interactive)
+        hh.setStretchLastSection(True)
+        hh.setSectionsMovable(True)
+        # First-run widths; any persisted widths below take precedence.
+        for col, width in enumerate((96, 78, 200, 600)):
+            hh.resizeSection(col, width)
+        self._restore_column_widths()
+        hh.sectionResized.connect(self._on_section_resized)
         root.addWidget(self._table, 1)
 
         self._proxy.rowsInserted.connect(self._on_rows)
@@ -298,17 +333,16 @@ class LogsPanel(QWidget):
         """Repaint the log table and force empty viewport areas onto the theme."""
         pal = T.CURRENT
         self.setStyleSheet(f"QWidget#logsPanel {{ background-color: {pal.surface}; }}")
+        # NB: deliberately no ``QTableView::item { color }`` rule — pinning a flat
+        # item foreground here overrides the model's per-row ForegroundRole and the
+        # whole console renders monochrome.  Row colors come from LogItemDelegate;
+        # cell/selection backgrounds come from the base view rule below (Qt's
+        # default item painting, which honors selection-background-color).
         self._table.setStyleSheet(
             f"QTableView {{ background-color: {pal.surface};"
             f" border: 1px solid {pal.border}; gridline-color: {pal.border};"
-            f" selection-background-color: {T.SELECTION}; selection-color: {pal.text};"
+            f" selection-background-color: {T.SELECTION};"
             f" outline: none; }}"
-            f"QTableView::item {{ background-color: {pal.surface}; color: {pal.text}; }}"
-            # A per-item background overrides selection-background-color, so selected
-            # rows looked unselected (the "selection does nothing" bug) — restate the
-            # highlight explicitly for :selected so a click/drag is actually visible.
-            f"QTableView::item:selected {{ background-color: {T.SELECTION};"
-            f" color: {pal.text}; }}"
         )
         self._table.viewport().setStyleSheet(f"background-color: {pal.surface};")
         self._table.viewport().update()
@@ -331,6 +365,40 @@ class LogsPanel(QWidget):
         self._autoscroll_btn.setText(f"Autoscroll: {'On' if on else 'Off'}")
         if on:
             self._table.scrollToBottom()
+
+    # ── column-width persistence ─────────────────────────────────────────────────
+
+    def _restore_column_widths(self) -> None:
+        """Apply persisted Time/Level/Logger widths (Message stretches to fill)."""
+        self._restoring_columns = True
+        try:
+            try:
+                saved = self._client.getSetting("logs_columns", {}) or {}
+            except Exception:  # noqa: BLE001 — bad/absent settings → keep defaults
+                saved = {}
+            if isinstance(saved, dict):
+                hh = self._table.horizontalHeader()
+                for key, width in saved.items():
+                    try:
+                        col, w = int(key), int(width)
+                    except (TypeError, ValueError):
+                        continue
+                    if 0 <= col < 3 and w > 0:
+                        hh.resizeSection(col, w)
+        finally:
+            self._restoring_columns = False
+
+    def _on_section_resized(self, index: int, _old: int, new: int) -> None:
+        """Persist a user drag of a Time/Level/Logger column (Message is derived)."""
+        if getattr(self, "_restoring_columns", False) or not (0 <= index < 3):
+            return
+        try:
+            saved = self._client.getSetting("logs_columns", {}) or {}
+            saved = dict(saved) if isinstance(saved, dict) else {}
+            saved[str(index)] = int(new)
+            self._client.setSetting("logs_columns", saved)
+        except Exception:  # noqa: BLE001 — persistence is best-effort
+            log.debug("persist log column width failed", exc_info=True)
 
     def _on_rows(self, *_args: Any) -> None:
         if self._autoscroll:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -260,23 +260,168 @@ class TestSystemMetricsShape:
         # RSS. Feed a FAKE proc with a fixed RSS so the fallback is deterministic —
         # a live process's RSS churns between two reads, which made the old
         # `mem == rss` assertion flaky on non-macOS CI.
+        import os
         import sys
         import types
 
-        from autoptz.engine.runtime.diagnostics import _app_memory_bytes
+        from autoptz.engine.runtime.diagnostics import _proc_memory_bytes
 
         sentinel_rss = 7_000_000_003  # implausible exact value
         fake = types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=sentinel_rss))
 
-        mem = _app_memory_bytes(fake)
+        # Pass THIS process's pid: macOS reads its real phys_footprint for that pid.
+        mem = _proc_memory_bytes(os.getpid(), fake)
         assert mem > 0
         if sys.platform == "darwin":
-            # macOS reads the real proc_pid_rusage phys_footprint of THIS process
-            # (ignoring the passed proc), so it must differ from the sentinel RSS.
+            # macOS reads the real proc_pid_rusage phys_footprint of the given pid,
+            # so it must differ from the sentinel RSS fallback.
             assert mem != sentinel_rss
         else:
             # Non-macOS returns the proc's RSS straight through — now exact.
             assert mem == sentinel_rss
+
+    def test_unreadable_pid_falls_back_to_rss(self) -> None:
+        # A child pid the rusage call can't read (or any non-darwin path) must fall
+        # back to the proc's RSS rather than raising or returning 0.
+        import types
+
+        from autoptz.engine.runtime.diagnostics import _proc_memory_bytes
+
+        sentinel_rss = 4_242_424_247
+        fake = types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=sentinel_rss))
+        # An obviously-invalid pid: proc_pid_rusage fails → RSS fallback on every OS.
+        mem = _proc_memory_bytes(-1, fake)
+        assert mem == sentinel_rss
+
+
+def _burn_cpu() -> None:  # pragma: no cover — runs in a spawned child
+    """Tight loop that pins one core; the parent measures whether it's counted."""
+    x = 0
+    while True:
+        x = (x * 1_000_003 + 7) % 2_147_483_647
+
+
+class TestAppProcessTreeCpu:
+    """``system_metrics`` must count child processes (process-per-camera workers,
+    go2rtc) in App CPU/Mem — the GUI PID alone undercounts badly once cameras run
+    in their own processes ('not accounting for the new process')."""
+
+    def _reset(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        for name, val in (
+            ("_PROC", None),
+            ("_PRIMED", False),
+            ("_CHILD_PROCS", {}),
+            ("_CACHE", None),
+            ("_CACHE_T", 0.0),
+        ):
+            monkeypatch.setattr(diag, name, val)
+
+    def test_tree_cpu_primes_newcomers_then_counts_them(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_CHILD_PROCS", {})
+
+        class FakeChild:
+            def __init__(self, pid: int, value: float) -> None:
+                self.pid, self.value, self.calls = pid, value, 0
+
+            def cpu_percent(self, interval=None):  # noqa: ANN001
+                self.calls += 1
+                return self.value
+
+        child = FakeChild(101, 40.0)
+
+        class FakeParent:
+            def children(self, recursive=False):  # noqa: ANN001
+                return [child]
+
+        parent = FakeParent()
+        # First sight → primed only (0 baseline), contributes nothing this round.
+        assert diag._app_tree_cpu(parent) == 0.0
+        # Known on the next round → its real CPU is counted.
+        assert diag._app_tree_cpu(parent) == 40.0
+        assert child.calls == 2
+
+    def test_tree_cpu_reads_the_primed_instance_across_calls(self, monkeypatch) -> None:
+        # children() hands back a FRESH Process object each call (like psutil); the
+        # real read must come from the cached/primed instance, not the fresh one —
+        # else the cpu_percent baseline resets every call and CPU reads as ~0.
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_CHILD_PROCS", {})
+
+        class FakeChild:
+            def __init__(self, pid: int, value: float) -> None:
+                self.pid, self.value, self.calls = pid, value, 0
+
+            def cpu_percent(self, interval=None):  # noqa: ANN001
+                self.calls += 1
+                return self.value
+
+        primed = FakeChild(101, 33.0)
+        fresh = FakeChild(101, 999.0)
+        batches = iter([[primed], [fresh]])
+
+        class FakeParent:
+            def children(self, recursive=False):  # noqa: ANN001
+                return next(batches)
+
+        parent = FakeParent()
+        assert diag._app_tree_cpu(parent) == 0.0  # primes `primed`
+        assert diag._app_tree_cpu(parent) == 33.0  # reads cached `primed`, not `fresh`
+        assert primed.calls == 2
+        assert fresh.calls == 0  # the fresh duplicate-pid object is never sampled
+
+    def test_tree_cpu_drops_dead_children(self, monkeypatch) -> None:
+        from autoptz.engine.runtime import diagnostics as diag
+
+        monkeypatch.setattr(diag, "_CHILD_PROCS", {})
+
+        class FakeChild:
+            def __init__(self, pid: int) -> None:
+                self.pid = pid
+
+            def cpu_percent(self, interval=None):  # noqa: ANN001
+                return 50.0
+
+        child = FakeChild(7)
+        batches = iter([[child], []])
+
+        class FakeParent:
+            def children(self, recursive=False):  # noqa: ANN001
+                return next(batches)
+
+        parent = FakeParent()
+        diag._app_tree_cpu(parent)  # track + prime pid 7
+        assert 7 in diag._CHILD_PROCS
+        diag._app_tree_cpu(parent)  # pid 7 gone → pruned
+        assert 7 not in diag._CHILD_PROCS
+
+    def test_app_cpu_percent_counts_a_busy_child(self, monkeypatch) -> None:
+        import multiprocessing as mp
+        import time
+
+        psutil = pytest.importorskip("psutil")
+        from autoptz.engine.runtime import diagnostics as diag
+
+        self._reset(monkeypatch)
+        ncpu = psutil.cpu_count(logical=True) or 1
+        one_core_share = 100.0 / ncpu
+
+        proc = mp.get_context().Process(target=_burn_cpu, daemon=True)
+        proc.start()
+        try:
+            diag.system_metrics()  # prime main + discover/prime the child (child → 0)
+            time.sleep(1.2)  # exceed the 1 s cache TTL; let the child pin a core
+            metrics = diag.system_metrics()  # recompute → child CPU now included
+            assert metrics["available"]
+            # Without the fix the parent is idle (~0%); with it, ≈ one core's share.
+            assert metrics["app_cpu_percent"] > 0.4 * one_core_share, metrics["app_cpu_percent"]
+        finally:
+            proc.terminate()
+            proc.join(timeout=5)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_experimental_dialog.py
+++ b/tests/test_experimental_dialog.py
@@ -1,0 +1,120 @@
+"""ExperimentalFeaturesDialog (offscreen): Apply gives visible feedback and then
+offers an application restart — but only when something actually changed, and
+never as a blocking modal in tests (the restart prompt + relaunch are injectable).
+
+Runs in its own process (CI shards per file) so it builds a real ``QApplication``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def qtapp():
+    from PySide6.QtWidgets import QApplication
+
+    yield QApplication.instance() or QApplication([])
+
+
+def _client(settings: dict[str, Any] | None = None) -> SimpleNamespace:
+    store: dict[str, Any] = dict(settings or {})
+
+    def get_setting(key: str, default: Any = None) -> Any:
+        return store.get(key, default)
+
+    def set_setting(key: str, value: Any) -> None:
+        store[key] = value
+
+    return SimpleNamespace(getSetting=get_setting, setSetting=set_setting, _store=store)
+
+
+def _dialog(client: SimpleNamespace):
+    """Build the dialog with restart prompt + relaunch stubbed (no modal, no exec)."""
+    from autoptz.ui.widgets.dialogs.experimental import ExperimentalFeaturesDialog
+
+    dlg = ExperimentalFeaturesDialog(client)
+    calls: dict[str, int] = {"confirm": 0, "restart": 0}
+    dlg._confirm_restart = lambda: (calls.__setitem__("confirm", calls["confirm"] + 1), False)[1]
+    dlg._do_restart = lambda: calls.__setitem__("restart", calls["restart"] + 1)
+    return dlg, calls
+
+
+def test_apply_persists_selection(qtapp) -> None:
+    client = _client()
+    dlg, _ = _dialog(client)
+    dlg._bool_boxes["AUTOPTZ_UNIFIED_POSE"].setChecked(True)
+    dlg._on_apply()
+    saved = client.getSetting("experimental_features", {})
+    assert saved.get("AUTOPTZ_UNIFIED_POSE") == "1"
+    dlg.close()
+
+
+def test_apply_shows_visible_feedback(qtapp) -> None:
+    """The Apply button must visibly acknowledge the click ("Applied")."""
+    client = _client()
+    dlg, _ = _dialog(client)
+    assert dlg._apply_btn.text() == "Apply"
+    dlg._bool_boxes["AUTOPTZ_PTZ_PUMP"].setChecked(True)
+    dlg._on_apply()
+    assert "Applied" in dlg._apply_btn.text()
+    dlg.close()
+
+
+def test_apply_offers_restart_when_a_flag_changed(qtapp) -> None:
+    client = _client()
+    dlg, calls = _dialog(client)
+    # Make the (stubbed) prompt say "yes, restart".
+    dlg._confirm_restart = lambda: (calls.__setitem__("confirm", calls["confirm"] + 1), True)[1]
+    dlg._bool_boxes["AUTOPTZ_PTZ_PUMP"].setChecked(True)
+    dlg._on_apply()
+    assert calls["confirm"] == 1, "restart was not offered after a real change"
+    assert calls["restart"] == 1, "confirming restart did not trigger the relaunch"
+    dlg.close()
+
+
+def test_apply_with_no_change_does_not_nag_for_restart(qtapp) -> None:
+    """Clicking Apply without touching anything must not prompt for a restart."""
+    client = _client()
+    dlg, calls = _dialog(client)
+    dlg._on_apply()
+    assert calls["confirm"] == 0
+    assert calls["restart"] == 0
+    dlg.close()
+
+
+def test_second_apply_without_new_change_does_not_reoffer(qtapp) -> None:
+    """After applying a change, applying again with no further change is quiet."""
+    client = _client()
+    dlg, calls = _dialog(client)
+    dlg._bool_boxes["AUTOPTZ_UNIFIED_POSE"].setChecked(True)
+    dlg._on_apply()
+    first = calls["confirm"]
+    dlg._on_apply()  # nothing changed since the last apply
+    assert calls["confirm"] == first
+    dlg.close()
+
+
+def test_apply_button_click_runs_the_apply_flow(qtapp) -> None:
+    """The real Apply button must be wired to the new flow (feedback + persist)."""
+    client = _client()
+    dlg, _ = _dialog(client)
+    dlg._bool_boxes["AUTOPTZ_UNIFIED_POSE"].setChecked(True)
+    dlg._apply_btn.click()
+    assert client.getSetting("experimental_features", {}).get("AUTOPTZ_UNIFIED_POSE") == "1"
+    assert "Applied" in dlg._apply_btn.text()
+    dlg.close()
+
+
+def test_legacy_apply_still_just_persists(qtapp) -> None:
+    """``_apply`` stays a pure persist (no modal) so existing callers/tests hold."""
+    client = _client()
+    dlg, calls = _dialog(client)
+    dlg._bool_boxes["AUTOPTZ_PTZ_PUMP"].setChecked(True)
+    dlg._apply()
+    assert client.getSetting("experimental_features", {}).get("AUTOPTZ_PTZ_PUMP") == "1"
+    assert calls["confirm"] == 0  # pure persist never offers a restart
+    dlg.close()

--- a/tests/test_logs_panel.py
+++ b/tests/test_logs_panel.py
@@ -1,0 +1,193 @@
+"""LogsPanel (offscreen): per-row coloring, a stylesheet that doesn't clobber it,
+and user-resizable + persisted columns.
+
+Runs in its own process (CI shards per file), so it builds a real ``QApplication``
+via a local ``qtapp`` fixture rather than the headless ``QCoreApplication`` the
+session-scoped ``qapp`` fixture provides — widgets need a GUI application object.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from PySide6.QtCore import Qt
+
+# Plain-int alias so role lookups read cleanly; importing QtCore needs no QApplication.
+_FOREGROUND = int(Qt.ItemDataRole.ForegroundRole)
+
+
+@pytest.fixture
+def qtapp():
+    from PySide6.QtWidgets import QApplication
+
+    yield QApplication.instance() or QApplication([])
+
+
+def _client(settings: dict[str, Any] | None = None) -> SimpleNamespace:
+    """A minimal EngineClient stand-in: the few slots LogsPanel calls + a settings store."""
+    store: dict[str, Any] = dict(settings or {})
+
+    def get_setting(key: str, default: Any = None) -> Any:
+        return store.get(key, default)
+
+    def set_setting(key: str, value: Any) -> None:
+        store[key] = value
+
+    return SimpleNamespace(
+        setLogLevel=lambda *_: None,
+        copyLogsToClipboard=lambda *_: None,
+        exportLogs=lambda *_: None,
+        getSetting=get_setting,
+        setSetting=set_setting,
+        _store=store,
+    )
+
+
+def _seed_model():
+    from autoptz.ui.log_bridge import LogListModel
+
+    src = LogListModel()
+    src.appendRow("ERROR", "autoptz.engine.supervisor", "boom", "00:00:01.000")
+    src.appendRow("WARNING", "autoptz.engine.camera_worker", "slow frame", "00:00:02.000")
+    src.appendRow("DEBUG", "autoptz.engine.pipeline.detect", "tick", "00:00:03.000")
+    src.appendRow("INFO", "autoptz.engine.supervisor", "started", "00:00:04.000")
+    src.appendRow(
+        "INFO", "autoptz.engine.camera_worker", "opened camera_id=abcdef123456", "00:00:05.000"
+    )
+    return src
+
+
+# ── model coloring (the data the renderer must honor) ────────────────────────
+
+
+def test_model_foreground_role_maps_levels_to_theme_colors(qtapp) -> None:
+    from PySide6.QtGui import QColor
+
+    from autoptz.ui import theme as T
+    from autoptz.ui.widgets.logs_panel import LogTableModel
+
+    model = LogTableModel(_seed_model())
+    fg = lambda r: model.data(model.index(r, 1), role=int(_FOREGROUND))  # noqa: E731
+
+    assert fg(0) == QColor(T.ERROR)
+    assert fg(1) == QColor(T.WARNING)
+    assert fg(2) == QColor(T.CURRENT.muted)  # DEBUG → muted
+    assert fg(3) == QColor(T.CURRENT.text)  # INFO → default text
+
+
+def test_model_tints_message_column_per_camera_for_normal_rows(qtapp) -> None:
+    from PySide6.QtGui import QColor
+
+    from autoptz.ui import theme as T
+    from autoptz.ui.widgets.logs_panel import LogTableModel
+
+    model = LogTableModel(_seed_model())
+    # Row 4 is an INFO row carrying a camera_id: its Message column (col 3) gets a
+    # stable per-camera tint, distinct from the plain text color.
+    msg_color = model.data(model.index(4, 3), role=int(_FOREGROUND))
+    assert isinstance(msg_color, QColor)
+    assert msg_color != QColor(T.CURRENT.text)
+    # The non-message columns of that same row stay on the level color, not the tint.
+    assert model.data(model.index(4, 1), role=int(_FOREGROUND)) == QColor(T.CURRENT.text)
+
+
+def test_warning_message_keeps_level_color_not_camera_tint(qtapp) -> None:
+    """A WARNING/ERROR must stay on its level color even with a camera_id present."""
+    from PySide6.QtGui import QColor
+
+    from autoptz.ui import theme as T
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogTableModel
+
+    src = LogListModel()
+    src.appendRow("WARNING", "autoptz.engine.camera_worker", "x camera_id=abcdef99", "00:00:01.000")
+    model = LogTableModel(src)
+    assert model.data(model.index(0, 3), role=int(_FOREGROUND)) == QColor(T.WARNING)
+
+
+# ── the actual rendering bug: a delegate must carry the color into the option ─
+
+
+def test_delegate_carries_foreground_role_into_palette(qtapp) -> None:
+    """The fix for "logs aren't colored": a delegate copies ForegroundRole into the
+    style option's palette, which the painter honors even under a view stylesheet
+    (a hardcoded ``QTableView::item { color }`` otherwise silently wins)."""
+    from PySide6.QtGui import QColor, QPalette
+    from PySide6.QtWidgets import QStyleOptionViewItem
+
+    from autoptz.ui import theme as T
+    from autoptz.ui.widgets.logs_panel import LogItemDelegate, LogTableModel
+
+    model = LogTableModel(_seed_model())
+    delegate = LogItemDelegate()
+    opt = QStyleOptionViewItem()
+    delegate.initStyleOption(opt, model.index(0, 1))  # ERROR row
+    # Both normal and selected text must carry the color so the row stays colored
+    # whether or not it's selected.
+    assert opt.palette.color(QPalette.ColorRole.Text) == QColor(T.ERROR)
+    assert opt.palette.color(QPalette.ColorRole.HighlightedText) == QColor(T.ERROR)
+
+
+def test_panel_installs_the_color_delegate(qtapp) -> None:
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogItemDelegate, LogsPanel
+
+    panel = LogsPanel(_client(), LogListModel())
+    assert isinstance(panel._table.itemDelegate(), LogItemDelegate)
+
+
+def test_table_stylesheet_does_not_pin_item_text_color(qtapp) -> None:
+    """Regression guard: a ``QTableView::item`` rule that sets ``color`` overrides
+    the per-row ForegroundRole — the exact reason the logs rendered monochrome."""
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogsPanel
+
+    panel = LogsPanel(_client(), LogListModel())
+    ss = panel._table.styleSheet()
+    # Pull out the ::item rule body (if any) and assert it pins no foreground color.
+    if "::item" in ss:
+        body = ss.split("::item", 1)[1]
+        body = body.split("}", 1)[0]
+        body = body.replace("background-color", "").replace("selection-color", "")
+        assert "color:" not in body, f"::item still pins a foreground color: {body!r}"
+
+
+# ── resizable + persisted columns ────────────────────────────────────────────
+
+
+def test_first_columns_are_user_resizable(qtapp) -> None:
+    from PySide6.QtWidgets import QHeaderView
+
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogsPanel
+
+    panel = LogsPanel(_client(), LogListModel())
+    hh = panel._table.horizontalHeader()
+    for col in (0, 1, 2):
+        assert hh.sectionResizeMode(col) == QHeaderView.ResizeMode.Interactive, (
+            f"column {col} is not draggable"
+        )
+
+
+def test_resizing_a_column_persists_its_width(qtapp) -> None:
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogsPanel
+
+    client = _client()
+    panel = LogsPanel(client, LogListModel())
+    panel._table.horizontalHeader().resizeSection(1, 123)
+    saved = client.getSetting("logs_columns", {})
+    assert saved.get("1") == 123
+
+
+def test_persisted_column_widths_are_restored_on_construct(qtapp) -> None:
+    from autoptz.ui.log_bridge import LogListModel
+    from autoptz.ui.widgets.logs_panel import LogsPanel
+
+    client = _client({"logs_columns": {"0": 140, "2": 200}})
+    panel = LogsPanel(client, LogListModel())
+    hh = panel._table.horizontalHeader()
+    assert hh.sectionSize(0) == 140
+    assert hh.sectionSize(2) == 200

--- a/tests/test_mark_window.py
+++ b/tests/test_mark_window.py
@@ -325,11 +325,18 @@ def test_theme_toggle_repaints_hud(qtapp) -> None:
 def test_panel_restyle_idempotent(qtapp) -> None:
     win = _win(qtapp)
     try:
-        # Calling _restyle repeatedly must not raise.
+        # Idempotent means *converges*, not merely "doesn't raise": _restyle sets
+        # child-widget stylesheets from the theme, so a second call with no theme
+        # change must reproduce the exact same stylesheet (no drift/accumulation).
         win._controls._restyle()
+        controls_ss = win._controls._verdict_label.styleSheet()
         win._controls._restyle()
+        assert win._controls._verdict_label.styleSheet() == controls_ss
+
         win._details._restyle()
+        details_ss = win._details._empty.styleSheet()
         win._details._restyle()
+        assert win._details._empty.styleSheet() == details_ss
     finally:
         win.deleteLater()
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -387,6 +387,10 @@ class TestCameraWorker:
         worker.update_config(_camera_config("cmdcam01abcd"))
         worker.enroll_track(7, "id-1", "Alice")
 
+        # …and they must be true no-ops on lifecycle: none may start the worker or
+        # flip it to running before start() is actually called.
+        assert worker.is_running is False
+
     def test_enroll_track_sets_pending_and_immediate_label(self, qapp) -> None:
         """Click-to-assign queues a pending enrollment and labels the box at once."""
         from autoptz.engine.camera_worker import CameraWorker

--- a/tests/test_process_worker.py
+++ b/tests/test_process_worker.py
@@ -136,6 +136,48 @@ class TestRelayIdentityLockFree:
         )
 
 
+class TestChildThreadCaps:
+    """A spawned camera child must re-apply the per-camera thread budget itself.
+
+    It inherits the supervisor's env, but ``torch.set_num_threads`` / OpenCV caps
+    are *runtime* calls no env performs — without them each camera process imports
+    torch/cv2 at cores-wide and several oversubscribe the machine (the "each new
+    process eats a lot of CPU" headroom)."""
+
+    def test_applies_inherited_budget_to_torch_and_opencv(self, monkeypatch) -> None:
+        from autoptz.engine import process_worker as pw
+        from autoptz.engine.runtime import flags
+
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            flags, "apply_opencv_thread_cap", lambda *a, **k: seen.setdefault("cv2", True)
+        )
+        monkeypatch.setattr(flags, "apply_thread_caps", lambda n: seen.__setitem__("torch", n))
+        monkeypatch.setenv("AUTOPTZ_ORT_INTRA_THREADS", "3")
+
+        pw._apply_child_thread_caps()
+
+        assert seen.get("cv2") is True
+        assert seen.get("torch") == 3
+
+    def test_skips_torch_cap_when_no_budget_published(self, monkeypatch) -> None:
+        from autoptz.engine import process_worker as pw
+        from autoptz.engine.runtime import flags
+
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            flags, "apply_opencv_thread_cap", lambda *a, **k: seen.setdefault("cv2", True)
+        )
+        monkeypatch.setattr(flags, "apply_thread_caps", lambda n: seen.__setitem__("torch", n))
+        monkeypatch.delenv("AUTOPTZ_ORT_INTRA_THREADS", raising=False)
+
+        pw._apply_child_thread_caps()
+
+        # OpenCV cap (reads its own env) still runs; the torch budget cap is skipped.
+        assert seen.get("cv2") is True
+        assert "torch" not in seen
+
+
 class TestHandleProxy:
     """The handle must serialize each supervisor method call onto the command queue
     (post-start), and buffer pre-start feature/defer config into the spec."""


### PR DESCRIPTION
Four fixes from a user report, each with tests (lint/format + CI-scope mypy clean; 96/96 test files pass per-file).

### 1. Logs render monochrome
`QTableView::item { color }` in `LogsPanel._restyle` overrode the model's per-row `ForegroundRole` (classic Qt gotcha), so per-level (red/amber) and per-camera tints never showed. Color now goes through a `LogItemDelegate` that copies `ForegroundRole` into the style-option palette (honored even under the view stylesheet); the `::item` color rule is dropped.

### 2. Log columns weren't resizable
Header was locked to `ResizeToContents`/`Stretch`. Now Time/Level/Logger are Interactive (draggable), sections are movable, and widths persist via a `logs_columns` setting.

### 3. Experimental Apply gave no feedback
Apply was a silent `setSetting`. It now flashes "Applied ✓" and, only when the selection changed, offers an application restart (full relaunch). `_apply` stays a pure persist so existing callers/tests hold.

### 4. Per-process camera CPU undercounted
`system_metrics()` sampled only the GUI PID, so process-per-camera workers (and go2rtc) weren't counted — App CPU read tiny while System CPU was high. It now sums the GUI process + its live descendants (primed/cached per pid, pruned on death). Each spawned camera child also re-applies the full thread budget (`apply_thread_caps` → torch + cv2), not just cv2, to cut per-process headroom.

Plus: hardened two tests whose names promised behavior the body never verified (`test_panel_restyle_idempotent`, `test_commands_..._noops_before_start`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)