### PR TITLE
feat(phase0): redesign instrumentation — frame-drop estimate, end-to-end latency probe, latency-aware eval harness

### DIFF
--- a/autoptz/config/models.py
+++ b/autoptz/config/models.py
@@ -309,6 +309,12 @@ class PTZConfig(BaseModel, frozen=True):
     # inference) in addition to ``lead_time_s``, so following compensates for how
     # long the pipeline actually takes on this machine, not a fixed guess.
     lead_time_auto: bool = True
+    # Phase 0b — configured estimate of the camera-motor actuation lag (ms): the
+    # delay between issuing a PTZ command and the camera physically starting to
+    # move.  Not directly observable, so it's an operator-set estimate; it's the
+    # final term of the true end-to-end lead (capture_age + command_send +
+    # actuation) and is surfaced in telemetry as ``actuation_estimate_ms``.
+    actuation_estimate_ms: float = Field(default=40.0, ge=0.0, le=1000.0)
     # Motion prediction: project the aim point forward by this many seconds using
     # the target's measured velocity, so the camera anticipates motion instead of
     # always chasing where the subject *was* (which reads as laggy following).

--- a/autoptz/engine/camera_worker.py
+++ b/autoptz/engine/camera_worker.py
@@ -225,6 +225,26 @@ def _ptz_pump_enabled() -> bool:
     )
 
 
+def _true_latency_lead_enabled() -> bool:
+    """Lead the PTZ aim by the MEASURED end-to-end latency (default OFF).
+
+    When OFF (the default — ``AUTOPTZ_TRUE_LATENCY_LEAD`` unset/0), the controller
+    is fed the legacy ``ingest+inference`` latency exactly as before (zero
+    behavior change).  When ON, it's fed the measured whole-pipeline dead time
+    (capture age + command send + configured actuation estimate).  The
+    decomposition is measured for telemetry either way; this flag only changes
+    which value steers the lead.
+    """
+    import os
+
+    return os.environ.get("AUTOPTZ_TRUE_LATENCY_LEAD", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _appearance_guarded(method: Callable) -> Callable:
     """Serialise a target/identity method under the worker's ``_appearance_lock``.
 
@@ -566,10 +586,18 @@ class CameraWorker:
         self._frame_lock = threading.Lock()
         self._latest_frame: NDArray[np.uint8] | None = None
         self._latest_frame_id = 0
+        # Phase 0b — monotonic capture timestamp of the latest frame, stamped by
+        # the capture thread under ``_frame_lock`` so the inference thread can
+        # measure how old the driving frame is when auto-control commands the
+        # camera (``capture_age_ms``).  0.0 until the first frame is captured.
+        self._latest_capture_ts = 0.0
         self._frame_ready = threading.Event()
         self._inference_start = threading.Event()
         self._inference_start.set()
         self._current_inference_frame_id = 0
+        # Capture timestamp of the frame the inference thread is currently driving
+        # from, read under ``_frame_lock`` alongside the frame.  0.0 until stamped.
+        self._current_inference_capture_ts = 0.0
         # Most recent inference output, read by the capture thread for telemetry.
         self._last_tracks: list[TrackInfo] = []
         self._last_tracks_frame_id = 0
@@ -673,6 +701,14 @@ class CameraWorker:
         # in milliseconds, published in telemetry for the live stats overlay.
         self._latency_ms = 0.0
         self._inference_ms = 0.0
+        # Phase 0b — true end-to-end latency decomposition (ms), measured each
+        # auto-control tick in _drive_ptz_auto and surfaced in telemetry.  These
+        # are measured-only by default; only when AUTOPTZ_TRUE_LATENCY_LEAD is on
+        # does ``end_to_end_ms`` actually steer the controller's lead.
+        self._true_latency_lead = _true_latency_lead_enabled()
+        self._capture_age_ms = 0.0
+        self._command_send_ms = 0.0
+        self._end_to_end_ms = 0.0
         self._ingest_ms = 0.0
         self._detect_ms = 0.0
         self._track_ms = 0.0
@@ -1401,9 +1437,26 @@ class CameraWorker:
                 ctrl.note_manual_hold()
             return
 
-        # Tell the controller how long this machine's capture+inference pipeline
-        # takes so its lead time anticipates the real delay (lead_time_auto).
-        ctrl.set_loop_latency(self._latency_ms / 1000.0)
+        # Phase 0b — measure the true end-to-end control dead time decomposition.
+        # ``capture_age_ms`` = how old the driving frame is at command time (spans
+        # ingest read + handoff wait + detect + track); ``command_send_ms`` = the
+        # PTZ transport send wall time from the controller's last real send;
+        # ``actuation_estimate_ms`` = the configured (not observable) motor lag.
+        cap_ts = self._current_inference_capture_ts
+        self._capture_age_ms = (now - cap_ts) * 1000.0 if cap_ts > 0 else 0.0
+        self._command_send_ms = float(getattr(ctrl, "last_cmd_send_ms", lambda: 0.0)())
+        actuation_ms = float(getattr(self.config.ptz, "actuation_estimate_ms", 40.0))
+        self._end_to_end_ms = self._capture_age_ms + self._command_send_ms + actuation_ms
+
+        # Tell the controller how long this machine's pipeline takes so its lead
+        # time anticipates the real delay (lead_time_auto).  DEFAULT (flag off) =
+        # the legacy ingest+inference latency, unchanged.  Only when
+        # AUTOPTZ_TRUE_LATENCY_LEAD is on do we feed the measured end-to-end dead
+        # time so the lead also covers transport + actuation.
+        if self._true_latency_lead:
+            ctrl.set_loop_latency(self._end_to_end_ms / 1000.0)
+        else:
+            ctrl.set_loop_latency(self._latency_ms / 1000.0)
 
         # Global ``tracking`` switch hard-gates auto-following: when off we never
         # drive the camera toward a target (the controller is stepped idle so it
@@ -2687,9 +2740,12 @@ class CameraWorker:
 
                         # Hand the newest frame to the inference thread (latest wins)
                         # so detection/face never gate the capture+preview rate.
+                        # Stamp the capture instant (reuse ``now``) so auto-control
+                        # can measure how old the driving frame is (capture_age_ms).
                         with self._frame_lock:
                             self._latest_frame = frame
                             self._latest_frame_id += 1
+                            self._latest_capture_ts = now
                         self._frames_captured += 1
                         self._frame_ready.set()
 
@@ -2814,6 +2870,7 @@ class CameraWorker:
                     with self._frame_lock:
                         frame = self._latest_frame
                         fid = self._latest_frame_id
+                        self._current_inference_capture_ts = self._latest_capture_ts
                     if frame is None or fid == last_id:
                         continue
                     last_id = fid
@@ -4998,6 +5055,9 @@ class CameraWorker:
         # a streaming-but-box-blind camera has no tracks.
         if last_error is None and self._infer_last_error is not None:
             last_error = self._infer_last_error
+        # Phase 0a — per-source frame-delivery telemetry (NDI-only real values;
+        # other sources return {} and fall back to the worker's own counters).
+        dm = self._delivery_metrics()
         msg = TelemetryMsg(
             camera_id=self.camera_id,
             seq=self._seq,
@@ -5013,6 +5073,15 @@ class CameraWorker:
             track_ms=self._track_ms,
             face_ms=self._face_ms,
             pose_ms=self._pose_ms,
+            capture_age_ms=self._capture_age_ms,
+            command_send_ms=self._command_send_ms,
+            actuation_estimate_ms=float(getattr(self.config.ptz, "actuation_estimate_ms", 40.0)),
+            end_to_end_ms=self._end_to_end_ms,
+            frames_delivered=int(dm.get("frames_delivered", self._frames_captured)),
+            frames_dropped_est=int(dm.get("frames_dropped_est", 0)),
+            delivered_fps=float(dm.get("delivered_fps", self._fps)),
+            source_fps=float(dm.get("source_fps", 0.0)),
+            ndi_queue_depth=int(dm.get("ndi_queue_depth", -1)),
             streaming=self._frame_w > 0,
             source_fps_cap=self._source_fps_cap(),
             target_fps=self._target_fps(),
@@ -5058,6 +5127,24 @@ class CameraWorker:
         except Exception:  # noqa: BLE001
             return 0.0
         return float(cap) if cap else 0.0
+
+    def _delivery_metrics(self) -> dict[str, float | int]:
+        """Per-source frame-delivery telemetry from the running frame source.
+
+        Empty ``{}`` when no source, no method, or it raises — the caller then
+        falls back to the worker's own frame counters (Phase 0a).
+        """
+        src = self._source
+        if src is None:
+            return {}
+        fn = getattr(src, "delivery_metrics", None)
+        if not callable(fn):
+            return {}
+        try:
+            m = fn()
+        except Exception:  # noqa: BLE001
+            return {}
+        return m if isinstance(m, dict) else {}
 
     def _ground_truth(self) -> list[GroundTruthPerson]:
         """Synthetic-scene ground truth for the AutoPTZ Mark accuracy bench.

--- a/autoptz/engine/pipeline/ingest.py
+++ b/autoptz/engine/pipeline/ingest.py
@@ -169,6 +169,23 @@ class SourceAdapter(ABC):
         with self._status_lock:
             self._status.source_fps_cap = cap
 
+    def delivery_metrics(self) -> dict[str, float | int]:
+        """Per-source frame-delivery telemetry (Phase 0a).
+
+        No-op default — only :class:`NDIAdapter` tracks real values (NDI's
+        FrameSync never signals "no new frame", so drops are *estimated* from
+        ``source_fps`` vs ``delivered_fps`` over a rolling window).  Every other
+        adapter has direct frame-miss accounting already, so it returns the
+        zero/unknown defaults here.
+        """
+        return {
+            "frames_delivered": 0,
+            "frames_dropped_est": 0,
+            "delivered_fps": 0.0,
+            "source_fps": 0.0,
+            "ndi_queue_depth": -1,
+        }
+
     # ── Public API ─────────────────────────────────────────────────────────────
 
     def start(self) -> None:
@@ -958,7 +975,32 @@ class NDIAdapter(SourceAdapter):
         # next reconnect self-heals to the universal SDK-converted path.
         self._color_format_pref = _ndi_color_format_pref()
 
+        # ── Phase 0a: per-source frame-drop + queue telemetry ─────────────────
+        # FrameSync ALWAYS hands back the latest frame (never "no new frame"), so
+        # true drops can't be read directly.  Estimate them over a rolling 1.0 s
+        # window from ``source_fps`` (advertised, or peak-delivered fallback) vs
+        # ``delivered_fps``.  Guarded by the inherited ``_status_lock``.
+        self._delivered = 0  # frames delivered this rolling window
+        self._win_t0 = 0.0  # monotonic start of the current window
+        self._win_delivered0 = 0  # cumulative delivered at window start
+        self._delivered_fps = 0.0
+        self._source_fps = 0.0
+        self._frames_dropped_est = 0  # cumulative estimated drops since (re)connect
+        self._queue_depth = -1  # SDK queue depth, -1 when the SDK exposes none
+
+    def _reset_delivery_metrics(self) -> None:
+        """Clear the rolling-window drop/queue state (on (re)connect/close)."""
+        with self._status_lock:
+            self._delivered = 0
+            self._win_t0 = 0.0
+            self._win_delivered0 = 0
+            self._delivered_fps = 0.0
+            self._source_fps = 0.0
+            self._frames_dropped_est = 0
+            self._queue_depth = -1
+
     def _open(self) -> bool:
+        self._reset_delivery_metrics()
         if not _probe_ndi():
             self._set_error("cyndilib not available — install cyndilib.")
             return False
@@ -1070,6 +1112,7 @@ class NDIAdapter(SourceAdapter):
             fourcc = _ndi_fourcc_name(vf)
             bgr = _ndi_frame_to_bgr(arr, fourcc, h, w)
             if bgr is not None:
+                self._note_delivered(vf)
                 return np.ascontiguousarray(bgr)
 
             # Unsupported native format (16-bit P216/PA16) on the fastest path:
@@ -1090,6 +1133,87 @@ class NDIAdapter(SourceAdapter):
             log.debug("camera_id=%s NDI read_frame error: %s", self.camera_id, exc)
             return None
 
+    def _note_delivered(self, vf: object) -> None:
+        """Account one delivered frame and roll the 1.0 s drop-estimate window.
+
+        ``source_fps`` prefers the source's advertised ``frame_rate_N/frame_rate_D``
+        (guarded), else falls back to the *peak* delivered fps observed so far.
+        Drops are accrued only when the source-vs-delivered shortfall exceeds half
+        a frame, so per-window jitter doesn't manufacture phantom drops.  All
+        writes are under the inherited status lock; never raises.
+        """
+        now = time.monotonic()
+        with self._status_lock:
+            self._delivered += 1
+            # Best-effort SDK queue-depth probe (almost always absent → -1).
+            # Done every delivered frame so the latest depth is always current.
+            self._queue_depth = self._probe_queue_depth()
+            if self._win_t0 <= 0.0:
+                self._win_t0 = now
+                self._win_delivered0 = self._delivered
+                return
+            dt = now - self._win_t0
+            if dt < 1.0:
+                return
+            delivered = self._delivered - self._win_delivered0
+            self._delivered_fps = delivered / dt if dt > 0 else 0.0
+
+            # Advertised source rate (guarded) → peak-delivered fallback.
+            adv = 0.0
+            try:
+                rate_n = float(getattr(vf, "frame_rate_N", 0) or 0)
+                rate_d = float(getattr(vf, "frame_rate_D", 0) or 0)
+                if rate_n > 0 and rate_d > 0:
+                    adv = rate_n / rate_d
+            except Exception:  # noqa: BLE001 — telemetry must never fail the read
+                adv = 0.0
+            if adv > 0.0:
+                self._source_fps = max(self._source_fps, adv)
+            self._source_fps = max(self._source_fps, self._delivered_fps)
+
+            expected = self._source_fps * dt
+            shortfall = expected - delivered
+            if shortfall > 0.5:
+                self._frames_dropped_est += int(round(shortfall))
+
+            # Reset the window.
+            self._win_t0 = now
+            self._win_delivered0 = self._delivered
+
+    def _probe_queue_depth(self) -> int:
+        """Best-effort SDK queue-depth probe; -1 when nothing exposes one.
+
+        cyndilib does not expose a queue/performance API, but newer SDK builds
+        or wrappers might.  Try a couple of likely accessors and swallow anything
+        that raises — this is pure telemetry and must never break the read.
+        """
+        receiver = self._receiver
+        try:
+            fn = getattr(receiver, "get_queue_depth", None)
+            if callable(fn):
+                return int(fn())
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            fs = getattr(receiver, "frame_sync", None)
+            qd = getattr(fs, "queue_depth", None)
+            if qd is not None:
+                return int(qd)
+        except Exception:  # noqa: BLE001
+            pass
+        return -1
+
+    def delivery_metrics(self) -> dict[str, float | int]:
+        """Return the tracked rolling-window delivery telemetry (Phase 0a)."""
+        with self._status_lock:
+            return {
+                "frames_delivered": int(self._delivered),
+                "frames_dropped_est": int(self._frames_dropped_est),
+                "delivered_fps": float(self._delivered_fps),
+                "source_fps": float(self._source_fps),
+                "ndi_queue_depth": int(self._queue_depth),
+            }
+
     def _close(self) -> None:
         receiver = self._receiver
         if receiver is not None:
@@ -1106,6 +1230,7 @@ class NDIAdapter(SourceAdapter):
         self._receiver = None
         self._finder = None
         self._video_frame = None
+        self._reset_delivery_metrics()
 
 
 # ── Synthetic Adapter (test / scaling, no camera or OS permission needed) ────────

--- a/autoptz/engine/ptz/controller.py
+++ b/autoptz/engine/ptz/controller.py
@@ -354,6 +354,12 @@ class PTZController:
         # as extra lead so the aim anticipates the real pipeline delay.
         self._loop_latency_s: float = 0.0
 
+        # Phase 0b — measured PTZ transport send wall time (ms) of the most recent
+        # tick that actually fired a backend ``move_velocity`` (change-suppressed
+        # ticks leave this untouched).  0.0 until the first real send.  Surfaced as
+        # ``command_send_ms`` in telemetry + fed into the true end-to-end lead.
+        self._last_cmd_send_ms: float = 0.0
+
         # last command sent (for rate-limit suppression)
         self._last_pan: float = 0.0
         self._last_tilt: float = 0.0
@@ -587,12 +593,26 @@ class PTZController:
             or abs(tilt_cmd - self._last_tilt) > 1e-4
             or abs(zoom_cmd - self._last_zoom) > 1e-4
         ):
