### PR TITLE
deps(tracking): pin boxmot to 19.0.0 and split torch/numpy by platform

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,14 @@ onnxruntime==1.23.2; platform_system == "Darwin" and platform_machine == "x86_64
 onnxruntime==1.24.1; platform_system != "Darwin" or platform_machine != "x86_64"
 
 # ── computer vision ───────────────────────────────────────────────────────────
-numpy==2.2.6
+# numpy is split by platform because the optional tracking extra (torch, see
+# requirements/tracking.txt) needs the last Intel-mac torch wheel (2.2.2),
+# which requires numpy<2. Every other platform keeps numpy 2.2.6. The torch-
+# free core works with either version, so base.txt intentionally pins Intel
+# macOS to numpy 1.26.4 and tracking mirrors the same split for standalone
+# installs.
+numpy==1.26.4; platform_system == "Darwin" and platform_machine == "x86_64"
+numpy==2.2.6; platform_system != "Darwin" or platform_machine != "x86_64"
 opencv-contrib-python==4.11.0.86
 Pillow==12.2.0
 

--- a/requirements/tracking.txt
+++ b/requirements/tracking.txt
@@ -12,5 +12,31 @@
 # Also provides the OSNet ReID backend used by engine/pipeline/reid.py for
 # body-appearance recovery after occlusion (weights auto-download on first use).
 # Optional at import time — Tracker / BodyReID degrade gracefully if absent.
-# Pin to a specific release once a stable wheel is available for all platforms.
-boxmot>=10.0.91
+#
+# Pinned to 19.0.0: this is the newest release that both keeps the tracker API
+# engine/pipeline/track.py uses (`from boxmot.trackers import BotSort, ByteTrack,
+# DeepOcSort` with the reid_model / with_reid constructor) AND installs on every
+# target platform. In 22.x those classes are no longer importable from
+# `boxmot.trackers` (they now live in tracker-specific submodules like
+# `boxmot.trackers.botsort` / `bytetrack` / `deepocsort`), so this import path
+# breaks. 20.x/21.x keep the API but require numpy>=2.2, which has no compatible
+# torch wheel on x86_64 macOS (last Intel torch is 2.2.2, needs numpy<2). Revisit
+# when track.py adopts the newer boxmot import layout and/or platform wheel
+# constraints change.
+boxmot==19.0.0
+
+# torch comes in transitively via boxmot, but pin it explicitly by platform so
+# the extra resolves on x86_64 macOS: the last Intel-mac torch wheel is 2.2.2
+# (which needs numpy<2, see the numpy split in base.txt). Every other platform
+# takes a numpy-2-compatible torch>=2.3.1. The >=2.3.1 floor matters: torch
+# wheels declare no numpy upper bound, so without it pip can pick an older torch
+# and pair it with numpy 2, an ABI mismatch that crashes at runtime.
+#
+# Repeat the numpy split here so this file is installable on its own
+# (`pip install -r requirements/tracking.txt`) without relying on base.txt.
+numpy==1.26.4; platform_system == "Darwin" and platform_machine == "x86_64"
+numpy==2.2.6; platform_system != "Darwin" or platform_machine != "x86_64"
+torch==2.2.2; platform_system == "Darwin" and platform_machine == "x86_64"
+torchvision==0.17.2; platform_system == "Darwin" and platform_machine == "x86_64"
+torch>=2.3.1,<3; platform_system != "Darwin" or platform_machine != "x86_64"
+torchvision>=0.18.1,<1; platform_system != "Darwin" or platform_machine != "x86_64"


### PR DESCRIPTION
## What & why

Makes the optional `tracking` extra install cleanly on every supported platform
by (1) pinning `boxmot` and (2) resolving `torch`/`numpy` per platform.

The default install is torch-free (detection runs on ONNX Runtime; tracking
falls back to the built-in IoU tracker). The `tracking` extra pulls in PyTorch
transitively via `boxmot`, and that graph currently resolves differently — and
sometimes not at all — across platforms.

## How

**boxmot pinned to `19.0.0`** — newest release that both keeps the tracker API
`engine/pipeline/track.py` uses (`from boxmot.trackers import BotSort,
ByteTrack, DeepOcSort` with the `reid_model` / `with_reid` constructor) *and*
installs on every target platform:

- 22.x moves those classes out of `boxmot.trackers` into per-tracker submodules
  (e.g. `boxmot.trackers.botsort`), breaking that import path.
- 20.x/21.x keep the API but require `numpy>=2.2`, which has no compatible torch
  wheel on x86_64 macOS (last Intel torch is 2.2.2, needs `numpy<2`).

**torch/numpy split by platform:**

- **x86_64 macOS:** last Intel torch wheel is `2.2.2` (needs `numpy<2`) →
  `numpy==1.26.4`, `torch==2.2.2`, `torchvision==0.17.2`.
- **All other platforms:** `numpy==2.2.6`, `torch>=2.3.1,<3`,
  `torchvision>=0.18.1,<1`. The `>=2.3.1` floor matters: torch wheels declare no
  numpy upper bound, so without it pip can pair an older torch with numpy 2 — an
  ABI mismatch that crashes at runtime.

The `numpy` split lives in `base.txt` (the torch-free core works with either
version) and is mirrored in `tracking.txt` so the extra installs standalone via
`pip install -r requirements/tracking.txt`.

## Checklist

- [x] `ruff check autoptz/ tests/ tools/` passes
- [x] `ruff format --check autoptz/ tests/ tools/` passes
- [x] `mypy autoptz/engine/runtime/ autoptz/config/` passes (CI gate: Linux / numpy 2.2.6)
- [x] `pytest tests/ --timeout=60` green
- [x] `python -m autoptz --selftest` passes
- [x] Docs updated if behavior/config changed (rationale captured inline in the `base.txt` / `tracking.txt` comments)

## Testing

Requirements-only change (no `.py` touched). Verified end-to-end on **x86_64
macOS, Python 3.12** — the platform this split most affects — via
`python tools/install.py --ci --dev --editable`: the tracking stack resolves and
installs cleanly (`torch 2.2.2` / `torchvision 0.17.2` / `numpy 1.26.4` /
`boxmot 19.0.0`), and ruff / ruff-format / selftest all pass. arm64-macOS /
Linux / Windows are covered by CI.