+            # Measure the transport send wall time only when a send actually fires
+            # (change-suppression skips unchanged commands, so the prior reading
+            # holds across suppressed ticks — Phase 0b ``command_send_ms``).
+            send_t0 = time.perf_counter()
             self._backend.move_velocity(pan_cmd, tilt_cmd, zoom_cmd)
+            self._last_cmd_send_ms = (time.perf_counter() - send_t0) * 1000.0
             self._last_pan = pan_cmd
             self._last_tilt = tilt_cmd
             self._last_zoom = zoom_cmd
 
         return pan_cmd, tilt_cmd, zoom_cmd
+
+    def last_cmd_send_ms(self) -> float:
+        """Most recent measured PTZ transport send wall time (ms).
+
+        0.0 until the first real send; holds across change-suppressed ticks (a
+        tick whose command is unchanged fires no backend send, so this value is
+        not overwritten).
+        """
+        return self._last_cmd_send_ms
 
     def _heartbeat_stalled(self) -> bool:
         """True when actively driving but the producer feed has gone stale.

--- a/autoptz/engine/runtime/experimental_flags.py
+++ b/autoptz/engine/runtime/experimental_flags.py
@@ -124,6 +124,20 @@ EXPERIMENTAL_FLAGS: tuple[ExperimentalFlag, ...] = (
         restart_required=True,
     ),
     ExperimentalFlag(
+        env_key="AUTOPTZ_TRUE_LATENCY_LEAD",
+        label="True end-to-end latency lead",
+        description=(
+            "Lead the PTZ aim by the MEASURED whole-pipeline dead time (capture "
+            "age + command send + configured actuation estimate) instead of just "
+            "the ingest+inference latency. Off by default; the decomposition is "
+            "always measured for telemetry, but only steers the lead when on."
+        ),
+        default="0",
+        kind="bool",
+        choices=(),
+        restart_required=True,
+    ),
+    ExperimentalFlag(
         env_key="AUTOPTZ_NDI_COLOR_FORMAT",
         label="NDI receive color format",
         description=(

--- a/autoptz/engine/runtime/messages.py
+++ b/autoptz/engine/runtime/messages.py
@@ -227,6 +227,28 @@ class TelemetryMsg(BaseModel):
     # explains the fps cliff (e.g. capture 30 → +detection 23 → +face 19).
     face_ms: float = 0.0
     pose_ms: float = 0.0
+    # Phase 0b — true end-to-end latency decomposition (milliseconds).  Unlike
+    # ``latency_ms`` (ingest+detect+track only), these account for the WHOLE
+    # control dead time the PTZ loop actually fights: ``capture_age_ms`` is how old
+    # the driving frame is at the instant auto-control commands the camera (spans
+    # ingest read + handoff wait + detect + track), ``command_send_ms`` is the PTZ
+    # transport send wall time, ``actuation_estimate_ms`` is the configured
+    # camera‑motor lag (not directly observable), and ``end_to_end_ms`` is their
+    # sum.  Measured‑only by default; surfaced so the redesign can size the lead.
+    capture_age_ms: float = 0.0
+    command_send_ms: float = 0.0
+    actuation_estimate_ms: float = 0.0
+    end_to_end_ms: float = 0.0
+    # Phase 0a — per-source frame-delivery telemetry.  ``frames_dropped_est`` is an
+    # ESTIMATE of frames the source produced but the receiver did not deliver,
+    # computed from ``source_fps`` vs ``delivered_fps`` over a rolling window (NDI's
+    # FrameSync never signals "no new frame", so true drops can't be read directly).
+    # ``ndi_queue_depth`` is -1 when the SDK exposes no queue (the common case).
+    frames_delivered: int = 0
+    frames_dropped_est: int = 0
+    delivered_fps: float = 0.0
+    source_fps: float = 0.0
+    ndi_queue_depth: int = -1
     # True once at least one real frame has been read + pushed to the preview shm.
     # The UI gates its "No Signal" overlay on this (not on fps, which lags a full
     # second, nor on the preview Image load, which can latch on a placeholder).

--- a/autoptz/engine/worker/frame_source.py
+++ b/autoptz/engine/worker/frame_source.py
@@ -139,6 +139,20 @@ class _AdapterFrameSource:
         except Exception:  # noqa: BLE001
             return None
 
+    def delivery_metrics(self) -> dict[str, float | int]:
+        """Pass through the adapter's per-source frame-delivery telemetry.
+
+        Returns ``{}`` when the wrapped adapter predates the method (older fakes
+        in tests), so the worker can fall back to its own frame counters.
+        """
+        fn = getattr(self._adapter, "delivery_metrics", None)
+        if not callable(fn):
+            return {}
+        try:
+            return fn()
+        except Exception:  # noqa: BLE001
+            return {}
+
 
 def build_frame_source(camera_id: str, config: CameraConfig) -> FrameSource:
     """Construct the right ingest-adapter-backed FrameSource for *config*.

--- a/autoptz/ui/list_models.py
+++ b/autoptz/ui/list_models.py
@@ -100,6 +100,73 @@ class CameraRecord:
             return 0.0
         return float(getattr(self.telemetry, "source_fps_cap", 0.0))
 
+    # ── Phase 0 per-source delivery telemetry ─────────────────────────────────
+
+    @property
+    def frames_delivered(self) -> int:
+        """Cumulative frames the receiver actually delivered (0 until known)."""
+        if not self.telemetry:
+            return 0
+        return int(getattr(self.telemetry, "frames_delivered", 0))
+
+    @property
+    def frames_dropped_est(self) -> int:
+        """Estimated frames the source produced but the receiver missed."""
+        if not self.telemetry:
+            return 0
+        return int(getattr(self.telemetry, "frames_dropped_est", 0))
+
+    @property
+    def delivered_fps(self) -> float:
+        """Receiver-side delivered frame rate (0.0 until known)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "delivered_fps", 0.0))
+
+    @property
+    def source_fps(self) -> float:
+        """Source-advertised frame rate (0.0 until known)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "source_fps", 0.0))
+
+    @property
+    def ndi_queue_depth(self) -> int:
+        """Pending receive-queue depth; -1 when the source exposes no queue."""
+        if not self.telemetry:
+            return -1
+        return int(getattr(self.telemetry, "ndi_queue_depth", -1))
+
+    # ── Phase 0 end-to-end latency decomposition ──────────────────────────────
+
+    @property
+    def end_to_end_ms(self) -> float:
+        """Capture→actuation control dead time (0.0 until the probe runs)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "end_to_end_ms", 0.0))
+
+    @property
+    def capture_age_ms(self) -> float:
+        """Age of the driving frame at command time (0.0 until known)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "capture_age_ms", 0.0))
+
+    @property
+    def command_send_ms(self) -> float:
+        """PTZ transport send wall time (0.0 until known)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "command_send_ms", 0.0))
+
+    @property
+    def actuation_estimate_ms(self) -> float:
+        """Configured camera-motor actuation lag estimate (0.0 until known)."""
+        if not self.telemetry:
+            return 0.0
+        return float(getattr(self.telemetry, "actuation_estimate_ms", 0.0))
+
     def _crop_norm(self) -> tuple[float, float, float, float] | None:
         """Active digital-crop mapping params ``(cx, cy, cw, ch)`` in full-frame
         pixels when Center Stage is driving the preview, else None.

--- a/autoptz/ui/widgets/camera_info_panel.py
+++ b/autoptz/ui/widgets/camera_info_panel.py
@@ -39,6 +39,8 @@ class CameraInfoPanel(QWidget):
         self._camera_id = ""
         self._vals: dict[str, QLabel] = {}
         self._keys: list[QLabel] = []
+        # key → its caption QLabel, so conditional rows can be hidden as a pair.
+        self._key_labels: dict[str, QLabel] = {}
         # Remember the semantic color requested per value so a theme flip can
         # re-resolve palette-driven defaults without losing status colors.
         self._val_colors: dict[str, str | None] = {}
@@ -102,7 +104,18 @@ class CameraInfoPanel(QWidget):
     _GROUPS: list[tuple[str, list[str]]] = [
         ("Tracking", ["Following", "Match", "Lock", "People in view"]),
         ("Identity", ["Display name", "Source", "Address"]),
-        ("Stream", ["Resolution", "Live fps", "Health", "Dropped frames"]),
+        (
+            "Stream",
+            [
+                "Resolution",
+                "Live fps",
+                "Health",
+                "Dropped frames",
+                "Est. source drops",
+                "Delivered / source",
+                "NDI queue depth",
+            ],
+        ),
         (
             "Runtime",
             [
@@ -145,6 +158,7 @@ class CameraInfoPanel(QWidget):
                 "Face stage",
                 "Pose stage",
                 "Latency",
+                "End-to-end latency",
             ],
         ),
         ("PTZ", ["Backend"]),
@@ -200,6 +214,7 @@ class CameraInfoPanel(QWidget):
             for key in keys:
                 k = QLabel(key)
                 self._keys.append(k)
+                self._key_labels[key] = k
                 v = QLabel("—")
                 v.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
                 v.setWordWrap(True)
@@ -301,6 +316,27 @@ class CameraInfoPanel(QWidget):
         )
         self._set("Dropped frames", str(getattr(rec, "dropped_frames", 0)))
 
+        # Phase 0a per-source delivery telemetry.
+        drops_est = int(getattr(rec, "frames_dropped_est", 0) or 0)
+        self._set(
+            "Est. source drops",
+            str(drops_est),
+            color=T.WARNING if drops_est > 0 else None,
+        )
+        src_fps = float(getattr(rec, "source_fps", 0.0) or 0.0)
+        deliv_fps = float(getattr(rec, "delivered_fps", 0.0) or 0.0)
+        show_rates = src_fps > 0
+        self._set_row_visible("Delivered / source", show_rates)
+        if show_rates:
+            self._set("Delivered / source", f"{deliv_fps:.1f} / {src_fps:.1f} fps")
+        # -1 == the source exposes no queue; omit the row entirely so non-NDI /
+        # no-queue sources don't show a confusing "-1".
+        queue_depth = int(getattr(rec, "ndi_queue_depth", -1))
+        show_queue = queue_depth >= 0
+        self._set_row_visible("NDI queue depth", show_queue)
+        if show_queue:
+            self._set("NDI queue depth", str(queue_depth))
+
         target_fps = float(getattr(tel, "target_fps", 0.0) or src.get("fps", 30.0) or 30.0)
         budget_ms = float(getattr(tel, "frame_budget_ms", 0.0) or (1000.0 / max(1.0, target_fps)))
         self._set("Target fps", f"{target_fps:.0f} fps")
@@ -356,6 +392,13 @@ class CameraInfoPanel(QWidget):
         self._set("Pose stage", *_stage_text(tel, "pose", "pose_ms"))
         lat = int(getattr(rec, "latency_ms", 0) or 0)
         self._set("Latency", f"{lat} ms" if lat > 0 else "—")
+        # Phase 0b end-to-end control dead time — 0.0 until the probe runs, so
+        # hide the row entirely until there's a real measurement.
+        e2e = float(getattr(rec, "end_to_end_ms", 0.0) or 0.0)
+        show_e2e = e2e > 0
+        self._set_row_visible("End-to-end latency", show_e2e)
+        if show_e2e:
+            self._set("End-to-end latency", f"{e2e:.0f} ms")
 
         ep = (_safe(lambda: self._client.engineEp, "") or "—").replace("ExecutionProvider", "")
         self._set("Inference EP", ep)
@@ -367,6 +410,19 @@ class CameraInfoPanel(QWidget):
         lab.setText(str(value))
         self._val_colors[key] = color
         self._paint(lab, color)
+
+    def _set_row_visible(self, key: str, visible: bool) -> None:
+        """Show/hide a whole form row (its caption + value) as a pair.
+
+        Used for rows that would otherwise show a confusing sentinel (e.g. the
+        ``-1`` "no queue" NDI depth) or pure noise (zero/undriven values).
+        """
+        val = self._vals.get(key)
+        cap = self._key_labels.get(key)
+        if val is not None:
+            val.setVisible(visible)
+        if cap is not None:
+            cap.setVisible(visible)
 
     @staticmethod
     def _paint(lab: QLabel, color: str | None) -> None:

--- a/tests/latency_harness.py
+++ b/tests/latency_harness.py
@@ -1,0 +1,295 @@
+"""Latency-aware closed-loop tracking evaluation harness (headless, deterministic).
+
+Drives the *real* ``PTZController.step`` seam inside a tiny closed loop with a
+configurable feedback **dead time** (sensor/inference latency) and proves that
+tracking error and command oscillation grow as the delay grows — the way a
+real PTZ head hunts when its corrections lag the subject.
+
+Why this exists
+---------------
+The current ``PTZController`` is *reactive* (PD on the latest measured error,
+no motion prediction).  A pure-integrator plant fed a delayed error is the
+textbook recipe for dead-time-induced overshoot: the controller keeps pushing
+on stale information and overshoots, then corrects and overshoots back.  This
+harness makes that physics measurable so a later *predictive* phase can show it
+recovers the lost margin (the same tests should then degrade *less* with delay).
+
+Design
+------
+* **Controller seam** — ``PTZController.step((ex,ey),(vx,vy),h,active,t)`` returns
+  a normalized ``(pan,tilt,zoom)`` rate in ``[-1,1]``.  We only use 1-D pan.
+* **Error convention** — normalized ``(target - aim) / half_frame``; here ``aim``
+  and ``target`` already live in that normalized space (range ~``[-1,1]``), so the
+  composite error is simply ``target - aim``.
+* **Plant** — a scalar ``aim`` integrating the pan command:
+  ``aim += pan * slew_gain * dt``.  This *pure integrator* (no damping in the
+  plant) is what turns dead time into overshoot.
+* **Delay seam** — a ring/history of past composite errors; the controller is fed
+  ``e_seen = history[max(0, k-d)]`` with ``d = round(delay_ms/1000/dt)`` and a
+  finite-difference ``v_seen``.  **Scoring always uses the TRUE error**
+  ``target - aim`` for the current step, never the delayed signal.
+
+Determinism
+-----------
+Every tick is driven with an explicit ``t = k*dt`` (no wall clock), the config is
+fixed, and there is no hardware, model, or thread — so results are bit-stable.
+
+Calibration note
+----------------
+The baseline gains (``kp=0.6``, ``slew_gain=6.0``, ``rate_hz=20`` → loop
+gain/tick ≈ 0.18) are picked so the ``delay=0`` loop is *stable but not
+over-damped*: snappy enough that dead time bites.  At the spec's nominal
+``slew_gain=2.0`` (loop gain ≈ 0.06) the loop is so heavily damped that delay
+barely changes the error and the sensitivity guarantees can't hold — so the
+harness default is bumped to ``6.0`` to preserve the intended physics (more
+delay ⇒ worse tracking).  The sinusoid default ``omega`` is likewise raised
+(slow waves are nearly insensitive to a few hundred ms of lag) so that a
+realistic delay produces a measurable phase-lag growth.  The built-in predictive
+lead is disabled in the baseline cfg (``lead_time_s=0``, ``lead_time_auto=False``)
+so the harness measures the *non-predictive* controller in isolation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from autoptz.config.models import PTZConfig
+from autoptz.engine.ptz.controller import PTZController
+
+# Reuse the deterministic config builder + plant-free backend from the existing
+# synthetic-tracking fakes (no duplication of the PTZConfig defaults / MockBackend).
+from tests.synthetic_tracking import MockBackend, make_cfg
+
+__all__ = [
+    "LoopResult",
+    "baseline_cfg",
+    "make_cfg",
+    "MockBackend",
+    "step_profile",
+    "ramp_profile",
+    "sinusoid_profile",
+    "run_latency_loop",
+    "rms",
+    "steady_state_error",
+    "overshoot",
+    "settling_time",
+    "sign_flips",
+    "peak_abs_error",
+]
+
+
+# ── baseline config ─────────────────────────────────────────────────────────────
+
+
+def baseline_cfg(*, kp: float = 0.6, **kw: object) -> PTZConfig:
+    """The stable non-predictive baseline used by the harness.
+
+    A snappy reactive PD: smoothing off, oscillation guard left to the caller,
+    and every *predictive* / nonlinear feature that would mask or compensate the
+    dead-time signal disabled (built-in lead, catch-up speed boost, safe zone,
+    dead zones, slew limiter, auto zoom).  What's left is essentially
+    ``pan = shape(clamp(kp * error))`` so the latency effect is unobscured.
+    """
+    defaults: dict[str, object] = {
+        "kp": kp,
+        "aim_smoothing": 0.0,
+        "osc_guard": False,
+        "lead_time_s": 0.0,
+        "lead_time_auto": False,
+        "catch_up_speed": 0.0,
+        "safe_zone_enabled": False,
+        "deadzone_x": 0.0,
+        "deadzone_y": 0.0,
+        "max_accel": 0.0,
+        "auto_zoom": False,
+    }
+    defaults.update(kw)
+    return make_cfg(**defaults)
+
+
+# ── motion profiles (normalized-error space, range ~[-1, 1]) ─────────────────────
+
+
+def step_profile(n: int, amp: float = 0.6, t_step: int = 5) -> list[float]:
+    """A step: 0 until ``t_step``, then ``amp`` — the classic overshoot probe."""
+    return [0.0 if i < t_step else amp for i in range(n)]
+
+
+def ramp_profile(n: int, v: float = 0.04, x0: float = -0.6) -> list[float]:
+    """A constant-velocity ramp ``x0 + v*i`` (clamped to ``[-1, 1]``)."""
+    return [max(-1.0, min(1.0, x0 + v * i)) for i in range(n)]
+
+
+def sinusoid_profile(n: int, amp: float = 0.5, omega: float = 2.0, dt: float = 0.05) -> list[float]:
+    """A sine ``amp*sin(omega * i*dt)`` — phase lag from dead time shows here.
+
+    ``omega`` is in rad/s and is deliberately higher than a leisurely sweep so a
+    few hundred ms of feedback delay is a non-trivial fraction of the period (a
+    very slow wave is almost insensitive to lag).
+    """
+    return [amp * math.sin(omega * i * dt) for i in range(n)]
+
+
+# ── closed-loop result ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class LoopResult:
+    """Per-tick traces from one closed-loop run.
+
+    ``error`` is the SCORED true error ``target - aim`` (not the delayed signal);
+    ``seen`` is what the controller was actually fed (delayed); ``command`` is the
+    returned pan rate.
+    """
+
+    t: list[float] = field(default_factory=list)
+    target: list[float] = field(default_factory=list)
+    aim: list[float] = field(default_factory=list)
+    error: list[float] = field(default_factory=list)
+    seen: list[float] = field(default_factory=list)
+    command: list[float] = field(default_factory=list)
+
+
+# ── the loop ─────────────────────────────────────────────────────────────────────
+
+
+def run_latency_loop(
+    target: list[float],
+    *,
+    delay_ms: float,
+    cfg: PTZConfig | None = None,
+    rate_hz: float = 20.0,
+    slew_gain: float = 6.0,
+    subject_height: float = 0.45,
+) -> LoopResult:
+    """Run the delayed closed loop and return the per-tick traces.
+
+    The controller sees a *delayed* composite error; the plant integrates the
+    returned pan command; scoring uses the *true* error for the current tick.
+
+    Args:
+        target: per-tick setpoint in normalized-error space (range ~[-1, 1]).
+        delay_ms: feedback dead time; ``d = round(delay_ms/1000 / dt)`` ticks.
+        cfg: controller config; defaults to :func:`baseline_cfg` (kp=0.6).
+        rate_hz: control rate; ``dt = 1/rate_hz`` and ``t = k*dt`` per tick.
+        slew_gain: plant integrator gain (normalized units of aim per unit
+            command per second).
+        subject_height: fed to ``step`` (auto-zoom is off, so it's inert here).
+    """
+    if cfg is None:
+        cfg = baseline_cfg()
+
+    dt = 1.0 / rate_hz
+    d = round((delay_ms / 1000.0) / dt)
+    n = len(target)
+
+    controller = PTZController(MockBackend(), cfg, rate_hz=rate_hz)
+
+    res = LoopResult()
+    aim = 0.0
+    history: list[float] = []  # composite = target - aim, per tick
+    prev_seen = 0.0
+
+    for k in range(n):
+        tgt = target[k]
+        composite = tgt - aim  # TRUE error this tick
+        history.append(composite)
+
+        # Delay seam: feed the controller a PAST error (dead time), with a
+        # finite-difference velocity of that same delayed signal.
+        e_seen = history[max(0, k - d)]
+        v_seen = (e_seen - prev_seen) / dt
+        prev_seen = e_seen
+
+        pan, _tilt, _zoom = controller.step(
+            (e_seen, 0.0), (v_seen, 0.0), subject_height, True, k * dt
+        )
+
+        # Plant: pure integrator driven by the command.
+        aim += pan * slew_gain * dt
+
+        true_error = tgt - aim  # scored AFTER the move
+        res.t.append(k * dt)
+        res.target.append(tgt)
+        res.aim.append(aim)
+        res.error.append(true_error)
+        res.seen.append(e_seen)
+        res.command.append(pan)
+
+    return res
+
+
+# ── metrics ──────────────────────────────────────────────────────────────────────
+
+
+def rms(xs: list[float]) -> float:
+    """Root-mean-square of a sequence (0.0 for an empty sequence)."""
+    if not xs:
+        return 0.0
+    return math.sqrt(sum(x * x for x in xs) / len(xs))
+
+
+def steady_state_error(error: list[float], tail: int = 20) -> float:
+    """RMS of the last ``tail`` error samples — the residual once transients fade."""
+    if not error:
+        return 0.0
+    return rms(error[-tail:])
+
+
+def overshoot(aim: list[float], setpoint: float) -> float:
+    """How far ``aim`` overshot ``setpoint`` past it (0.0 if it never crossed).
+
+    For a positive setpoint this is ``max(aim) - setpoint`` (clamped at 0); for a
+    negative setpoint it's the symmetric ``setpoint - min(aim)``.
+    """
+    if not aim:
+        return 0.0
+    if setpoint >= 0.0:
+        return max(0.0, max(aim) - setpoint)
+    return max(0.0, setpoint - min(aim))
+
+
+def settling_time(error: list[float], dt: float, band: float = 0.05) -> float:
+    """Time (s) after which ``|error|`` stays within ``band`` for the rest of the run.
+
+    Returns ``len*dt`` (never settles) when the error re-leaves the band before the
+    end — i.e. the LAST exit from the band sets the settling instant.
+    """
+    n = len(error)
+    if n == 0:
+        return 0.0
+    last_out = -1
+    for i, e in enumerate(error):
+        if abs(e) > band:
+            last_out = i
+    if last_out < 0:
+        return 0.0  # already within band the whole time
+    if last_out >= n - 1:
+        return n * dt  # never settled
+    return (last_out + 1) * dt
+
+
+def sign_flips(command: list[float], eps: float = 1e-3) -> int:
+    """Count sign changes in a command stream, ignoring near-zero (|cmd|<eps) ticks.
+
+    A flip is counted when a non-trivial command's sign differs from the previous
+    non-trivial command's sign; sustained zero-crossing chatter ⇒ high count.
+    """
+    flips = 0
+    prev = 0
+    for c in command:
+        if abs(c) < eps:
+            continue
+        sign = 1 if c > 0.0 else -1
+        if prev != 0 and sign != prev:
+            flips += 1
+        prev = sign
+    return flips
+
+
+def peak_abs_error(error: list[float]) -> float:
+    """Largest absolute error over the run (divergence / NaN sentinel)."""
+    if not error:
+        return 0.0
+    return max(abs(x) for x in error)

--- a/tests/test_camera_info_telemetry.py
+++ b/tests/test_camera_info_telemetry.py
@@ -1,0 +1,189 @@
+"""Phase 0 per-camera telemetry: CameraRecord accessors + CameraInfoPanel rows.
+
+These exercise (1) the read-only ``@property`` accessors on ``CameraRecord`` that
+mirror the new ``TelemetryMsg`` Phase-0 fields, and (2) that ``CameraInfoPanel``
+renders the new rows, conditionally hiding the ones that would otherwise show a
+confusing sentinel (NDI queue depth ``-1``) or noise (zero/undriven values).
+
+Run offscreen so they execute in CI without a display:
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/test_camera_info_telemetry.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def qtapp():
+    from PySide6.QtWidgets import QApplication
+
+    yield QApplication.instance() or QApplication([])
+
+
+def _telemetry(camera_id: str = "cam0", **fields):
+    from autoptz.engine.runtime.messages import TelemetryMsg
+
+    return TelemetryMsg(camera_id=camera_id, seq=1, **fields)
+
+
+# ── CameraRecord accessors ────────────────────────────────────────────────────
+
+
+class TestCameraRecordPhase0:
+    def test_defaults_without_telemetry(self, qtapp) -> None:
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "ndi://x", "Cam")
+        # ndi_queue_depth must be -1 (the "no queue" sentinel) when unknown.
+        assert rec.ndi_queue_depth == -1
+        assert rec.frames_delivered == 0
+        assert rec.frames_dropped_est == 0
+        assert rec.delivered_fps == 0.0
+        assert rec.source_fps == 0.0
+        assert rec.end_to_end_ms == 0.0
+        assert rec.capture_age_ms == 0.0
+        assert rec.command_send_ms == 0.0
+        assert rec.actuation_estimate_ms == 0.0
+
+    def test_values_from_telemetry(self, qtapp) -> None:
+        from autoptz.ui.engine_client import CameraRecord
+
+        rec = CameraRecord("id1", "ndi://x", "Cam")
+        rec.telemetry = _telemetry(
+            "id1",
+            frames_delivered=900,
+            frames_dropped_est=12,
+            delivered_fps=29.5,
+            source_fps=30.0,
+            ndi_queue_depth=3,
+            capture_age_ms=40.0,
+            command_send_ms=5.0,
+            actuation_estimate_ms=80.0,
+            end_to_end_ms=125.0,
+        )
+        assert rec.frames_delivered == 900
+        assert rec.frames_dropped_est == 12
+        assert rec.delivered_fps == pytest.approx(29.5)
+        assert rec.source_fps == pytest.approx(30.0)
+        assert rec.ndi_queue_depth == 3
+        assert rec.capture_age_ms == pytest.approx(40.0)
+        assert rec.command_send_ms == pytest.approx(5.0)
+        assert rec.actuation_estimate_ms == pytest.approx(80.0)
+        assert rec.end_to_end_ms == pytest.approx(125.0)
+
+
+# ── CameraInfoPanel rows ──────────────────────────────────────────────────────
+
+
+class _Signal:
+    def connect(self, _slot) -> None:
+        pass
+
+
+class _FakeCameraModel:
+    def __init__(self, rec) -> None:
+        self._rec = rec
+
+    def get_record(self, camera_id):  # noqa: ANN001
+        return self._rec
+
+
+class _FakeClient:
+    """Minimal stand-in for EngineClient that CameraInfoPanel reads from."""
+
+    def __init__(self, rec, config) -> None:
+        self.engineRunning = True
+        self.engineEp = "CPUExecutionProvider"
+        self.cameraModel = _FakeCameraModel(rec)
+        self._config = config
+        # Signals the panel connects to in __init__.
+        self.telemetryUpdated = _Signal()
+        self.configChanged = _Signal()
+        self.engineStateChanged = _Signal()
+        # on_theme_changed() in widgets.common probes for a theme signal; a plain
+        # object without it is fine (the helper swallows the AttributeError).
+
+    def getCameraConfig(self, _camera_id):  # noqa: ANN001
+        return self._config
+
+
+def _panel_for(qtapp, telemetry):
+    from autoptz.ui.engine_client import CameraRecord
+    from autoptz.ui.widgets.camera_info_panel import CameraInfoPanel
+
+    rec = CameraRecord("cam0", "ndi://x", "Cam")
+    rec.telemetry = telemetry
+    config = {
+        "name": "Cam",
+        "source": {"type": "ndi", "address": "ndi://x"},
+        "tracking": {},
+        "ptz": {},
+    }
+    client = _FakeClient(rec, config)
+    panel = CameraInfoPanel(client)
+    panel.set_camera("cam0")
+    panel.refresh()
+    return panel
+
+
+def _text(panel, key: str) -> str:
+    return panel._vals[key].text()
+
+
+def _visible(panel, key: str) -> bool:
+    # The panel is never .show()n in tests, so isVisible() is always False
+    # (no top-level window). isHidden() reflects the *explicit* hide state set by
+    # setVisible(), which is exactly the conditional-row behaviour under test.
+    return not panel._vals[key].isHidden()
+
+
+class TestCameraInfoPanelPhase0:
+    def test_est_source_drops_row_shows_and_warns(self, qtapp) -> None:
+        from autoptz.ui import theme as T
+
+        panel = _panel_for(
+            qtapp, _telemetry(frames_dropped_est=7, source_fps=30.0, delivered_fps=28.0)
+        )
+        assert _text(panel, "Est. source drops") == "7"
+        # >0 drops paints WARNING.
+        assert panel._val_colors["Est. source drops"] == T.WARNING
+
+    def test_est_source_drops_no_warning_when_zero(self, qtapp) -> None:
+        from autoptz.ui import theme as T
+
+        panel = _panel_for(qtapp, _telemetry(frames_dropped_est=0))
+        assert _text(panel, "Est. source drops") == "0"
+        assert panel._val_colors["Est. source drops"] != T.WARNING
+
+    def test_delivered_source_row_shown_when_source_fps_positive(self, qtapp) -> None:
+        panel = _panel_for(qtapp, _telemetry(delivered_fps=28.0, source_fps=30.0))
+        assert _visible(panel, "Delivered / source") is True
+        assert _text(panel, "Delivered / source") == "28.0 / 30.0 fps"
+
+    def test_delivered_source_row_hidden_when_source_fps_zero(self, qtapp) -> None:
+        panel = _panel_for(qtapp, _telemetry(delivered_fps=0.0, source_fps=0.0))
+        assert _visible(panel, "Delivered / source") is False
+
+    def test_ndi_queue_row_hidden_when_unavailable(self, qtapp) -> None:
+        # -1 == no queue exposed; the row must NOT show a confusing "-1".
+        panel = _panel_for(qtapp, _telemetry(ndi_queue_depth=-1))
+        assert _visible(panel, "NDI queue depth") is False
+
+    def test_ndi_queue_row_shown_when_available(self, qtapp) -> None:
+        panel = _panel_for(qtapp, _telemetry(ndi_queue_depth=0))
+        assert _visible(panel, "NDI queue depth") is True
+        assert _text(panel, "NDI queue depth") == "0"
+
+        panel2 = _panel_for(qtapp, _telemetry(ndi_queue_depth=4))
+        assert _visible(panel2, "NDI queue depth") is True
+        assert _text(panel2, "NDI queue depth") == "4"
+
+    def test_end_to_end_latency_row_shown_when_probed(self, qtapp) -> None:
+        panel = _panel_for(qtapp, _telemetry(end_to_end_ms=125.4))
+        assert _visible(panel, "End-to-end latency") is True
+        assert _text(panel, "End-to-end latency") == "125 ms"
+
+    def test_end_to_end_latency_row_hidden_until_probed(self, qtapp) -> None:
+        panel = _panel_for(qtapp, _telemetry(end_to_end_ms=0.0))
+        assert _visible(panel, "End-to-end latency") is False

--- a/tests/test_experimental_flags.py
+++ b/tests/test_experimental_flags.py
@@ -44,7 +44,17 @@ def test_expected_flags_inventoried() -> None:
         "AUTOPTZ_COREML_UNITS",
         "AUTOPTZ_NDI_COLOR_FORMAT",
         "AUTOPTZ_PTZ_SERIAL_AUTOPROBE",
+        "AUTOPTZ_TRUE_LATENCY_LEAD",
     }
+
+
+def test_true_latency_lead_flag_registered() -> None:
+    flag = next(f for f in EXPERIMENTAL_FLAGS if f.env_key == "AUTOPTZ_TRUE_LATENCY_LEAD")
+    assert flag.kind == "bool"
+    assert flag.default == "0"  # default OFF → legacy latency lead
+    assert flag.restart_required is True
+    assert flag.label.strip()
+    assert flag.description.strip()
 
 
 def test_ndi_color_format_uses_real_source_values() -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -780,6 +780,137 @@ class TestNDIReadFrame:
         assert adapter._color_format_pref == "bgra"
 
 
+# ── Phase 0a: per-source frame-drop + queue telemetry ──────────────────────────
+
+
+class TestNDIDeliveryMetrics:
+    """NDIAdapter estimates source-vs-delivered drops over a rolling 1.0 s window.
+
+    FrameSync ALWAYS returns the latest frame (never "no new frame") so true
+    drops aren't directly observable — they're estimated from ``source_fps`` vs
+    ``delivered_fps`` over the window.  These tests drive a fake monotonic clock
+    and a real (non-None) frame so only the rolling-window math is exercised.
+    """
+
+    def _adapter(self, fourcc: str = "BGRA") -> NDIAdapter:
+        buf = np.full(_H * _W * 4, 128, dtype=np.uint8)  # BGRA layout
+        adapter = NDIAdapter("cam-ndi-metrics", ndi_name="SRC (CAM)")
+        adapter._color_format_pref = "fastest"
+        vf = MagicMock()
+        vf.xres = _W
+        vf.yres = _H
+        vf.get_array.return_value = buf
+        vf.get_fourcc.return_value = types.SimpleNamespace(name=fourcc)
+        adapter._video_frame = vf
+        adapter._receiver = MagicMock()
+        return adapter
+
+    def test_drop_estimate_accrues_when_delivered_below_source(self) -> None:
+        """Source advertises 30 fps but we only deliver 20 in the window → ~10 drops."""
+        adapter = self._adapter()
+        # Advertise 30 fps so source_fps > delivered_fps.
+        adapter._video_frame.frame_rate_N = 30
+        adapter._video_frame.frame_rate_D = 1
+
+        clock = {"t": 100.0}
+        with patch("autoptz.engine.pipeline.ingest.time.monotonic", lambda: clock["t"]):
+            # Deliver 20 frames, then trip the 1.0 s window boundary.
+            for _ in range(20):
+                assert adapter._read_frame() is not None
+            clock["t"] += 1.0
+            assert adapter._read_frame() is not None  # 21st delivered, window computed
+
+        m = adapter.delivery_metrics()
+        assert m["source_fps"] >= 29.0
+        assert 8 <= m["frames_dropped_est"] <= 12
+
+    def test_no_false_drops_when_keeping_up(self) -> None:
+        """Delivering at the advertised rate accrues no drops."""
+        adapter = self._adapter()
+        adapter._video_frame.frame_rate_N = 30
+        adapter._video_frame.frame_rate_D = 1
+
+        clock = {"t": 200.0}
+        with patch("autoptz.engine.pipeline.ingest.time.monotonic", lambda: clock["t"]):
+            for _ in range(30):
+                adapter._read_frame()
+            clock["t"] += 1.0
+            adapter._read_frame()
+
+        assert adapter.delivery_metrics()["frames_dropped_est"] == 0
+
+    def test_source_fps_peak_fallback_when_rate_not_advertised(self) -> None:
+        """With no advertised rate, source_fps falls back to the peak delivered fps."""
+        adapter = self._adapter()
+        # No frame_rate_N/D attributes → peak-delivered fallback only.
+        for attr in ("frame_rate_N", "frame_rate_D"):
+            if hasattr(adapter._video_frame, attr):
+                delattr(adapter._video_frame, attr)
+        adapter._video_frame.configure_mock(spec=["xres", "yres", "get_array", "get_fourcc"])
+
+        clock = {"t": 300.0}
+        with patch("autoptz.engine.pipeline.ingest.time.monotonic", lambda: clock["t"]):
+            for _ in range(25):
+                adapter._read_frame()
+            clock["t"] += 1.0
+            adapter._read_frame()
+
+        m = adapter.delivery_metrics()
+        # Peak delivered ≈ 25 fps over the 1.0 s window.
+        assert m["source_fps"] >= 24.0
+        assert m["delivered_fps"] >= 24.0
+
+    def test_queue_probe_returns_value_when_exposed(self) -> None:
+        adapter = self._adapter()
+        adapter._receiver.get_queue_depth = MagicMock(return_value=3)
+        adapter._read_frame()
+        assert adapter.delivery_metrics()["ndi_queue_depth"] == 3
+
+    def test_queue_probe_is_minus_one_when_probe_raises(self) -> None:
+        adapter = self._adapter()
+        # get_queue_depth raises and frame_sync exposes no queue_depth → -1.
+        adapter._receiver.get_queue_depth = MagicMock(side_effect=RuntimeError("boom"))
+        # Restrict frame_sync so the auto-mock doesn't fabricate a truthy
+        # ``queue_depth`` (only the capture_video the read path actually uses).
+        adapter._receiver.frame_sync = MagicMock(spec=["capture_video"])
+        adapter._read_frame()
+        assert adapter.delivery_metrics()["ndi_queue_depth"] == -1
+
+    def test_counters_reset_on_reconnect(self) -> None:
+        """_open/_close reset the rolling-window state so a reconnect starts clean."""
+        adapter = self._adapter()
+        adapter._video_frame.frame_rate_N = 30
+        adapter._video_frame.frame_rate_D = 1
+
+        clock = {"t": 400.0}
+        with patch("autoptz.engine.pipeline.ingest.time.monotonic", lambda: clock["t"]):
+            for _ in range(15):
+                adapter._read_frame()
+            clock["t"] += 1.0
+            adapter._read_frame()
+        assert adapter.delivery_metrics()["frames_delivered"] > 0
+
+        adapter._close()
+        m = adapter.delivery_metrics()
+        assert m["frames_delivered"] == 0
+        assert m["frames_dropped_est"] == 0
+        assert m["delivered_fps"] == 0.0
+
+
+class TestBaseAdapterDeliveryMetrics:
+    def test_base_adapter_returns_noop_defaults(self) -> None:
+        """A non-NDI adapter returns the no-op default delivery metrics."""
+        adapter = USBAdapter("cam-base", source=0)
+        m = adapter.delivery_metrics()
+        assert m == {
+            "frames_delivered": 0,
+            "frames_dropped_est": 0,
+            "delivered_fps": 0.0,
+            "source_fps": 0.0,
+            "ndi_queue_depth": -1,
+        }
+
+
 class TestSyntheticDrawnSceneCleanBackground:
     """The drawn ('anim') ground-truth scene must NOT paint a bundled photo behind the
     people (no zidane/bus 'picture floating around') — a plain/neutral procedural

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -114,6 +114,56 @@ class TestTelemetryMsg:
         assert restored.height == 1080
         assert restored.dropped_frames == 7
 
+    def test_delivery_metrics_default(self) -> None:
+        # Phase 0a: per-source frame-delivery telemetry. queue depth is -1
+        # ("unavailable") by default since most sources expose no SDK queue.
+        msg = TelemetryMsg(camera_id="c", seq=0)
+        assert msg.frames_delivered == 0
+        assert msg.frames_dropped_est == 0
+        assert msg.delivered_fps == 0.0
+        assert msg.source_fps == 0.0
+        assert msg.ndi_queue_depth == -1
+
+    def test_delivery_metrics_round_trip(self) -> None:
+        msg = TelemetryMsg(
+            camera_id="c",
+            seq=1,
+            frames_delivered=900,
+            frames_dropped_est=42,
+            delivered_fps=28.5,
+            source_fps=30.0,
+            ndi_queue_depth=3,
+        )
+        restored = TelemetryMsg.from_msgpack(msg.to_msgpack())
+        assert restored.frames_delivered == 900
+        assert restored.frames_dropped_est == 42
+        assert restored.delivered_fps == pytest.approx(28.5)
+        assert restored.source_fps == pytest.approx(30.0)
+        assert restored.ndi_queue_depth == 3
+
+    def test_latency_breakdown_default_zero(self) -> None:
+        # Phase 0b: true end-to-end latency decomposition.
+        msg = TelemetryMsg(camera_id="c", seq=0)
+        assert msg.capture_age_ms == 0.0
+        assert msg.command_send_ms == 0.0
+        assert msg.actuation_estimate_ms == 0.0
+        assert msg.end_to_end_ms == 0.0
+
+    def test_latency_breakdown_round_trip(self) -> None:
+        msg = TelemetryMsg(
+            camera_id="c",
+            seq=1,
+            capture_age_ms=55.0,
+            command_send_ms=7.5,
+            actuation_estimate_ms=40.0,
+            end_to_end_ms=102.5,
+        )
+        restored = TelemetryMsg.from_msgpack(msg.to_msgpack())
+        assert restored.capture_age_ms == pytest.approx(55.0)
+        assert restored.command_send_ms == pytest.approx(7.5)
+        assert restored.actuation_estimate_ms == pytest.approx(40.0)
+        assert restored.end_to_end_ms == pytest.approx(102.5)
+
     def test_digital_crop_rect_defaults_none(self) -> None:
         msg = TelemetryMsg(camera_id="c", seq=0)
         assert msg.digital_crop_rect is None

--- a/tests/test_ptz.py
+++ b/tests/test_ptz.py
@@ -1050,3 +1050,70 @@ class TestSlewRateLimit:
         high = ctrl.step((0.0, 0.0), (0.0, 0.0), 0.45, True, t=0.8)[0]  # centered now
         lower = ctrl.step((0.0, 0.0), (0.0, 0.0), 0.45, True, t=0.9)[0]
         assert 0.0 <= lower < high  # decelerating, not slamming to 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 0b — command_send_ms instrumentation (measured PTZ transport wall time)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _SlowBackend(MockBackend):
+    """MockBackend whose move_velocity blocks a fixed ms, to measure send time."""
+
+    def __init__(self, send_delay_s: float) -> None:
+        super().__init__()
+        self._send_delay_s = send_delay_s
+
+    def move_velocity(self, pan: float, tilt: float, zoom: float = 0.0) -> None:
+        time.sleep(self._send_delay_s)
+        super().move_velocity(pan, tilt, zoom)
+
+
+class TestCommandSendMs:
+    def test_send_ms_zero_before_first_send(self) -> None:
+        ctrl = PTZController(MockBackend(), _cfg(kp=0.6))
+        assert ctrl.last_cmd_send_ms() == 0.0
+
+    def test_send_ms_measured_on_a_real_send(self) -> None:
+        ctrl = PTZController(_SlowBackend(send_delay_s=0.02), _cfg(kp=0.6))
+        # First non-centered step fires move_velocity (command changed from 0).
+        ctrl.step((1.0, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        sent = ctrl.last_cmd_send_ms()
+        # Loosely gated: a real send happened and took at least a few ms.  (Timing
+        # is not asserted tightly so a loaded CI runner can't flake it.)
+        assert sent > 0.0
+
+    def test_send_ms_holds_when_command_suppressed(self) -> None:
+        """A tick whose command is unchanged does NOT fire a send → value holds."""
+        backend = _SlowBackend(send_delay_s=0.02)
+        ctrl = PTZController(backend, _cfg(kp=0.6))
+        ctrl.step((1.0, 0.0), (0.0, 0.0), 0.45, True, t=0.0)
+        first = ctrl.last_cmd_send_ms()
+        n_sends_before = len(backend.velocity_calls)
+        # Re-step with the SAME error → identical command → change-suppression skips
+        # the backend send, so last_cmd_send_ms must be untouched.
+        ctrl.step((1.0, 0.0), (0.0, 0.0), 0.45, True, t=0.05)
+        assert len(backend.velocity_calls) == n_sends_before  # suppressed
+        assert ctrl.last_cmd_send_ms() == first
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 0b — PTZConfig.actuation_estimate_ms (configured camera-motor lag)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestActuationEstimateConfig:
+    def test_default_is_forty_ms(self) -> None:
+        cfg = PTZConfig()
+        assert cfg.actuation_estimate_ms == 40.0
+
+    def test_accepts_in_range_value(self) -> None:
+        cfg = PTZConfig(actuation_estimate_ms=120.0)
+        assert cfg.actuation_estimate_ms == 120.0
+
+    def test_clamps_reject_out_of_range(self) -> None:
+        from pydantic import ValidationError
+
+        for bad in (-1.0, 1000.1):
+            with pytest.raises(ValidationError):
+                PTZConfig(actuation_estimate_ms=bad)

--- a/tests/test_synthetic_latency_eval.py
+++ b/tests/test_synthetic_latency_eval.py
@@ -1,0 +1,190 @@
+"""Latency sensitivity evaluation for the (current, non-predictive) PTZController.
+
+These tests pin the *physics* the harness is built to expose: a reactive PD on a
+delayed error, integrated by a pure-integrator plant, tracks WORSE as the
+feedback dead time grows.  The load-bearing assertion is Test B — error RMS is
+monotone non-decreasing across delay and grows by >1.5x from 0 → 300 ms.  When a
+later phase adds motion prediction, these same tests should degrade *less* with
+delay, demonstrating the fix.
+
+Run::
+
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/test_synthetic_latency_eval.py -q
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tests.latency_harness import (
+    baseline_cfg,
+    overshoot,
+    peak_abs_error,
+    ramp_profile,
+    rms,
+    run_latency_loop,
+    settling_time,
+    sign_flips,
+    sinusoid_profile,
+    steady_state_error,
+    step_profile,
+)
+
+DELAYS_MS = [0, 50, 100, 200, 300]
+RATE_HZ = 20.0
+DT = 1.0 / RATE_HZ
+N = 200
+
+# Profiles keyed by name (the sinusoid's dt must match the loop's dt).
+PROFILES = {
+    "step": lambda: step_profile(N),
+    "ramp": lambda: ramp_profile(N),
+    "sinusoid": lambda: sinusoid_profile(N, dt=DT),
+}
+
+
+def _rms_error_over_delays(profile: list[float], *, kp: float, osc_guard: bool) -> list[float]:
+    """RMS of the SCORED true error for each delay in ``DELAYS_MS``."""
+    cfg = baseline_cfg(kp=kp, osc_guard=osc_guard)
+    out: list[float] = []
+    for d in DELAYS_MS:
+        res = run_latency_loop(profile, delay_ms=d, cfg=cfg, rate_hz=RATE_HZ)
+        out.append(rms(res.error))
+    return out
+
+
+# ── Test A — the loop stays bounded for every profile × delay ────────────────────
+
+
+@pytest.mark.parametrize("profile_name", list(PROFILES))
+@pytest.mark.parametrize("delay_ms", DELAYS_MS)
+def test_loop_bounded(profile_name: str, delay_ms: int) -> None:
+    """No divergence / NaN: peak error stays small and the tail residual is bounded."""
+    profile = PROFILES[profile_name]()
+    res = run_latency_loop(profile, delay_ms=delay_ms, cfg=baseline_cfg(), rate_hz=RATE_HZ)
+
+    assert all(math.isfinite(e) for e in res.error), "error went non-finite (diverged)"
+    assert peak_abs_error(res.error) < 2.0, "peak error exceeded the divergence bound"
+    assert steady_state_error(res.error, tail=20) < 0.5, "tail residual too large"
+
+
+# ── Test B — LOAD-BEARING latency sensitivity guarantee ──────────────────────────
+
+
+@pytest.mark.parametrize("profile_name", ["step", "sinusoid"])
+def test_error_monotone_in_delay(profile_name: str) -> None:
+    """RMS error is monotone non-decreasing in delay AND rms[300] > 1.5 * rms[0].
+
+    With the oscillation guard OFF (so it can't mask the latency signal) more dead
+    time must mean more tracking error — the core premise the whole harness exists
+    to demonstrate.
+    """
+    profile = PROFILES[profile_name]()
+    rms_by_delay = _rms_error_over_delays(profile, kp=0.6, osc_guard=False)
+
+    # Monotone non-decreasing across [0, 50, 100, 200, 300] ms.
+    for lo, hi in zip(rms_by_delay, rms_by_delay[1:], strict=False):
+        assert hi >= lo - 1e-9, f"RMS error not monotone in delay: {rms_by_delay}"
+
+    # Sensitivity: 300 ms of dead time must inflate the error by >1.5x.
+    assert rms_by_delay[-1] > rms_by_delay[0] * 1.5, (
+        f"delay barely changed the error ({rms_by_delay}); harness not sensitive enough"
+    )
+
+
+# ── Test C — dead time induces command oscillation (sign flips) ──────────────────
+
+
+def test_command_oscillation_grows_with_delay() -> None:
+    """At a higher gain (kp=0.8) the step command goes from clean to hunting.
+
+    Few/no flips with no delay; many more with 300 ms of dead time.
+    """
+    profile = step_profile(N)
+    cfg = baseline_cfg(kp=0.8, osc_guard=False)
+    flips = [
+        sign_flips(run_latency_loop(profile, delay_ms=d, cfg=cfg, rate_hz=RATE_HZ).command)
+        for d in DELAYS_MS
+    ]
+
+    assert flips[0] <= 1, f"clean (delay=0) step should not hunt: {flips}"
+    assert flips[-1] > flips[0], f"delay should add command sign flips: {flips}"
+
+
+# ── Test D — step overshoot is bounded but grows with delay ──────────────────────
+
+
+def test_step_overshoot_bounded() -> None:
+    """Overshoot stays physical (<1.0) for every delay on the baseline step."""
+    profile = step_profile(N)
+    cfg = baseline_cfg(kp=0.6, osc_guard=False)
+    for d in DELAYS_MS:
+        res = run_latency_loop(profile, delay_ms=d, cfg=cfg, rate_hz=RATE_HZ)
+        ovr = overshoot(res.aim, 0.6)
+        assert ovr < 1.0, f"overshoot unphysical at delay={d}: {ovr}"
+
+
+def test_step_overshoot_grows_with_delay() -> None:
+    """Dead time makes the integrator overshoot the setpoint: 300 ms > 0 ms."""
+    profile = step_profile(N)
+    cfg = baseline_cfg(kp=0.8, osc_guard=False)
+    ov0 = overshoot(run_latency_loop(profile, delay_ms=0, cfg=cfg, rate_hz=RATE_HZ).aim, 0.6)
+    ov300 = overshoot(run_latency_loop(profile, delay_ms=300, cfg=cfg, rate_hz=RATE_HZ).aim, 0.6)
+    assert ov300 > ov0, f"overshoot did not grow with delay: {ov0} -> {ov300}"
+    assert ov300 < 1.0, f"overshoot unphysical at 300 ms: {ov300}"
+
+
+# ── Harness self-tests ───────────────────────────────────────────────────────────
+
+
+def test_zero_delay_feeds_true_error() -> None:
+    """With delay=0 the controller's SEEN error equals the TRUE composite error."""
+    profile = step_profile(N)
+    res = run_latency_loop(profile, delay_ms=0, cfg=baseline_cfg(), rate_hz=RATE_HZ)
+    # seen[k] is history[k] = target[k] - aim_before_move[k]; the true composite at
+    # tick k (before the move) is target[k] - aim[k-1]. Reconstruct and compare.
+    for k in range(N):
+        aim_before = 0.0 if k == 0 else res.aim[k - 1]
+        true_composite = res.target[k] - aim_before
+        assert res.seen[k] == pytest.approx(true_composite, abs=1e-12)
+
+
+def test_nonzero_delay_lags_true_error() -> None:
+    """A non-zero delay shifts the seen signal back by exactly ``d`` ticks."""
+    profile = sinusoid_profile(N, dt=DT)
+    res = run_latency_loop(profile, delay_ms=100, cfg=baseline_cfg(), rate_hz=RATE_HZ)
+    d = round((100 / 1000.0) / DT)
+    assert d == 2
+    # seen[k] == composite history at k-d for k >= d (and clamped to 0 before that).
+    # Composite[j] = target[j] - aim_before_move[j]; aim_before_move[j] = aim[j-1].
+    for k in range(d, N):
+        j = k - d
+        aim_before_j = 0.0 if j == 0 else res.aim[j - 1]
+        assert res.seen[k] == pytest.approx(res.target[j] - aim_before_j, abs=1e-12)
+
+
+def test_metric_helpers() -> None:
+    """Metric helpers on hand-crafted arrays."""
+    assert rms([3.0, 4.0]) == pytest.approx(3.5355339059, abs=1e-9)
+    assert rms([]) == 0.0
+    assert sign_flips([1.0, -1.0, 1.0]) == 2
+    assert sign_flips([0.5, 0.0, 0.4]) == 0  # same sign, zero ignored
+    assert sign_flips([1.0, 5e-4, -1.0]) == 1  # |cmd|<1e-3 ignored, still one flip
+    assert peak_abs_error([0.1, -0.7, 0.3]) == pytest.approx(0.7)
+    assert overshoot([0.0, 0.5, 0.7, 0.6], 0.6) == pytest.approx(0.1)
+    assert overshoot([0.0, -0.5, -0.7], -0.6) == pytest.approx(0.1)
+    assert overshoot([0.0, 0.3, 0.5], 0.6) == 0.0  # never reached setpoint
+    assert steady_state_error([1.0, 1.0, 0.0, 0.0], tail=2) == 0.0
+
+
+def test_settling_time_helper() -> None:
+    """settling_time = time after which |error| stays within band for the rest."""
+    # Error leaves the band at i=0,1 then settles from i=2 onward → 2 ticks * dt.
+    err = [0.5, 0.2, 0.01, 0.0, 0.0]
+    assert settling_time(err, DT, band=0.05) == pytest.approx(2 * DT)
+    # Within band the whole time → 0.0.
+    assert settling_time([0.01, 0.0, 0.02], DT, band=0.05) == 0.0
+    # Never settles (last sample out of band) → full duration.
+    assert settling_time([0.0, 0.0, 0.9], DT, band=0.05) == pytest.approx(3 * DT)

--- a/tests/test_worker_latency_probe.py
+++ b/tests/test_worker_latency_probe.py
@@ -1,0 +1,221 @@
+"""Phase 0 ENGINE instrumentation — worker-side wiring.
+
+Covers:
+  * Feature 0a — per-source frame-drop + queue telemetry passthrough
+    (``_AdapterFrameSource.delivery_metrics`` and the 5 ``TelemetryMsg`` fields
+    populated by ``CameraWorker._emit_telemetry``).
+  * Feature 0b — true end-to-end latency probe (capture_age / command_send /
+    actuation / end_to_end), the ``AUTOPTZ_TRUE_LATENCY_LEAD`` flag gate, and the
+    4 ``TelemetryMsg`` latency fields.
+
+No cameras, no real models — the worker is built bare (never ``.start()``ed) and
+a fake frame source / controller is injected.
+"""
+
+from __future__ import annotations
+
+import autoptz.engine.camera_worker as cw
+from autoptz.config.models import CameraConfig
+from autoptz.engine.camera_worker import CameraWorker
+from autoptz.engine.runtime.messages import HealthState, TelemetryMsg
+
+
+def _bare_worker() -> CameraWorker:
+    cfg = CameraConfig(id="cam-lp", name="Cam LP")
+    return CameraWorker("cam-lp", cfg, on_telemetry=lambda m: None)
+
+
+# ── Feature 0a: frame_source passthrough ───────────────────────────────────────
+
+
+class TestFrameSourceDeliveryPassthrough:
+    def test_passthrough_returns_adapter_metrics(self) -> None:
+        class _Adapter:
+            def delivery_metrics(self) -> dict[str, float | int]:
+                return {
+                    "frames_delivered": 7,
+                    "frames_dropped_est": 2,
+                    "delivered_fps": 28.0,
+                    "source_fps": 30.0,
+                    "ndi_queue_depth": -1,
+                }
+
+        src = cw._AdapterFrameSource(_Adapter())
+        assert src.delivery_metrics()["frames_dropped_est"] == 2
+
+    def test_passthrough_returns_empty_when_method_absent(self) -> None:
+        class _Adapter:  # no delivery_metrics
+            pass
+
+        src = cw._AdapterFrameSource(_Adapter())
+        assert src.delivery_metrics() == {}
+
+    def test_passthrough_returns_empty_when_method_raises(self) -> None:
+        class _Adapter:
+            def delivery_metrics(self) -> dict[str, float | int]:
+                raise RuntimeError("boom")
+
+        src = cw._AdapterFrameSource(_Adapter())
+        assert src.delivery_metrics() == {}
+
+
+# ── Feature 0a: _emit_telemetry populates the 5 delivery fields ─────────────────
+
+
+class _FakeDeliverySource:
+    """A frame source exposing only delivery_metrics() for telemetry tests."""
+
+    def __init__(self, metrics: dict[str, float | int]) -> None:
+        self._metrics = metrics
+
+    def delivery_metrics(self) -> dict[str, float | int]:
+        return self._metrics
+
+
+def test_emit_telemetry_includes_delivery_fields() -> None:
+    w = _bare_worker()
+    w._source = _FakeDeliverySource(
+        {
+            "frames_delivered": 123,
+            "frames_dropped_est": 9,
+            "delivered_fps": 27.5,
+            "source_fps": 30.0,
+            "ndi_queue_depth": 4,
+        }
+    )
+    captured: list[TelemetryMsg] = []
+    w._on_telemetry = captured.append
+    w._emit_telemetry(tracks=[], health=HealthState.OK, last_error=None)
+
+    assert captured
+    msg = captured[0]
+    assert msg.frames_delivered == 123
+    assert msg.frames_dropped_est == 9
+    assert msg.delivered_fps == 27.5
+    assert msg.source_fps == 30.0
+    assert msg.ndi_queue_depth == 4
+
+
+def test_emit_telemetry_falls_back_to_worker_counters() -> None:
+    """No delivery_metrics → frames_delivered falls back to _frames_captured."""
+    w = _bare_worker()
+    w._source = None  # no source → _delivery_metrics() returns {}
+    w._frames_captured = 55
+    w._fps = 24.0
+    captured: list[TelemetryMsg] = []
+    w._on_telemetry = captured.append
+    w._emit_telemetry(tracks=[], health=HealthState.OK, last_error=None)
+
+    msg = captured[0]
+    assert msg.frames_delivered == 55
+    assert msg.frames_dropped_est == 0
+    assert msg.delivered_fps == 24.0
+    assert msg.source_fps == 0.0
+    assert msg.ndi_queue_depth == -1
+
+
+# ── Feature 0b: true end-to-end latency probe ──────────────────────────────────
+
+
+class _CaptureLatencyController:
+    """Records the seconds passed to set_loop_latency + supports the drive path."""
+
+    def __init__(self) -> None:
+        self.loop_latency_s: float | None = None
+        self._cmd_send_ms = 0.0
+
+    def set_loop_latency(self, seconds: float) -> None:
+        self.loop_latency_s = seconds
+
+    def last_cmd_send_ms(self) -> float:
+        return self._cmd_send_ms
+
+
+def _drive_with_flag(monkeypatch, *, flag_on: bool) -> _CaptureLatencyController:
+    """Run _drive_ptz_auto once with a fake controller and the flag set, returning
+    the controller so the test can read which latency was fed to set_loop_latency."""
+    if flag_on:
+        monkeypatch.setenv("AUTOPTZ_TRUE_LATENCY_LEAD", "1")
+    else:
+        monkeypatch.delenv("AUTOPTZ_TRUE_LATENCY_LEAD", raising=False)
+
+    w = _bare_worker()
+    ctrl = _CaptureLatencyController()
+    w._ptz = ctrl
+    # Known measured legacy latency + a stamped capture timestamp.
+    w._latency_ms = 50.0  # legacy ingest+inference latency → 0.050 s
+    w._manual_override_active = lambda now: False  # type: ignore[assignment]
+    # No target resolvable → the idle branch runs but set_loop_latency is fed first.
+    w._resolve_target_track = lambda tracks: None  # type: ignore[assignment]
+    w._feature = lambda name: True  # type: ignore[assignment]
+    now = 1000.0
+    # Capture frame is 30 ms old at command time.
+    w._current_inference_capture_ts = now - 0.030
+    w._drive_ptz_auto([], None, now)
+    return ctrl
+
+
+class TestTrueLatencyLeadFlag:
+    def test_flag_off_feeds_legacy_latency(self, monkeypatch) -> None:
+        ctrl = _drive_with_flag(monkeypatch, flag_on=False)
+        # Default OFF: the legacy self._latency_ms/1000 is fed, unchanged.
+        assert ctrl.loop_latency_s == 0.050
+
+    def test_flag_on_feeds_end_to_end_latency(self, monkeypatch) -> None:
+        ctrl = _drive_with_flag(monkeypatch, flag_on=True)
+        # ON: capture_age (30) + command_send (0, no send yet) + actuation (40)
+        # = 70 ms → 0.070 s. Distinct from the legacy 0.050.
+        assert ctrl.loop_latency_s is not None
+        assert abs(ctrl.loop_latency_s - 0.070) < 1e-6
+
+
+class TestCaptureAgePlumbing:
+    def test_capture_age_computed_from_stamped_ts(self, monkeypatch) -> None:
+        monkeypatch.delenv("AUTOPTZ_TRUE_LATENCY_LEAD", raising=False)
+        w = _bare_worker()
+        w._ptz = _CaptureLatencyController()
+        w._manual_override_active = lambda now: False  # type: ignore[assignment]
+        w._resolve_target_track = lambda tracks: None  # type: ignore[assignment]
+        w._feature = lambda name: True  # type: ignore[assignment]
+        now = 2000.0
+        w._current_inference_capture_ts = now - 0.025  # 25 ms old
+        w._drive_ptz_auto([], None, now)
+        # capture_age_ms is stamped onto the worker for telemetry (~25 ms).
+        assert abs(w._capture_age_ms - 25.0) < 1.0
+
+    def test_capture_age_zero_when_unstamped(self, monkeypatch) -> None:
+        monkeypatch.delenv("AUTOPTZ_TRUE_LATENCY_LEAD", raising=False)
+        w = _bare_worker()
+        w._ptz = _CaptureLatencyController()
+        w._manual_override_active = lambda now: False  # type: ignore[assignment]
+        w._resolve_target_track = lambda tracks: None  # type: ignore[assignment]
+        w._feature = lambda name: True  # type: ignore[assignment]
+        w._current_inference_capture_ts = 0.0  # never stamped
+        w._drive_ptz_auto([], None, 3000.0)
+        assert w._capture_age_ms == 0.0
+
+
+class TestTrueLatencyFlagHelper:
+    def test_flag_helper_default_off(self, monkeypatch) -> None:
+        monkeypatch.delenv("AUTOPTZ_TRUE_LATENCY_LEAD", raising=False)
+        assert cw._true_latency_lead_enabled() is False
+
+    def test_flag_helper_on(self, monkeypatch) -> None:
+        monkeypatch.setenv("AUTOPTZ_TRUE_LATENCY_LEAD", "1")
+        assert cw._true_latency_lead_enabled() is True
+
+
+class TestEmitTelemetryLatencyFields:
+    def test_emit_telemetry_includes_latency_decomposition(self) -> None:
+        w = _bare_worker()
+        w._capture_age_ms = 30.0
+        w._command_send_ms = 5.0
+        w._end_to_end_ms = 75.0
+        captured: list[TelemetryMsg] = []
+        w._on_telemetry = captured.append
+        w._emit_telemetry(tracks=[], health=HealthState.OK, last_error=None)
+        msg = captured[0]
+        assert msg.capture_age_ms == 30.0
+        assert msg.command_send_ms == 5.0
+        assert msg.actuation_estimate_ms == w.config.ptz.actuation_estimate_ms
+        assert msg.end_to_end_ms == 75.0


### PR DESCRIPTION
**Phase 0 of the streaming/tracking redesign** ([PR #135 research doc](https://github.com/AutoPTZ/autoptz/pull/135)) — pure instrumentation, the prerequisite that measures the two pains before any behavioral fix. **Default behavior is unchanged** (the one behavioral lever is off by default behind a flag).

### What's measured now
- **Per-source frame-drop estimate** — `NDIAdapter` tracks delivered-vs-source fps over a rolling 1s window (advertised `frame_rate_N/D`, else peak-delivered fallback) and best-effort probes NDI queue depth. NDI FrameSync never signals "no new frame", so drops are *estimated*. Surfaced in Camera Info as **Est. source drops** / **Delivered / source** / **NDI queue depth** (hidden when unavailable).
- **True end-to-end latency probe** — stamps a monotonic capture timestamp through the capture→inference handoff to compute `capture_age_ms` at the instant auto-control drives the camera, plus `command_send_ms` (PTZ transport wall time) + a configurable `actuation_estimate_ms`, summed to `end_to_end_ms`. This exposes the *whole* control dead-time the loop fights (today the controller is fed only `ingest+inference`). Surfaced as **End-to-end latency**. Feeding it to the controller's lead is gated behind a new experimental flag `AUTOPTZ_TRUE_LATENCY_LEAD` (**default off** → zero behavior change).
- **Latency-aware eval harness** — a headless closed-loop harness that drives the real `PTZController` with a configurable feedback dead-time and proves error/oscillation **grows with latency** under the current non-predictive controller, so the predictive-control phase can demonstrate the fix in CI.

### Phase 0d finding (cyndilib GIL)
cyndilib holds the GIL during capture (no `with nogil:` on the call chain), **but** AutoPTZ uses the non-blocking FrameSync snapshot (microsecond-scale hold) and `cv2.cvtColor` releases the GIL — so **NDI capture can stay threads**; process isolation is a whole-pipeline decision, not a capture one. (Never switch to the blocking `RecvThread` — it holds the GIL across the network wait.) Folded into the research doc.

### Tests
New/updated: telemetry fields (35), engine 0a/0b (`test_ingest` 49, `test_ptz` 105, `test_worker_latency_probe` 12, `test_experimental_flags` 7), UI (`test_camera_info_telemetry` 10), harness (`test_synthetic_latency_eval` 24). Full touched-file sweep green per-file; ruff + CI-scope mypy clean.

Built test-first; the numbers want validation on your real NDI cameras (the plumbing + estimates are unit-tested with fakes, but the actual drop/latency figures need hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)